### PR TITLE
docs: SDD artifacts for speckit consolidation and fix stale template paths

### DIFF
--- a/.speckit/features/108-speckit-consolidation/checklists/requirements.md
+++ b/.speckit/features/108-speckit-consolidation/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Consolidate Spec Directories to .speckit/
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- FR-010 mentions `git mv` which is an implementation detail, but it's the only mechanism for preserving rename tracking and is part of the requirement itself (not prescribing a solution approach). Accepted as-is since there is no technology-agnostic way to express "preserve file history during moves."
+- All items pass validation. Spec is ready for `/speckit.plan`.

--- a/.speckit/features/108-speckit-consolidation/plan.md
+++ b/.speckit/features/108-speckit-consolidation/plan.md
@@ -1,0 +1,127 @@
+# Implementation Plan: Consolidate Spec Directories to .speckit/
+
+**Branch**: `108-speckit-consolidation` | **Date**: 2026-01-27 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `.speckit/features/108-speckit-consolidation/spec.md`
+
+## Summary
+
+Consolidate three SDD-related directories (`.specify/`, `.speckit/`, `specs/`) into a single `.speckit/` root with subdirectories for features, templates, scripts, and memory. Update all internal path references across bash scripts, command files, and settings to use the new `.speckit/` paths. Preserve git rename history using `git mv`.
+
+## Technical Context
+
+**Language/Version**: Bash (shell scripts), Markdown (command files, settings)
+**Primary Dependencies**: Git (for `git mv` rename tracking), Bash 4+ (for scripts)
+**Storage**: N/A (filesystem reorganization only)
+**Testing**: Manual verification via `grep` and `ls` commands; no automated test suite for this feature
+**Target Platform**: macOS/Linux developer workstations
+**Project Type**: single (monorepo tooling)
+**Performance Goals**: N/A (one-time migration)
+**Constraints**: Must preserve git blame/rename history; zero downtime for SDD workflows
+**Scale/Scope**: ~55 files moved/updated across 3 source directories and ~15 config files
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Monorepo Modularity | PASS | No cross-package changes; SDD tooling is repo-level infrastructure |
+| II. OpenAPI-First | N/A | No API changes |
+| III. Test-Alongside | PASS (with note) | No automated tests added since this is a file-move operation with manual verification. No code logic is changed. |
+| IV. Observability | N/A | No runtime components changed |
+| V. Simplicity | PASS | Reduces complexity by consolidating 3 directories into 1 |
+
+No violations. No complexity tracking entries needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+.speckit/features/108-speckit-consolidation/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output (minimal — no unknowns)
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+.speckit/                          # Consolidated SDD root (TARGET)
+├── features/                      # All feature specs (moved from specs/)
+│   ├── 001-phase1-core-server/
+│   ├── 001-doc-serve-phase1/      # Pre-existing orphan
+│   ├── 002-cli-tool/
+│   ├── ...
+│   ├── 106-vertex-ai/
+│   └── 108-speckit-consolidation/ # This feature
+├── templates/                     # SDD templates (moved from .specify/templates/)
+│   ├── agent-file-template.md
+│   ├── checklist-template.md
+│   ├── plan-template.md
+│   ├── spec-template.md
+│   └── tasks-template.md
+├── scripts/                       # SDD scripts (moved from .specify/scripts/)
+│   └── bash/
+│       ├── check-prerequisites.sh
+│       ├── common.sh
+│       ├── create-new-feature.sh
+│       ├── setup-plan.sh
+│       └── update-agent-context.sh
+└── memory/                        # Constitution (moved from .specify/memory/)
+    └── constitution.md
+
+.claude/
+├── commands/
+│   └── speckit.*.md               # 9 command files (path references updated)
+└── settings.local.json            # Script permissions (paths updated)
+```
+
+**Structure Decision**: No new source code directories. This is purely a reorganization of existing SDD infrastructure files with path reference updates in configuration files.
+
+## Phases
+
+### Phase 1: Directory Migration
+
+1. Create target directories under `.speckit/` if not existing (features, templates, scripts, memory)
+2. Use `git mv` to move all content from `specs/*` to `.speckit/features/`
+3. Use `git mv` to move `.specify/templates/` to `.speckit/templates/`
+4. Use `git mv` to move `.specify/scripts/` to `.speckit/scripts/`
+5. Use `git mv` to move `.specify/memory/` to `.speckit/memory/`
+6. Remove empty `.specify/` and `specs/` directories
+
+### Phase 2: Path Reference Updates
+
+Update internal references in these file groups:
+
+**Bash scripts** (4 files in `.speckit/scripts/bash/`):
+- `common.sh`: `$repo_root/specs` → `$repo_root/.speckit/features`; `get_feature_dir()` path
+- `create-new-feature.sh`: `.specify` marker → `.speckit`; `SPECS_DIR` path; template path
+- `setup-plan.sh`: template path `.specify/templates/` → `.speckit/templates/`
+- `update-agent-context.sh`: template path `.specify/templates/` → `.speckit/templates/`
+
+**Command files** (9 files in `.claude/commands/`):
+- Global replace `.specify/` → `.speckit/` in all `speckit.*.md` files
+- Replace `specs/` directory references → `.speckit/features/` in `speckit.specify.md`
+- Add reinforcement note after frontmatter in each file
+
+**Settings** (1 file):
+- `.claude/settings.local.json`: Update 4 script permission paths
+
+### Phase 3: Verification
+
+1. `ls .speckit/features/` — 13+ feature dirs
+2. `ls .speckit/templates/` — 5 template files
+3. `ls .speckit/scripts/bash/` — 5 scripts
+4. `ls .speckit/memory/` — constitution.md
+5. `grep -r '\.specify/' .speckit/scripts/` — 0 results (excluding command name references)
+6. `grep -r '\.specify/' .claude/commands/` — 0 results (excluding command name references)
+7. `grep -rn '"specs/' .speckit/scripts/` — 0 results
+8. `ls -d .specify specs` — both should not exist
+
+## Complexity Tracking
+
+No violations to justify. This feature adds zero new dependencies and involves zero lines of new application code.

--- a/.speckit/features/108-speckit-consolidation/research.md
+++ b/.speckit/features/108-speckit-consolidation/research.md
@@ -1,0 +1,27 @@
+# Research: Consolidate Spec Directories to .speckit/
+
+**Branch**: `108-speckit-consolidation` | **Date**: 2026-01-27
+
+## Summary
+
+No unknowns or NEEDS CLARIFICATION items exist for this feature. The consolidation involves moving files and updating path references — all technologies and approaches are well-understood.
+
+## Decisions
+
+### D1: Use `git mv` for file moves
+
+- **Decision**: Use `git mv` instead of plain `mv` + `git add`
+- **Rationale**: `git mv` ensures git tracks the operation as a rename, preserving blame history and enabling clean `git log --follow` across the move
+- **Alternatives considered**: Plain filesystem `mv` followed by `git add` — rejected because git may not detect the rename if files are modified simultaneously
+
+### D2: Global sed replacement for command files
+
+- **Decision**: Use `sed -i` for bulk path replacement across 9 command files
+- **Rationale**: All 9 command files need the same `.specify/` → `.speckit/` replacement, making batch processing more reliable than individual edits
+- **Alternatives considered**: Manual editing of each file — rejected as error-prone for repetitive changes
+
+### D3: Reinforcement note in command files
+
+- **Decision**: Add a blockquote note after frontmatter in each command file reminding that all SDD artifacts live under `.speckit/`
+- **Rationale**: Prevents future drift if command files are edited without awareness of the consolidation
+- **Alternatives considered**: No note — rejected because the path change is non-obvious to future contributors

--- a/.speckit/features/108-speckit-consolidation/spec.md
+++ b/.speckit/features/108-speckit-consolidation/spec.md
@@ -1,0 +1,95 @@
+# Feature Specification: Consolidate Spec Directories to .speckit/
+
+**Feature Branch**: `108-speckit-consolidation`
+**Created**: 2026-01-27
+**Status**: Draft
+**Input**: User description: "Consolidate spec directories to speckit"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Developer Finds SDD Artifacts in One Place (Priority: P1)
+
+A developer working on a Doc-Serve feature needs to locate spec, plan, and task files. Currently, SDD-related content is scattered across three directories (`.specify/`, `.speckit/`, `specs/`), causing confusion about which directory holds what. After consolidation, all SDD artifacts live under a single `.speckit/` directory with a clear internal structure.
+
+**Why this priority**: Without a single source of truth for SDD artifacts, developers waste time searching multiple directories and scripts may reference stale paths. This is the core value of the consolidation.
+
+**Independent Test**: Navigate to `.speckit/` and verify all feature specs, templates, scripts, and memory files are accessible from that single root.
+
+**Acceptance Scenarios**:
+
+1. **Given** the repository has been consolidated, **When** a developer looks for feature spec files, **Then** all 13+ feature directories exist under `.speckit/features/`
+2. **Given** the repository has been consolidated, **When** a developer looks for SDD templates, **Then** all template files exist under `.speckit/templates/`
+3. **Given** the repository has been consolidated, **When** a developer looks for SDD scripts, **Then** all bash scripts exist under `.speckit/scripts/bash/`
+4. **Given** the repository has been consolidated, **When** a developer searches for `.specify/` or `specs/` directories, **Then** neither directory exists
+
+---
+
+### User Story 2 - SDD Scripts Work After Migration (Priority: P1)
+
+A developer runs SDD workflow commands (e.g., `/speckit.specify`, `/speckit.plan`) after the directory consolidation. All bash scripts and command files must reference the new `.speckit/` paths so the workflow continues functioning without errors.
+
+**Why this priority**: Broken scripts would block all SDD workflows, making this equally critical to the directory move itself.
+
+**Independent Test**: Run `bash .speckit/scripts/bash/check-prerequisites.sh --help` and verify it executes without path errors.
+
+**Acceptance Scenarios**:
+
+1. **Given** scripts have been migrated to `.speckit/scripts/bash/`, **When** any SDD script is executed, **Then** it resolves all file paths correctly using `.speckit/` prefixes
+2. **Given** command files reference scripts, **When** a developer runs `/speckit.plan` or `/speckit.tasks`, **Then** the commands invoke scripts at `.speckit/scripts/bash/` paths
+3. **Given** the `create-new-feature.sh` script creates new features, **When** it runs, **Then** new feature directories are created under `.speckit/features/` (not `specs/`)
+
+---
+
+### User Story 3 - Claude Code Permissions Remain Valid (Priority: P2)
+
+A developer using Claude Code on this repository needs bash script execution permissions to work. The `.claude/settings.local.json` file must reference the new `.speckit/` script paths so permissions are not silently broken.
+
+**Why this priority**: Broken permissions would cause confusing permission-denied errors during SDD workflows, but the impact is limited to Claude Code users.
+
+**Independent Test**: Inspect `.claude/settings.local.json` and verify all script permission paths use `.speckit/scripts/bash/` prefixes.
+
+**Acceptance Scenarios**:
+
+1. **Given** settings reference script paths, **When** the settings file is loaded, **Then** all 4 bash script permissions point to `.speckit/scripts/bash/` paths
+2. **Given** a developer triggers a script via Claude Code, **When** the permission check runs, **Then** the script is allowed without manual re-authorization
+
+---
+
+### Edge Cases
+
+- What happens when a developer has local branches referencing old `specs/` paths? They would need to rebase onto main after consolidation.
+- How does the system handle the orphaned `.speckit/features/001-doc-serve-phase1/tasks.md` that pre-existed? It remains in place alongside the newly moved feature directories.
+- What if a developer runs an old cached version of a command file that still references `.specify/`? The script would fail with a "file not found" error, prompting them to pull latest.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: All feature spec directories MUST be located under `.speckit/features/`
+- **FR-002**: All SDD templates MUST be located under `.speckit/templates/`
+- **FR-003**: All SDD bash scripts MUST be located under `.speckit/scripts/bash/`
+- **FR-004**: The project constitution MUST be located at `.speckit/memory/constitution.md`
+- **FR-005**: All bash scripts MUST reference `.speckit/` paths internally (no references to `.specify/` or bare `specs/`)
+- **FR-006**: All 9 speckit command files MUST reference `.speckit/` paths (no references to `.specify/` or bare `specs/`)
+- **FR-007**: The `.claude/settings.local.json` MUST reference `.speckit/scripts/bash/` for all script permissions
+- **FR-008**: The old `.specify/` directory MUST be removed after migration
+- **FR-009**: The old `specs/` directory MUST be removed after migration
+- **FR-010**: Git history MUST preserve rename tracking for all moved files (use `git mv`)
+
+### Key Entities
+
+- **Feature Directory**: A numbered directory (e.g., `101-code-ingestion`) containing spec.md, plan.md, tasks.md, and optional supporting docs for a single SDD feature
+- **SDD Template**: A markdown template file used by scripts to scaffold new spec, plan, task, or agent files
+- **SDD Script**: A bash script that automates SDD workflow steps (prerequisites check, feature creation, plan setup, agent context updates)
+- **Command File**: A markdown file in `.claude/commands/` that defines behavior for `/speckit.*` slash commands
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All SDD artifacts are reachable from a single root directory (`.speckit/`) with zero files remaining in `.specify/` or `specs/`
+- **SC-002**: Zero references to `.specify/` directory paths exist in any script, command file, or settings file (verified by grep)
+- **SC-003**: Zero references to bare `specs/` directory paths exist in any script or command file (verified by grep)
+- **SC-004**: All 13+ feature directories are present under `.speckit/features/`
+- **SC-005**: SDD workflow scripts execute without path-related errors after migration
+- **SC-006**: Git recognizes all moves as renames (preserving blame history)

--- a/.speckit/features/108-speckit-consolidation/tasks.md
+++ b/.speckit/features/108-speckit-consolidation/tasks.md
@@ -1,0 +1,167 @@
+# Tasks: Consolidate Spec Directories to .speckit/
+
+**Input**: Design documents from `.speckit/features/108-speckit-consolidation/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md
+
+**Tests**: Not requested. This is a file-move/refactoring feature with manual verification steps.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create feature branch and target directory structure
+
+- [x] T001 Create feature branch `108-speckit-consolidation` from main
+- [x] T002 Create target directories: `.speckit/features/`, `.speckit/templates/`, `.speckit/scripts/`, `.speckit/memory/`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Move all files using `git mv` to preserve rename tracking. MUST complete before any path updates.
+
+**CRITICAL**: No path update work can begin until all moves are complete.
+
+- [x] T003 Use `git mv` to move all 13 directories from `specs/*` to `.speckit/features/`
+- [x] T004 [P] Use `git mv` to move `.specify/templates/*` to `.speckit/templates/`
+- [x] T005 [P] Use `git mv` to move `.specify/scripts/*` to `.speckit/scripts/`
+- [x] T006 [P] Use `git mv` to move `.specify/memory/*` to `.speckit/memory/`
+- [x] T007 Remove empty `.specify/` directory (after T004-T006 complete)
+- [x] T008 Remove empty `specs/` directory (after T003 complete)
+
+**Checkpoint**: All files now live under `.speckit/`. Old directories are gone. `git status` should show renames (R).
+
+---
+
+## Phase 3: User Story 1 - Developer Finds SDD Artifacts in One Place (Priority: P1) MVP
+
+**Goal**: All SDD artifacts consolidated under `.speckit/` with no remnant directories
+
+**Independent Test**: Run `ls .speckit/features/ .speckit/templates/ .speckit/scripts/bash/ .speckit/memory/` and verify all content is present. Confirm `.specify/` and `specs/` do not exist.
+
+### Implementation for User Story 1
+
+- [x] T009 [US1] Verify `.speckit/features/` contains all 13+ feature directories
+- [x] T010 [US1] Verify `.speckit/templates/` contains 5 template files (agent-file-template.md, checklist-template.md, plan-template.md, spec-template.md, tasks-template.md)
+- [x] T011 [US1] Verify `.speckit/scripts/bash/` contains 5 scripts (check-prerequisites.sh, common.sh, create-new-feature.sh, setup-plan.sh, update-agent-context.sh)
+- [x] T012 [US1] Verify `.speckit/memory/constitution.md` exists
+- [x] T013 [US1] Verify `.specify/` directory does not exist
+- [x] T014 [US1] Verify `specs/` directory does not exist
+
+**Checkpoint**: User Story 1 complete. All SDD artifacts in one place.
+
+---
+
+## Phase 4: User Story 2 - SDD Scripts Work After Migration (Priority: P1)
+
+**Goal**: All bash scripts and command files reference `.speckit/` paths; SDD workflows function without errors
+
+**Independent Test**: Run `bash .speckit/scripts/bash/check-prerequisites.sh --help` and verify no path errors. Run `grep -r '\.specify/' .speckit/scripts/ .claude/commands/` and confirm zero directory path matches.
+
+### Implementation for User Story 2
+
+- [x] T015 [P] [US2] Update path references in `.speckit/scripts/bash/common.sh`: replace `$repo_root/specs` with `$repo_root/.speckit/features` (2 occurrences) and `get_feature_dir()` function
+- [x] T016 [P] [US2] Update path references in `.speckit/scripts/bash/create-new-feature.sh`: replace `.specify` marker with `.speckit`, `SPECS_DIR` path to `.speckit/features`, template path to `.speckit/templates/spec-template.md`
+- [x] T017 [P] [US2] Update path reference in `.speckit/scripts/bash/setup-plan.sh`: replace `.specify/templates/plan-template.md` with `.speckit/templates/plan-template.md`
+- [x] T018 [P] [US2] Update path reference in `.speckit/scripts/bash/update-agent-context.sh`: replace `.specify/templates/agent-file-template.md` with `.speckit/templates/agent-file-template.md`
+- [x] T019 [US2] Replace all `.specify/` path references with `.speckit/` in 9 command files: `.claude/commands/speckit.analyze.md`, `speckit.checklist.md`, `speckit.clarify.md`, `speckit.constitution.md`, `speckit.implement.md`, `speckit.plan.md`, `speckit.specify.md`, `speckit.tasks.md`, `speckit.taskstoissues.md`
+- [x] T020 [US2] Replace `specs/[0-9]+-<short-name>` with `.speckit/features/[0-9]+-<short-name>` in `.claude/commands/speckit.specify.md`
+- [x] T021 [US2] Add reinforcement note after frontmatter in all 9 command files: `> **Spec directory**: All SDD artifacts live under .speckit/ (features, templates, scripts, memory).`
+- [x] T022 [US2] Verify zero `.specify/` directory path references remain in `.speckit/scripts/bash/` (excluding `/speckit.specify` command name references)
+- [x] T023 [US2] Verify zero `.specify/` directory path references remain in `.claude/commands/` (excluding `/speckit.specify` command name references)
+- [x] T024 [US2] Verify zero bare `specs/` directory path references remain in `.speckit/scripts/bash/`
+
+**Checkpoint**: User Story 2 complete. All SDD scripts and commands use `.speckit/` paths.
+
+---
+
+## Phase 5: User Story 3 - Claude Code Permissions Remain Valid (Priority: P2)
+
+**Goal**: Claude Code settings reference updated script paths so permissions work
+
+**Independent Test**: Inspect `.claude/settings.local.json` and verify all 4 script permission entries use `.speckit/scripts/bash/` paths.
+
+### Implementation for User Story 3
+
+- [x] T025 [US3] Update `.claude/settings.local.json`: replace 4 `.specify/scripts/bash/` permission paths with `.speckit/scripts/bash/` (check-prerequisites.sh, create-new-feature.sh, setup-plan.sh, update-agent-context.sh)
+- [x] T026 [US3] Verify `.claude/settings.local.json` contains zero `.specify/` references
+
+**Checkpoint**: User Story 3 complete. Claude Code permissions valid.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification and commit
+
+- [x] T027 Run full verification suite: `ls` checks for all 4 `.speckit/` subdirectories, `grep` checks for zero stale references, confirm old directories removed
+- [x] T028 Stage all changes with `git add` and verify `git status` shows renames (R prefix)
+- [x] T029 Commit with message: `refactor: consolidate .specify/ and specs/ into .speckit/`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - start immediately
+- **Foundational (Phase 2)**: Depends on Setup (T001-T002) - BLOCKS all user stories
+- **User Story 1 (Phase 3)**: Depends on Foundational (Phase 2) - verification of moves
+- **User Story 2 (Phase 4)**: Depends on Foundational (Phase 2) - can run in parallel with US1
+- **User Story 3 (Phase 5)**: Depends on Foundational (Phase 2) - can run in parallel with US1/US2
+- **Polish (Phase 6)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Depends only on Phase 2. Verification-only tasks.
+- **User Story 2 (P1)**: Depends only on Phase 2. Script/command file edits — independent of US1.
+- **User Story 3 (P2)**: Depends only on Phase 2. Settings file edit — independent of US1/US2.
+
+### Within Each User Story
+
+- US2: Bash script updates (T015-T018) can run in parallel, then command file updates (T019-T021) sequentially, then verification (T022-T024)
+- US3: Single edit (T025) then verification (T026)
+
+### Parallel Opportunities
+
+- T004, T005, T006 can run in parallel (moving different source directories)
+- T015, T016, T017, T018 can run in parallel (different bash script files)
+- US1, US2, US3 can all start once Phase 2 is complete
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 + 2)
+
+1. Complete Phase 1: Setup (T001-T002)
+2. Complete Phase 2: Foundational moves (T003-T008)
+3. Complete Phase 3: US1 verification (T009-T014)
+4. Complete Phase 4: US2 path updates (T015-T024)
+5. **STOP and VALIDATE**: Scripts work, no stale references
+6. Deploy/merge if ready
+
+### Full Delivery
+
+1. Complete MVP above
+2. Complete Phase 5: US3 settings update (T025-T026)
+3. Complete Phase 6: Final verification and commit (T027-T029)
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- US1 is verification-only (moves happen in Phase 2)
+- US2 is the bulk of the editing work (14 files updated)
+- US3 is a single file edit
+- Commit after Phase 6 only (one atomic commit for the entire consolidation)

--- a/.speckit/memory/constitution.md
+++ b/.speckit/memory/constitution.md
@@ -10,9 +10,9 @@ Added sections:
   - Governance
 Removed sections: N/A
 Templates requiring updates:
-  - .specify/templates/plan-template.md: ✅ compatible (Constitution Check section exists)
-  - .specify/templates/spec-template.md: ✅ compatible (requirements structure aligns)
-  - .specify/templates/tasks-template.md: ✅ compatible (phase structure supports modularity)
+  - .speckit/templates/plan-template.md: ✅ compatible (Constitution Check section exists)
+  - .speckit/templates/spec-template.md: ✅ compatible (requirements structure aligns)
+  - .speckit/templates/tasks-template.md: ✅ compatible (phase structure supports modularity)
 Follow-up TODOs: None
 -->
 

--- a/.speckit/templates/plan-template.md
+++ b/.speckit/templates/plan-template.md
@@ -1,9 +1,9 @@
 # Implementation Plan: [FEATURE]
 
 **Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
-**Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
+**Input**: Feature specification from `.speckit/features/[###-feature-name]/spec.md`
 
-**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+**Note**: This template is filled in by the `/speckit.plan` command.
 
 ## Summary
 
@@ -38,7 +38,7 @@
 ### Documentation (this feature)
 
 ```text
-specs/[###-feature]/
+.speckit/features/[###-feature]/
 ├── plan.md              # This file (/speckit.plan command output)
 ├── research.md          # Phase 0 output (/speckit.plan command)
 ├── data-model.md        # Phase 1 output (/speckit.plan command)

--- a/.speckit/templates/tasks-template.md
+++ b/.speckit/templates/tasks-template.md
@@ -5,7 +5,7 @@ description: "Task list template for feature implementation"
 
 # Tasks: [FEATURE NAME]
 
-**Input**: Design documents from `/specs/[###-feature-name]/`
+**Input**: Design documents from `.speckit/features/[###-feature-name]/`
 **Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
 
 **Tests**: The examples below include test tasks. Tests are OPTIONAL - only include them if explicitly requested in the feature specification.


### PR DESCRIPTION
## Summary
- Adds full SDD artifact set (spec, plan, tasks, research, checklist) for the 108-speckit-consolidation feature
- Fixes stale `.specify/` and `specs/` path references in `plan-template.md`, `tasks-template.md`, and `constitution.md` sync impact comment

## Test plan
- [x] All 29 tasks in tasks.md marked complete
- [x] Zero stale `.specify/` or `specs/` references in templates verified by grep
- [x] Git rename tracking confirmed via `git log --follow`
- [x] `/speckit.analyze` passed with 0 CRITICAL issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)