### PR TITLE
feat(reranking): Two-Stage Reranking + Phase 2 Pluggable Providers Planning

### DIFF
--- a/.github/workflows/pr-qa-gate.yml
+++ b/.github/workflows/pr-qa-gate.yml
@@ -47,6 +47,23 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
 
+      - name: Cache pip packages (PyTorch, CUDA, etc.)
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-py3.11-${{ hashFiles('agent-brain-server/poetry.lock') }}
+          restore-keys: |
+            pip-${{ runner.os }}-py3.11-
+            pip-${{ runner.os }}-
+
+      - name: Cache HuggingFace models (sentence-transformers)
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-${{ runner.os }}-sentence-transformers
+          restore-keys: |
+            hf-${{ runner.os }}-
+
       - name: Cache Poetry dependencies (server)
         uses: actions/cache@v4
         with:

--- a/.github/workflows/pr-qa-gate.yml
+++ b/.github/workflows/pr-qa-gate.yml
@@ -18,6 +18,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Free up disk space
+        run: |
+          # Remove unnecessary tools to free up ~10GB
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          df -h
+
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -1,0 +1,101 @@
+# Agent Brain
+
+## What This Is
+
+Agent Brain is a local-first RAG (Retrieval-Augmented Generation) service that indexes documentation and source code, providing intelligent semantic search via REST API for CLI tools and Claude Code integration. It combines vector search, BM25 keyword search, GraphRAG, and hybrid retrieval strategies for high-quality code and documentation understanding.
+
+## Core Value
+
+**Developers can semantically search their entire codebase and documentation through a single, fast, local-first API that understands code structure and relationships.**
+
+## Requirements
+
+### Validated
+
+- [x] **CORE-01**: Document ingestion (PDF + Markdown) — Phase 1
+- [x] **CORE-02**: Context-enriched chunking with Claude summarization — Phase 1
+- [x] **CORE-03**: Vector search with ChromaDB + OpenAI embeddings — Phase 1
+- [x] **CORE-04**: REST API (/query, /index, /health) — Phase 1
+- [x] **CORE-05**: CLI tool (agent-brain) with status, query, index, reset — Phase 1
+- [x] **BM25-01**: BM25 keyword search retriever — Phase 2 (Feature 100)
+- [x] **BM25-02**: Hybrid retrieval with RRF fusion — Phase 2 (Feature 100)
+- [x] **BM25-03**: Retrieval mode selection (vector/bm25/hybrid) — Phase 2 (Feature 100)
+- [x] **CODE-01**: AST-aware code ingestion (Python, TypeScript, JavaScript, Java, Go, Rust, C, C++) — Phase 3 (Feature 101)
+- [x] **CODE-02**: Code summaries via SummaryExtractor — Phase 3 (Feature 101)
+- [x] **CODE-03**: C# language support — Phase 3.2 (Feature 110)
+- [x] **MULTI-01**: Per-project server instances with isolation — Phase 3.1 (Feature 109)
+- [x] **MULTI-02**: Auto-port allocation — Phase 3.1 (Feature 109)
+- [x] **MULTI-03**: Runtime discovery via runtime.json — Phase 3.1 (Feature 109)
+- [x] **GRAPH-01**: Knowledge graph extraction (entities + relationships) — Phase 3.5 (Feature 113)
+- [x] **GRAPH-02**: Graph-enhanced retrieval mode — Phase 3.5 (Feature 113)
+- [x] **GRAPH-03**: Multi-mode query (vector/bm25/graph/hybrid/multi) — Phase 3.5 (Feature 113)
+- [x] **PLUGIN-01**: Claude Code plugin with slash commands — Phase 3.6 (Feature 114)
+- [x] **PLUGIN-02**: Specialized agents (researcher, indexer) — Phase 3.6 (Feature 114)
+- [x] **QUEUE-01**: Server-side job queue with JSONL persistence — Feature 115
+
+### Active
+
+- [ ] **RERANK-01**: Two-stage retrieval with optional reranking — Feature 123
+- [ ] **RERANK-02**: Ollama-based reranker (local-first, no API keys) — Feature 123
+- [ ] **RERANK-03**: Graceful degradation on reranker failure — Feature 123
+- [ ] **PROV-01**: Pluggable embedding providers (OpenAI/Ollama/Cohere) — Feature 103
+- [ ] **PROV-02**: Pluggable summarization providers (Anthropic/OpenAI/Gemini/Grok/Ollama) — Feature 103
+- [ ] **PROV-03**: YAML-based provider configuration — Feature 103
+- [ ] **PROV-04**: Fully offline operation with Ollama — Feature 103
+- [ ] **SCHEMA-01**: Domain-specific entity type schema for GraphRAG — Feature 122
+- [ ] **SCHEMA-02**: Enhanced relationship predicates (calls, extends, implements) — Feature 122
+- [ ] **SCHEMA-03**: Type-filtered graph queries — Feature 122
+- [ ] **TEST-01**: E2E test suite per provider — Feature 124
+- [ ] **TEST-02**: Provider health check endpoint — Feature 124
+
+### Out of Scope
+
+- **MCP Server**: User prefers Skill + CLI model over MCP — too heavyweight, context-hungry
+- **Real-time file watching**: Deferred to future optimization phase
+- **Embedding caching**: Deferred to future optimization phase
+- **PostgreSQL backend**: Future Phase 6 (Feature 104)
+- **AWS Bedrock provider**: Future Phase 7 (Feature 105)
+- **Vertex AI provider**: Future Phase 8 (Feature 106)
+
+## Context
+
+**Brownfield Project Migration**: This project was previously managed with GitHub Spec-Driven Development (.speckit/). We're migrating to GSD (Get Shit Done) workflow for better execution tracking.
+
+**Recently Shipped (2026-02)**:
+- Feature 113: GraphRAG Integration with triplet extraction (LLM + AST-based)
+- Feature 114: Agent Brain Plugin for Claude Code
+- Feature 115: Server-side job queue with JSONL persistence
+
+**Technology Stack**:
+- Python 3.10+ with Poetry packaging
+- FastAPI + Uvicorn server
+- ChromaDB vector store
+- LlamaIndex for document processing
+- OpenAI embeddings + Claude Haiku summarization (default, pluggable)
+
+**Architecture Principles** (from constitution.md):
+1. Monorepo Modularity — packages independently testable
+2. OpenAPI-First — contracts before code
+3. Test-Alongside — tests with implementation
+4. Observability — structured logging, health endpoints
+5. Simplicity — YAGNI, sensible defaults
+
+## Constraints
+
+- **Local-First**: Must work without cloud dependencies (Ollama support critical)
+- **Pre-Push Quality Gate**: `task before-push` MUST pass before any push
+- **Test Coverage**: >50% coverage required for CI
+- **Package Isolation**: Cross-package deps flow server ← cli/skill (never reverse)
+
+## Key Decisions
+
+| Decision | Rationale | Outcome |
+|----------|-----------|---------|
+| Start reranking with Ollama | Local-first philosophy, no API keys required, already integrated | — Pending |
+| Two-stage retrieval optional (off by default) | Graceful degradation, backward compatible | — Pending |
+| Skill + CLI over MCP | User preference: simpler, less context overhead | ✓ Good |
+| GraphRAG with SimplePropertyGraphStore | Simpler than full Kuzu integration for v1 | ✓ Good |
+| JSONL job queue over Redis | Local-first, no external dependencies | ✓ Good |
+
+---
+*Last updated: 2026-02-07 after GSD migration*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,124 @@
+# Requirements: Agent Brain
+
+**Defined:** 2026-02-07
+**Core Value:** Developers can semantically search their entire codebase and documentation through a single, fast, local-first API
+
+## v1 Requirements
+
+Requirements for current milestone. Each maps to roadmap phases.
+
+### Reranking (Feature 123)
+
+- [ ] **RERANK-01**: System supports two-stage retrieval with optional reranking
+- [ ] **RERANK-02**: Ollama-based reranker works locally without API keys
+- [ ] **RERANK-03**: Reranking gracefully degrades on failure (returns stage 1 results)
+- [ ] **RERANK-04**: Reranking adds <100ms latency for top 100 candidates
+- [ ] **RERANK-05**: Configuration via ENABLE_RERANKING, RERANKER_PROVIDER, RERANKER_MODEL
+
+### Pluggable Providers (Feature 103)
+
+- [ ] **PROV-01**: YAML configuration for embedding provider (OpenAI/Ollama/Cohere)
+- [ ] **PROV-02**: YAML configuration for summarization provider (Anthropic/OpenAI/Gemini/Grok/Ollama)
+- [ ] **PROV-03**: Switching providers requires only config change, no code changes
+- [ ] **PROV-04**: Fully offline operation supported with Ollama for both embeddings and summarization
+- [ ] **PROV-05**: API keys read from environment variables, never stored in config
+- [ ] **PROV-06**: Provider configuration validated on startup with clear errors
+- [ ] **PROV-07**: Embedding dimension mismatch detected and prevented
+
+### Schema-Based GraphRAG (Feature 122)
+
+- [ ] **SCHEMA-01**: Domain-specific entity types defined (Package, Module, Class, Method, Function, Interface, Enum)
+- [ ] **SCHEMA-02**: Documentation entity types defined (DesignDoc, UserDoc, PRD, Runbook, README, APIDoc)
+- [ ] **SCHEMA-03**: Enhanced relationship predicates (calls, extends, implements, references, depends_on)
+- [ ] **SCHEMA-04**: Entity type filtering in graph queries
+- [ ] **SCHEMA-05**: LLM extraction prompts use schema vocabulary
+
+### Provider Integration Testing (Feature 124)
+
+- [ ] **TEST-01**: E2E test suite for OpenAI provider
+- [ ] **TEST-02**: E2E test suite for Anthropic provider
+- [ ] **TEST-03**: E2E test suite for Ollama provider
+- [ ] **TEST-04**: E2E test suite for Cohere provider
+- [ ] **TEST-05**: Provider health check endpoint (/health/providers)
+- [ ] **TEST-06**: Verified provider configuration documentation
+
+## v2 Requirements
+
+Deferred to future releases. Tracked but not in current roadmap.
+
+### PostgreSQL Backend (Feature 104)
+
+- **PG-01**: pgvector for high-performance vector similarity search
+- **PG-02**: tsvector/tsquery for native full-text search (replaces BM25)
+- **PG-03**: JSONB for graph storage with GIN indexes
+- **PG-04**: Migration tool from ChromaDB
+
+### AWS Bedrock Provider (Feature 105)
+
+- **AWS-01**: Bedrock embedding provider (Titan, Cohere)
+- **AWS-02**: Bedrock summarization provider (Claude, Titan, Llama, Mistral)
+- **AWS-03**: Default AWS credentials chain support
+
+### Vertex AI Provider (Feature 106)
+
+- **VERTEX-01**: Vertex AI embedding provider (textembedding-gecko)
+- **VERTEX-02**: Vertex AI summarization provider (Gemini)
+- **VERTEX-03**: Application Default Credentials support
+
+### Future Optimizations
+
+- **OPT-01**: Embedding cache with content hashing (50-80% index speedup)
+- **OPT-02**: File watcher for auto-indexing
+- **OPT-03**: Background incremental updates
+- **OPT-04**: Query caching with LRU
+- **OPT-05**: UDS transport for sub-millisecond local queries
+
+## Out of Scope
+
+Explicitly excluded. Documented to prevent scope creep.
+
+| Feature | Reason |
+|---------|--------|
+| MCP Server | User prefers Skill + CLI model — simpler, less context overhead |
+| Real-time streaming | Not needed for document search use case |
+| Multi-tenancy | Local-first philosophy — one instance per project |
+| Web UI | CLI-first philosophy — agents are primary consumers |
+
+## Traceability
+
+Which phases cover which requirements. Updated during roadmap creation.
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| RERANK-01 | Phase 1 | Pending |
+| RERANK-02 | Phase 1 | Pending |
+| RERANK-03 | Phase 1 | Pending |
+| RERANK-04 | Phase 1 | Pending |
+| RERANK-05 | Phase 1 | Pending |
+| PROV-01 | Phase 2 | Pending |
+| PROV-02 | Phase 2 | Pending |
+| PROV-03 | Phase 2 | Pending |
+| PROV-04 | Phase 2 | Pending |
+| PROV-05 | Phase 2 | Pending |
+| PROV-06 | Phase 2 | Pending |
+| PROV-07 | Phase 2 | Pending |
+| SCHEMA-01 | Phase 3 | Pending |
+| SCHEMA-02 | Phase 3 | Pending |
+| SCHEMA-03 | Phase 3 | Pending |
+| SCHEMA-04 | Phase 3 | Pending |
+| SCHEMA-05 | Phase 3 | Pending |
+| TEST-01 | Phase 4 | Pending |
+| TEST-02 | Phase 4 | Pending |
+| TEST-03 | Phase 4 | Pending |
+| TEST-04 | Phase 4 | Pending |
+| TEST-05 | Phase 4 | Pending |
+| TEST-06 | Phase 4 | Pending |
+
+**Coverage:**
+- v1 requirements: 23 total
+- Mapped to phases: 23
+- Unmapped: 0 ✓
+
+---
+*Requirements defined: 2026-02-07*
+*Last updated: 2026-02-07 after GSD migration*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -8,7 +8,7 @@
 
 | Phase | Name | Feature | Requirements | Status |
 |-------|------|---------|--------------|--------|
-| 1 | Two-Stage Reranking | 123 | RERANK-01 to RERANK-05 | **NEXT** |
+| 1 | Two-Stage Reranking | 123 | RERANK-01 to RERANK-05 | **PLANNED** |
 | 2 | Pluggable Providers | 103 | PROV-01 to PROV-07 | Pending |
 | 3 | Schema-Based GraphRAG | 122 | SCHEMA-01 to SCHEMA-05 | Pending |
 | 4 | Provider Integration Testing | 124 | TEST-01 to TEST-06 | Pending |
@@ -67,6 +67,20 @@ agent_brain_server/providers/reranker/
 | config/provider_config.py | Add RerankerConfig class |
 | models/query.py | Add rerank_score, original_rank fields |
 | services/query_service.py | Add _rerank_results(), integrate into execute_query() |
+
+### Plans
+
+**Plans:** 7 plans in 4 waves
+
+| Plan | Wave | Objective |
+|------|------|-----------|
+| [01-01-PLAN.md](.planning/phases/01-two-stage-reranking/01-01-PLAN.md) | 1 | Add reranking settings and configuration |
+| [01-02-PLAN.md](.planning/phases/01-two-stage-reranking/01-02-PLAN.md) | 1 | Create RerankerProvider protocol and base class |
+| [01-03-PLAN.md](.planning/phases/01-two-stage-reranking/01-03-PLAN.md) | 2 | Implement SentenceTransformerRerankerProvider |
+| [01-04-PLAN.md](.planning/phases/01-two-stage-reranking/01-04-PLAN.md) | 2 | Implement OllamaRerankerProvider |
+| [01-05-PLAN.md](.planning/phases/01-two-stage-reranking/01-05-PLAN.md) | 3 | Integrate reranking into query_service.py |
+| [01-06-PLAN.md](.planning/phases/01-two-stage-reranking/01-06-PLAN.md) | 4 | Add unit and integration tests |
+| [01-07-PLAN.md](.planning/phases/01-two-stage-reranking/01-07-PLAN.md) | 4 | Update documentation |
 
 ---
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,0 +1,227 @@
+# Agent Brain Roadmap
+
+**Created:** 2026-02-07
+**Migrated from:** .speckit/ (GitHub Spec-Driven Development)
+**Core Value:** Developers can semantically search their entire codebase and documentation through a single, fast, local-first API
+
+## Phase Summary
+
+| Phase | Name | Feature | Requirements | Status |
+|-------|------|---------|--------------|--------|
+| 1 | Two-Stage Reranking | 123 | RERANK-01 to RERANK-05 | **NEXT** |
+| 2 | Pluggable Providers | 103 | PROV-01 to PROV-07 | Pending |
+| 3 | Schema-Based GraphRAG | 122 | SCHEMA-01 to SCHEMA-05 | Pending |
+| 4 | Provider Integration Testing | 124 | TEST-01 to TEST-06 | Pending |
+
+---
+
+## Phase 1: Two-Stage Reranking
+
+**Feature:** 123
+**Goal:** Add optional two-stage retrieval with Ollama-based reranking for +3-4% precision improvement
+**Priority:** IMMEDIATE
+
+### Requirements Covered
+
+- RERANK-01: Two-stage retrieval with optional reranking
+- RERANK-02: Ollama-based reranker (local-first)
+- RERANK-03: Graceful degradation on failure
+- RERANK-04: <100ms additional latency
+- RERANK-05: Configuration via environment variables
+
+### Architecture
+
+```
+Stage 1: Fast Retrieval (BM25 + Vector + Graph, top_k=100)
+    ↓
+RRF Fusion → ~50 candidates
+    ↓
+Stage 2: Ollama Reranking (optional, top_k=10)
+    ↓
+Final Results
+```
+
+### Success Criteria
+
+1. [ ] User can enable reranking with `ENABLE_RERANKING=true`
+2. [ ] Queries use two-stage retrieval when reranking enabled
+3. [ ] Reranking works with Ollama models (bge-reranker-v2-m3)
+4. [ ] System returns stage 1 results if reranker fails (graceful degradation)
+5. [ ] Reranking adds <100ms latency for 100 candidates
+6. [ ] All existing tests pass (backward compatible)
+
+### Files to Create
+
+```
+agent_brain_server/providers/reranker/
+├── __init__.py
+├── base.py          # RerankerProvider protocol + BaseRerankerProvider
+└── ollama.py        # OllamaRerankerProvider implementation
+```
+
+### Files to Modify
+
+| File | Changes |
+|------|---------|
+| config/settings.py | Add ENABLE_RERANKING, RERANKER_* settings |
+| config/provider_config.py | Add RerankerConfig class |
+| models/query.py | Add rerank_score, original_rank fields |
+| services/query_service.py | Add _rerank_results(), integrate into execute_query() |
+
+---
+
+## Phase 2: Pluggable Providers
+
+**Feature:** 103
+**Goal:** Configuration-driven model selection for embeddings and summarization
+**Priority:** HIGH
+
+### Requirements Covered
+
+- PROV-01 to PROV-07
+
+### Success Criteria
+
+1. [ ] Provider switching via config.yaml only (no code changes)
+2. [ ] OpenAI, Ollama, Cohere embeddings work
+3. [ ] Anthropic, OpenAI, Gemini, Grok, Ollama summarization work
+4. [ ] Fully offline operation with Ollama
+5. [ ] API keys read from environment variables
+6. [ ] Provider config validated on startup
+
+### Configuration Example
+
+```yaml
+embedding:
+  provider: ollama
+  model: nomic-embed-text
+  params:
+    base_url: http://localhost:11434
+
+summarization:
+  provider: anthropic
+  model: claude-haiku-4-5
+  params:
+    api_key_env: ANTHROPIC_API_KEY
+```
+
+---
+
+## Phase 3: Schema-Based GraphRAG
+
+**Feature:** 122
+**Goal:** Add domain-specific entity schema for improved code understanding
+**Priority:** MEDIUM
+
+### Requirements Covered
+
+- SCHEMA-01 to SCHEMA-05
+
+### Entity Type Schema
+
+| Category | Entity Types |
+|----------|-------------|
+| Code | Package, Module, Class, Method, Function, Interface, Enum |
+| Documentation | DesignDoc, UserDoc, PRD, Runbook, README, APIDoc |
+| Infrastructure | Service, Endpoint, Database, ConfigFile |
+
+### Relationship Predicates
+
+| Predicate | Description |
+|-----------|-------------|
+| `calls` | Function/method invocation |
+| `extends` | Class inheritance |
+| `implements` | Interface implementation |
+| `references` | Documentation references code |
+| `depends_on` | Package/module dependency |
+
+### Success Criteria
+
+1. [ ] Entity types defined as Pydantic enums
+2. [ ] CodeMetadataExtractor categorizes entities by type
+3. [ ] LLM extraction uses schema vocabulary
+4. [ ] Graph queries support type filtering
+5. [ ] Existing graph functionality preserved
+
+---
+
+## Phase 4: Provider Integration Testing
+
+**Feature:** 124
+**Goal:** Validate all provider combinations with E2E tests
+**Priority:** MEDIUM
+
+### Requirements Covered
+
+- TEST-01 to TEST-06
+
+### Test Matrix
+
+| Provider | Embeddings | Summarization | Status |
+|----------|------------|---------------|--------|
+| OpenAI | text-embedding-3-large | gpt-4-mini | Needs E2E |
+| Anthropic | — | claude-haiku-4-5 | Needs E2E |
+| Ollama | nomic-embed-text | llama3.2 | Working |
+| Cohere | embed-english-v3.0 | — | Needs E2E |
+
+### Success Criteria
+
+1. [ ] E2E test for each provider
+2. [ ] Provider health check endpoint
+3. [ ] Verified configuration documentation
+4. [ ] All providers pass CI
+
+---
+
+## Future Phases (v2)
+
+### Phase 5: PostgreSQL/AlloyDB Backend (Feature 104)
+
+- pgvector for similarity search
+- tsvector for full-text (replaces BM25)
+- JSONB for graph storage
+- Migration tool from ChromaDB
+
+### Phase 6: AWS Bedrock Provider (Feature 105)
+
+- Bedrock embeddings (Titan, Cohere)
+- Bedrock summarization (Claude, Llama, Mistral)
+
+### Phase 7: Vertex AI Provider (Feature 106)
+
+- Vertex embeddings (textembedding-gecko)
+- Vertex summarization (Gemini)
+
+### Future Optimizations
+
+- Embedding cache with content hashing
+- File watcher for auto-indexing
+- Background incremental updates
+- Query caching with LRU
+- UDS transport for sub-ms latency
+
+---
+
+## Completed Phases (Archive)
+
+### Phase 1 (Legacy): Core Document RAG — COMPLETED
+Features 001-005: Document ingestion, vector search, REST API, CLI
+
+### Phase 2 (Legacy): BM25 & Hybrid Retrieval — COMPLETED
+Feature 100: BM25 keyword search, hybrid retrieval with RRF
+
+### Phase 3 (Legacy): Source Code Ingestion — COMPLETED
+Feature 101: AST-aware code ingestion, code summaries
+
+### Phase 3.1-3.6 (Legacy): Extensions — COMPLETED
+- 109: Multi-instance architecture
+- 110: C# code indexing
+- 111: Skill instance discovery
+- 112: Agent Brain naming
+- 113: GraphRAG integration
+- 114: Agent Brain plugin
+- 115: Server-side job queue
+
+---
+*Roadmap created: 2026-02-07*
+*Last updated: 2026-02-07 after GSD migration*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -8,7 +8,7 @@
 
 | Phase | Name | Feature | Requirements | Status |
 |-------|------|---------|--------------|--------|
-| 1 | Two-Stage Reranking | 123 | RERANK-01 to RERANK-05 | **PLANNED** |
+| 1 | Two-Stage Reranking | 123 | RERANK-01 to RERANK-05 | **IN PROGRESS** (2/7 plans) |
 | 2 | Pluggable Providers | 103 | PROV-01 to PROV-07 | Pending |
 | 3 | Schema-Based GraphRAG | 122 | SCHEMA-01 to SCHEMA-05 | Pending |
 | 4 | Provider Integration Testing | 124 | TEST-01 to TEST-06 | Pending |
@@ -72,15 +72,15 @@ agent_brain_server/providers/reranker/
 
 **Plans:** 7 plans in 4 waves
 
-| Plan | Wave | Objective |
-|------|------|-----------|
-| [01-01-PLAN.md](.planning/phases/01-two-stage-reranking/01-01-PLAN.md) | 1 | Add reranking settings and configuration |
-| [01-02-PLAN.md](.planning/phases/01-two-stage-reranking/01-02-PLAN.md) | 1 | Create RerankerProvider protocol and base class |
-| [01-03-PLAN.md](.planning/phases/01-two-stage-reranking/01-03-PLAN.md) | 2 | Implement SentenceTransformerRerankerProvider |
-| [01-04-PLAN.md](.planning/phases/01-two-stage-reranking/01-04-PLAN.md) | 2 | Implement OllamaRerankerProvider |
-| [01-05-PLAN.md](.planning/phases/01-two-stage-reranking/01-05-PLAN.md) | 3 | Integrate reranking into query_service.py |
-| [01-06-PLAN.md](.planning/phases/01-two-stage-reranking/01-06-PLAN.md) | 4 | Add unit and integration tests |
-| [01-07-PLAN.md](.planning/phases/01-two-stage-reranking/01-07-PLAN.md) | 4 | Update documentation |
+| Plan | Wave | Status | Objective |
+|------|------|--------|-----------|
+| [01-01-PLAN.md](.planning/phases/01-two-stage-reranking/01-01-PLAN.md) | 1 | Complete | Add reranking settings and configuration |
+| [01-02-PLAN.md](.planning/phases/01-two-stage-reranking/01-02-PLAN.md) | 1 | Complete | Create RerankerProvider protocol and base class |
+| [01-03-PLAN.md](.planning/phases/01-two-stage-reranking/01-03-PLAN.md) | 2 | Pending | Implement SentenceTransformerRerankerProvider |
+| [01-04-PLAN.md](.planning/phases/01-two-stage-reranking/01-04-PLAN.md) | 2 | Pending | Implement OllamaRerankerProvider |
+| [01-05-PLAN.md](.planning/phases/01-two-stage-reranking/01-05-PLAN.md) | 3 | Pending | Integrate reranking into query_service.py |
+| [01-06-PLAN.md](.planning/phases/01-two-stage-reranking/01-06-PLAN.md) | 4 | Pending | Add unit and integration tests |
+| [01-07-PLAN.md](.planning/phases/01-two-stage-reranking/01-07-PLAN.md) | 4 | Pending | Update documentation |
 
 ---
 
@@ -238,4 +238,4 @@ Feature 101: AST-aware code ingestion, code summaries
 
 ---
 *Roadmap created: 2026-02-07*
-*Last updated: 2026-02-07 after GSD migration*
+*Last updated: 2026-02-08 - Completed plans 01-01 and 01-02*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -9,7 +9,7 @@
 | Phase | Name | Feature | Requirements | Status |
 |-------|------|---------|--------------|--------|
 | 1 | Two-Stage Reranking | 123 | RERANK-01 to RERANK-05 | **COMPLETE** (7/7 plans) |
-| 2 | Pluggable Providers | 103 | PROV-01 to PROV-07 | Pending |
+| 2 | Pluggable Providers | 103 | PROV-01 to PROV-07 | **PLANNED** (0/4 plans) |
 | 3 | Schema-Based GraphRAG | 122 | SCHEMA-01 to SCHEMA-05 | Pending |
 | 4 | Provider Integration Testing | 124 | TEST-01 to TEST-06 | Pending |
 
@@ -118,6 +118,26 @@ summarization:
   params:
     api_key_env: ANTHROPIC_API_KEY
 ```
+
+### Research Findings
+
+See: `.planning/phases/02-pluggable-providers/02-RESEARCH.md`
+
+**Status:** Most infrastructure exists. Key gaps:
+- PROV-07 (dimension mismatch) - NOT implemented
+- PROV-06 (strict validation) - Partial, only warns
+- PROV-03/04 - Need E2E verification tests
+
+### Plans
+
+**Plans:** 4 plans in 2 waves
+
+| Plan | Wave | Status | Objective |
+|------|------|--------|-----------|
+| [02-01-PLAN.md](.planning/phases/02-pluggable-providers/02-01-PLAN.md) | 1 | Pending | Dimension mismatch prevention (PROV-07) |
+| [02-02-PLAN.md](.planning/phases/02-pluggable-providers/02-02-PLAN.md) | 1 | Pending | Strict startup validation (PROV-06) |
+| [02-03-PLAN.md](.planning/phases/02-pluggable-providers/02-03-PLAN.md) | 2 | Pending | Provider switching E2E test (PROV-03) |
+| [02-04-PLAN.md](.planning/phases/02-pluggable-providers/02-04-PLAN.md) | 2 | Pending | Ollama offline E2E test (PROV-04) |
 
 ---
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -8,7 +8,7 @@
 
 | Phase | Name | Feature | Requirements | Status |
 |-------|------|---------|--------------|--------|
-| 1 | Two-Stage Reranking | 123 | RERANK-01 to RERANK-05 | **IN PROGRESS** (2/7 plans) |
+| 1 | Two-Stage Reranking | 123 | RERANK-01 to RERANK-05 | **COMPLETE** (7/7 plans) |
 | 2 | Pluggable Providers | 103 | PROV-01 to PROV-07 | Pending |
 | 3 | Schema-Based GraphRAG | 122 | SCHEMA-01 to SCHEMA-05 | Pending |
 | 4 | Provider Integration Testing | 124 | TEST-01 to TEST-06 | Pending |
@@ -43,12 +43,12 @@ Final Results
 
 ### Success Criteria
 
-1. [ ] User can enable reranking with `ENABLE_RERANKING=true`
-2. [ ] Queries use two-stage retrieval when reranking enabled
-3. [ ] Reranking works with Ollama models (bge-reranker-v2-m3)
-4. [ ] System returns stage 1 results if reranker fails (graceful degradation)
-5. [ ] Reranking adds <100ms latency for 100 candidates
-6. [ ] All existing tests pass (backward compatible)
+1. [x] User can enable reranking with `ENABLE_RERANKING=true`
+2. [x] Queries use two-stage retrieval when reranking enabled
+3. [x] Reranking works with SentenceTransformers CrossEncoder (primary) or Ollama (alternative)
+4. [x] System returns stage 1 results if reranker fails (graceful degradation)
+5. [x] Reranking adds <100ms latency for 100 candidates (CrossEncoder ~50ms)
+6. [x] All existing tests pass (backward compatible) + 55 new tests
 
 ### Files to Create
 
@@ -76,11 +76,11 @@ agent_brain_server/providers/reranker/
 |------|------|--------|-----------|
 | [01-01-PLAN.md](.planning/phases/01-two-stage-reranking/01-01-PLAN.md) | 1 | Complete | Add reranking settings and configuration |
 | [01-02-PLAN.md](.planning/phases/01-two-stage-reranking/01-02-PLAN.md) | 1 | Complete | Create RerankerProvider protocol and base class |
-| [01-03-PLAN.md](.planning/phases/01-two-stage-reranking/01-03-PLAN.md) | 2 | Pending | Implement SentenceTransformerRerankerProvider |
-| [01-04-PLAN.md](.planning/phases/01-two-stage-reranking/01-04-PLAN.md) | 2 | Pending | Implement OllamaRerankerProvider |
-| [01-05-PLAN.md](.planning/phases/01-two-stage-reranking/01-05-PLAN.md) | 3 | Pending | Integrate reranking into query_service.py |
-| [01-06-PLAN.md](.planning/phases/01-two-stage-reranking/01-06-PLAN.md) | 4 | Pending | Add unit and integration tests |
-| [01-07-PLAN.md](.planning/phases/01-two-stage-reranking/01-07-PLAN.md) | 4 | Pending | Update documentation |
+| [01-03-PLAN.md](.planning/phases/01-two-stage-reranking/01-03-PLAN.md) | 2 | Complete | Implement SentenceTransformerRerankerProvider |
+| [01-04-PLAN.md](.planning/phases/01-two-stage-reranking/01-04-PLAN.md) | 2 | Complete | Implement OllamaRerankerProvider |
+| [01-05-PLAN.md](.planning/phases/01-two-stage-reranking/01-05-PLAN.md) | 3 | Complete | Integrate reranking into query_service.py |
+| [01-06-PLAN.md](.planning/phases/01-two-stage-reranking/01-06-PLAN.md) | 4 | Complete | Add unit and integration tests |
+| [01-07-PLAN.md](.planning/phases/01-two-stage-reranking/01-07-PLAN.md) | 4 | Complete | Update documentation |
 
 ---
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,7 +2,7 @@
 
 **Last Updated:** 2026-02-07
 **Current Phase:** Phase 1 — Two-Stage Reranking (Feature 123)
-**Status:** Ready to Plan
+**Status:** Planned - Ready to Execute
 
 ## Project Reference
 
@@ -19,7 +19,7 @@ Roadmap Progress: ░░░░░░░░░░ 0%
 
 | Phase | Status | Plans | Progress |
 |-------|--------|-------|----------|
-| 1 — Two-Stage Reranking | ○ Ready | 0/0 | 0% |
+| 1 — Two-Stage Reranking | ◐ Planned | 0/7 | 0% |
 | 2 — Pluggable Providers | ○ Pending | 0/0 | 0% |
 | 3 — Schema GraphRAG | ○ Pending | 0/0 | 0% |
 | 4 — Provider Testing | ○ Pending | 0/0 | 0% |
@@ -27,7 +27,19 @@ Roadmap Progress: ░░░░░░░░░░ 0%
 ## Current Session
 
 **Phase 1:** Two-Stage Reranking
-**Status:** Not started — run `/gsd:plan-phase 1` to begin
+**Status:** Planned — 7 plans in 4 waves — run `/gsd:execute-phase 1` to begin
+
+### Plans Created
+
+| Plan | Wave | Objective |
+|------|------|-----------|
+| 01-01-PLAN.md | 1 | Add reranking settings and configuration |
+| 01-02-PLAN.md | 1 | Create RerankerProvider protocol and base class |
+| 01-03-PLAN.md | 2 | Implement SentenceTransformerRerankerProvider |
+| 01-04-PLAN.md | 2 | Implement OllamaRerankerProvider |
+| 01-05-PLAN.md | 3 | Integrate reranking into query_service.py |
+| 01-06-PLAN.md | 4 | Add unit and integration tests |
+| 01-07-PLAN.md | 4 | Update documentation |
 
 ### Key Context
 
@@ -65,10 +77,10 @@ This project was migrated from `.speckit/` (GitHub Spec-Driven Development) to G
 ## Next Action
 
 ```
-/gsd:plan-phase 1
+/gsd:execute-phase 1
 ```
 
-Plan the Two-Stage Reranking implementation.
+Execute the Two-Stage Reranking phase (7 plans in 4 waves).
 
 ---
 *State initialized: 2026-02-07*

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,74 @@
+# Agent Brain — Project State
+
+**Last Updated:** 2026-02-07
+**Current Phase:** Phase 1 — Two-Stage Reranking (Feature 123)
+**Status:** Ready to Plan
+
+## Project Reference
+
+See: .planning/PROJECT.md (updated 2026-02-07)
+
+**Core value:** Developers can semantically search their entire codebase and documentation through a single, fast, local-first API
+**Current focus:** Phase 1 — Two-Stage Reranking
+
+## Progress
+
+```
+Roadmap Progress: ░░░░░░░░░░ 0%
+```
+
+| Phase | Status | Plans | Progress |
+|-------|--------|-------|----------|
+| 1 — Two-Stage Reranking | ○ Ready | 0/0 | 0% |
+| 2 — Pluggable Providers | ○ Pending | 0/0 | 0% |
+| 3 — Schema GraphRAG | ○ Pending | 0/0 | 0% |
+| 4 — Provider Testing | ○ Pending | 0/0 | 0% |
+
+## Current Session
+
+**Phase 1:** Two-Stage Reranking
+**Status:** Not started — run `/gsd:plan-phase 1` to begin
+
+### Key Context
+
+- Feature 123 adds optional two-stage reranking
+- Start with Ollama (local-first, no API keys)
+- Off by default, graceful degradation
+- Expected +3-4% precision improvement
+
+### Decisions Made
+
+1. Ollama first (consistent with local-first philosophy)
+2. Reranking optional, off by default
+3. Graceful fallback to stage 1 on failure
+
+## Migration Notes
+
+This project was migrated from `.speckit/` (GitHub Spec-Driven Development) to GSD on 2026-02-07.
+
+**Completed Features (from speckit):**
+- 001-005: Core Document RAG
+- 100: BM25 & Hybrid Retrieval
+- 101: Source Code Ingestion
+- 109: Multi-Instance Architecture
+- 110: C# Code Indexing
+- 111: Skill Instance Discovery
+- 112: Agent Brain Naming
+- 113: GraphRAG Integration
+- 114: Agent Brain Plugin
+- 115: Server-Side Job Queue
+
+**Legacy Artifacts:**
+- `.speckit/` directory preserved for reference
+- `docs/roadmaps/product-roadmap.md` contains original roadmap
+
+## Next Action
+
+```
+/gsd:plan-phase 1
+```
+
+Plan the Two-Stage Reranking implementation.
+
+---
+*State initialized: 2026-02-07*

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,41 +2,41 @@
 
 **Last Updated:** 2026-02-08
 **Current Phase:** Phase 1 — Two-Stage Reranking (Feature 123)
-**Status:** In Progress
+**Status:** COMPLETE
 
 ## Current Position
 
 Phase: 1 of 4 (Two-Stage Reranking)
-Plan: 2 of 7 in current phase
-Status: In progress
-Last activity: 2026-02-08 - Completed 01-02-PLAN.md
+Plan: 7 of 7 in current phase
+Status: Complete
+Last activity: 2026-02-08 - Completed all plans (01-01 through 01-07)
 
-Progress: ██░░░░░░░░ 28%
+Progress: ██████████ 100%
 
 ## Project Reference
 
 See: .planning/PROJECT.md (updated 2026-02-07)
 
 **Core value:** Developers can semantically search their entire codebase and documentation through a single, fast, local-first API
-**Current focus:** Phase 1 — Two-Stage Reranking
+**Current focus:** Phase 1 — Two-Stage Reranking (COMPLETE)
 
 ## Progress
 
 ```
-Roadmap Progress: ██░░░░░░░░ 28%
+Roadmap Progress: ██▓░░░░░░░ 25%
 ```
 
 | Phase | Status | Plans | Progress |
 |-------|--------|-------|----------|
-| 1 — Two-Stage Reranking | ◐ In Progress | 2/7 | 28% |
+| 1 — Two-Stage Reranking | ● Complete | 7/7 | 100% |
 | 2 — Pluggable Providers | ○ Pending | 0/0 | 0% |
 | 3 — Schema GraphRAG | ○ Pending | 0/0 | 0% |
 | 4 — Provider Testing | ○ Pending | 0/0 | 0% |
 
-## Current Session
+## Completed Session
 
 **Phase 1:** Two-Stage Reranking
-**Status:** In Progress — Wave 1 complete (2/7 plans)
+**Status:** COMPLETE — All 7 plans executed across 4 waves
 
 ### Plans Status
 
@@ -44,40 +44,45 @@ Roadmap Progress: ██░░░░░░░░ 28%
 |------|------|--------|-----------|
 | 01-01-PLAN.md | 1 | Complete | Add reranking settings and configuration |
 | 01-02-PLAN.md | 1 | Complete | Create RerankerProvider protocol and base class |
-| 01-03-PLAN.md | 2 | Pending | Implement SentenceTransformerRerankerProvider |
-| 01-04-PLAN.md | 2 | Pending | Implement OllamaRerankerProvider |
-| 01-05-PLAN.md | 3 | Pending | Integrate reranking into query_service.py |
-| 01-06-PLAN.md | 4 | Pending | Add unit and integration tests |
-| 01-07-PLAN.md | 4 | Pending | Update documentation |
+| 01-03-PLAN.md | 2 | Complete | Implement SentenceTransformerRerankerProvider |
+| 01-04-PLAN.md | 2 | Complete | Implement OllamaRerankerProvider |
+| 01-05-PLAN.md | 3 | Complete | Integrate reranking into query_service.py |
+| 01-06-PLAN.md | 4 | Complete | Add unit and integration tests |
+| 01-07-PLAN.md | 4 | Complete | Update documentation |
 
-### Key Context
+### Key Deliverables
 
-- Feature 123 adds optional two-stage reranking
-- Start with Ollama (local-first, no API keys)
-- Off by default, graceful degradation
-- Expected +3-4% precision improvement
+1. **Configuration**: ENABLE_RERANKING, RERANKER_* settings in settings.py
+2. **Protocol**: RerankerProvider protocol and BaseRerankerProvider
+3. **Providers**:
+   - SentenceTransformerRerankerProvider (CrossEncoder, ~50ms)
+   - OllamaRerankerProvider (chat-based, ~500ms)
+4. **Integration**: _rerank_results() in QueryService with graceful fallback
+5. **Tests**: 55 new tests for reranking (all passing)
+6. **Documentation**: README.md and USER_GUIDE.md updated
 
 ### Decisions Made
 
-1. Ollama first (consistent with local-first philosophy)
-2. Reranking optional, off by default
-3. Graceful fallback to stage 1 on failure
-4. RerankerProvider protocol uses `list[tuple[int, float]]` return type for original indices
+1. SentenceTransformers as primary provider (not Ollama BGE models)
+2. Reranking optional, off by default (ENABLE_RERANKING=False)
+3. Graceful fallback to stage 1 on any failure
+4. RerankerProvider protocol uses `list[tuple[int, float]]` return type
 5. Added `is_available()` to protocol for graceful degradation
+6. asyncio.to_thread() for non-blocking CrossEncoder inference
 
 ## Session Continuity
 
-Last session: 2026-02-08T00:45:34Z
-Stopped at: Completed 01-02-PLAN.md
+Last session: 2026-02-08
+Stopped at: Completed Phase 1
 Resume file: None
 
 ## Next Action
 
 ```
-/gsd:execute-phase 1
+/gsd:plan-phase 2
 ```
 
-Continue the Two-Stage Reranking phase (Wave 2: plans 01-03 and 01-04).
+Plan Phase 2: Pluggable Providers for embeddings and summarization.
 
 ---
 *State updated: 2026-02-08*

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,24 +1,24 @@
 # Agent Brain — Project State
 
 **Last Updated:** 2026-02-08
-**Current Phase:** Phase 1 — Two-Stage Reranking (Feature 123)
-**Status:** COMPLETE
+**Current Phase:** Phase 2 — Pluggable Providers (Feature 103)
+**Status:** PLANNED
 
 ## Current Position
 
-Phase: 1 of 4 (Two-Stage Reranking)
-Plan: 7 of 7 in current phase
-Status: Complete
-Last activity: 2026-02-08 - Completed all plans (01-01 through 01-07)
+Phase: 2 of 4 (Pluggable Providers)
+Plan: 0 of 4 in current phase
+Status: Planned, ready for execution
+Last activity: 2026-02-08 - Created Phase 2 plans from research
 
-Progress: ██████████ 100%
+Progress: ██░░░░░░░░ 25%
 
 ## Project Reference
 
 See: .planning/PROJECT.md (updated 2026-02-07)
 
 **Core value:** Developers can semantically search their entire codebase and documentation through a single, fast, local-first API
-**Current focus:** Phase 1 — Two-Stage Reranking (COMPLETE)
+**Current focus:** Phase 2 — Pluggable Providers
 
 ## Progress
 
@@ -29,60 +29,63 @@ Roadmap Progress: ██▓░░░░░░░ 25%
 | Phase | Status | Plans | Progress |
 |-------|--------|-------|----------|
 | 1 — Two-Stage Reranking | ● Complete | 7/7 | 100% |
-| 2 — Pluggable Providers | ○ Pending | 0/0 | 0% |
+| 2 — Pluggable Providers | ◐ Planned | 0/4 | 0% |
 | 3 — Schema GraphRAG | ○ Pending | 0/0 | 0% |
 | 4 — Provider Testing | ○ Pending | 0/0 | 0% |
 
-## Completed Session
+## Current Session
 
-**Phase 1:** Two-Stage Reranking
-**Status:** COMPLETE — All 7 plans executed across 4 waves
+**Phase 2:** Pluggable Providers
+**Status:** PLANNED — Research complete, 4 plans ready for execution
+
+### Research Summary
+
+Most provider infrastructure already exists (PROV-01, PROV-02, PROV-04, PROV-05 done).
+Key gaps identified:
+- **PROV-07**: Dimension mismatch prevention (NOT implemented)
+- **PROV-06**: Strict startup validation (partial - only warns)
+- **PROV-03/04**: Need E2E verification tests
+
+See: `.planning/phases/02-pluggable-providers/02-RESEARCH.md`
 
 ### Plans Status
 
 | Plan | Wave | Status | Objective |
 |------|------|--------|-----------|
-| 01-01-PLAN.md | 1 | Complete | Add reranking settings and configuration |
-| 01-02-PLAN.md | 1 | Complete | Create RerankerProvider protocol and base class |
-| 01-03-PLAN.md | 2 | Complete | Implement SentenceTransformerRerankerProvider |
-| 01-04-PLAN.md | 2 | Complete | Implement OllamaRerankerProvider |
-| 01-05-PLAN.md | 3 | Complete | Integrate reranking into query_service.py |
-| 01-06-PLAN.md | 4 | Complete | Add unit and integration tests |
-| 01-07-PLAN.md | 4 | Complete | Update documentation |
+| 02-01-PLAN.md | 1 | Pending | Dimension mismatch prevention (PROV-07) |
+| 02-02-PLAN.md | 1 | Pending | Strict startup validation (PROV-06) |
+| 02-03-PLAN.md | 2 | Pending | Provider switching E2E test (PROV-03) |
+| 02-04-PLAN.md | 2 | Pending | Ollama offline E2E test (PROV-04) |
 
-### Key Deliverables
+### Key Context
 
-1. **Configuration**: ENABLE_RERANKING, RERANKER_* settings in settings.py
-2. **Protocol**: RerankerProvider protocol and BaseRerankerProvider
-3. **Providers**:
-   - SentenceTransformerRerankerProvider (CrossEncoder, ~50ms)
-   - OllamaRerankerProvider (chat-based, ~500ms)
-4. **Integration**: _rerank_results() in QueryService with graceful fallback
-5. **Tests**: 55 new tests for reranking (all passing)
-6. **Documentation**: README.md and USER_GUIDE.md updated
+- Feature 103: Configuration-driven model selection
+- Most infrastructure already built (factory, configs, providers)
+- Critical gap: Dimension mismatch can silently corrupt search
+- Estimated effort: 8-9 hours for all 4 plans
 
-### Decisions Made
+## Completed Phases
 
-1. SentenceTransformers as primary provider (not Ollama BGE models)
-2. Reranking optional, off by default (ENABLE_RERANKING=False)
-3. Graceful fallback to stage 1 on any failure
-4. RerankerProvider protocol uses `list[tuple[int, float]]` return type
-5. Added `is_available()` to protocol for graceful degradation
-6. asyncio.to_thread() for non-blocking CrossEncoder inference
+### Phase 1: Two-Stage Reranking (COMPLETE)
+
+- 7 plans executed across 4 waves
+- SentenceTransformerRerankerProvider + OllamaRerankerProvider
+- 55 new tests, all 453 tests passing
+- See: `.planning/phases/01-two-stage-reranking/`
 
 ## Session Continuity
 
 Last session: 2026-02-08
-Stopped at: Completed Phase 1
+Stopped at: Created Phase 2 plans
 Resume file: None
 
 ## Next Action
 
 ```
-/gsd:plan-phase 2
+/gsd:execute-phase 2
 ```
 
-Plan Phase 2: Pluggable Providers for embeddings and summarization.
+Execute Phase 2: Pluggable Providers (Wave 1: plans 02-01 and 02-02).
 
 ---
 *State updated: 2026-02-08*

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,8 +1,17 @@
 # Agent Brain — Project State
 
-**Last Updated:** 2026-02-07
+**Last Updated:** 2026-02-08
 **Current Phase:** Phase 1 — Two-Stage Reranking (Feature 123)
-**Status:** Planned - Ready to Execute
+**Status:** In Progress
+
+## Current Position
+
+Phase: 1 of 4 (Two-Stage Reranking)
+Plan: 2 of 7 in current phase
+Status: In progress
+Last activity: 2026-02-08 - Completed 01-02-PLAN.md
+
+Progress: ██░░░░░░░░ 28%
 
 ## Project Reference
 
@@ -14,12 +23,12 @@ See: .planning/PROJECT.md (updated 2026-02-07)
 ## Progress
 
 ```
-Roadmap Progress: ░░░░░░░░░░ 0%
+Roadmap Progress: ██░░░░░░░░ 28%
 ```
 
 | Phase | Status | Plans | Progress |
 |-------|--------|-------|----------|
-| 1 — Two-Stage Reranking | ◐ Planned | 0/7 | 0% |
+| 1 — Two-Stage Reranking | ◐ In Progress | 2/7 | 28% |
 | 2 — Pluggable Providers | ○ Pending | 0/0 | 0% |
 | 3 — Schema GraphRAG | ○ Pending | 0/0 | 0% |
 | 4 — Provider Testing | ○ Pending | 0/0 | 0% |
@@ -27,19 +36,19 @@ Roadmap Progress: ░░░░░░░░░░ 0%
 ## Current Session
 
 **Phase 1:** Two-Stage Reranking
-**Status:** Planned — 7 plans in 4 waves — run `/gsd:execute-phase 1` to begin
+**Status:** In Progress — Wave 1 complete (2/7 plans)
 
-### Plans Created
+### Plans Status
 
-| Plan | Wave | Objective |
-|------|------|-----------|
-| 01-01-PLAN.md | 1 | Add reranking settings and configuration |
-| 01-02-PLAN.md | 1 | Create RerankerProvider protocol and base class |
-| 01-03-PLAN.md | 2 | Implement SentenceTransformerRerankerProvider |
-| 01-04-PLAN.md | 2 | Implement OllamaRerankerProvider |
-| 01-05-PLAN.md | 3 | Integrate reranking into query_service.py |
-| 01-06-PLAN.md | 4 | Add unit and integration tests |
-| 01-07-PLAN.md | 4 | Update documentation |
+| Plan | Wave | Status | Objective |
+|------|------|--------|-----------|
+| 01-01-PLAN.md | 1 | Complete | Add reranking settings and configuration |
+| 01-02-PLAN.md | 1 | Complete | Create RerankerProvider protocol and base class |
+| 01-03-PLAN.md | 2 | Pending | Implement SentenceTransformerRerankerProvider |
+| 01-04-PLAN.md | 2 | Pending | Implement OllamaRerankerProvider |
+| 01-05-PLAN.md | 3 | Pending | Integrate reranking into query_service.py |
+| 01-06-PLAN.md | 4 | Pending | Add unit and integration tests |
+| 01-07-PLAN.md | 4 | Pending | Update documentation |
 
 ### Key Context
 
@@ -53,26 +62,14 @@ Roadmap Progress: ░░░░░░░░░░ 0%
 1. Ollama first (consistent with local-first philosophy)
 2. Reranking optional, off by default
 3. Graceful fallback to stage 1 on failure
+4. RerankerProvider protocol uses `list[tuple[int, float]]` return type for original indices
+5. Added `is_available()` to protocol for graceful degradation
 
-## Migration Notes
+## Session Continuity
 
-This project was migrated from `.speckit/` (GitHub Spec-Driven Development) to GSD on 2026-02-07.
-
-**Completed Features (from speckit):**
-- 001-005: Core Document RAG
-- 100: BM25 & Hybrid Retrieval
-- 101: Source Code Ingestion
-- 109: Multi-Instance Architecture
-- 110: C# Code Indexing
-- 111: Skill Instance Discovery
-- 112: Agent Brain Naming
-- 113: GraphRAG Integration
-- 114: Agent Brain Plugin
-- 115: Server-Side Job Queue
-
-**Legacy Artifacts:**
-- `.speckit/` directory preserved for reference
-- `docs/roadmaps/product-roadmap.md` contains original roadmap
+Last session: 2026-02-08T00:45:34Z
+Stopped at: Completed 01-02-PLAN.md
+Resume file: None
 
 ## Next Action
 
@@ -80,7 +77,7 @@ This project was migrated from `.speckit/` (GitHub Spec-Driven Development) to G
 /gsd:execute-phase 1
 ```
 
-Execute the Two-Stage Reranking phase (7 plans in 4 waves).
+Continue the Two-Stage Reranking phase (Wave 2: plans 01-03 and 01-04).
 
 ---
-*State initialized: 2026-02-07*
+*State updated: 2026-02-08*

--- a/.planning/config.json
+++ b/.planning/config.json
@@ -1,0 +1,17 @@
+{
+  "mode": "yolo",
+  "depth": "standard",
+  "parallelization": true,
+  "commit_docs": true,
+  "model_profile": "balanced",
+  "workflow": {
+    "research": true,
+    "plan_check": true,
+    "verifier": true
+  },
+  "migration": {
+    "source": "speckit",
+    "migrated_at": "2026-02-07",
+    "legacy_path": ".speckit/"
+  }
+}

--- a/.planning/phases/01-two-stage-reranking/01-01-PLAN.md
+++ b/.planning/phases/01-two-stage-reranking/01-01-PLAN.md
@@ -1,0 +1,202 @@
+---
+phase: 01-two-stage-reranking
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - agent-brain-server/agent_brain_server/config/settings.py
+  - agent-brain-server/agent_brain_server/config/provider_config.py
+  - agent-brain-server/agent_brain_server/providers/base.py
+autonomous: true
+
+must_haves:
+  truths:
+    - "Reranking is disabled by default (ENABLE_RERANKING=false)"
+    - "User can enable reranking via environment variable"
+    - "Reranker configuration follows existing provider pattern"
+  artifacts:
+    - path: "agent-brain-server/agent_brain_server/config/settings.py"
+      provides: "ENABLE_RERANKING, RERANKER_* settings"
+      contains: "ENABLE_RERANKING"
+    - path: "agent-brain-server/agent_brain_server/config/provider_config.py"
+      provides: "RerankerConfig class"
+      contains: "class RerankerConfig"
+    - path: "agent-brain-server/agent_brain_server/providers/base.py"
+      provides: "RerankerProviderType enum"
+      contains: "class RerankerProviderType"
+  key_links:
+    - from: "config/provider_config.py"
+      to: "providers/base.py"
+      via: "RerankerProviderType import"
+      pattern: "from.*providers.base.*import.*RerankerProviderType"
+---
+
+<objective>
+Add configuration settings and types for the two-stage reranking feature.
+
+Purpose: Enable users to configure reranking via environment variables and YAML config, following existing provider patterns.
+Output: Settings, config class, and provider type enum for reranking.
+</objective>
+
+<execution_context>
+@/Users/richardhightower/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/richardhightower/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/01-two-stage-reranking/01-RESEARCH.md
+@agent-brain-server/agent_brain_server/config/settings.py
+@agent-brain-server/agent_brain_server/config/provider_config.py
+@agent-brain-server/agent_brain_server/providers/base.py
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add reranking settings to Settings class</name>
+  <files>agent-brain-server/agent_brain_server/config/settings.py</files>
+  <action>
+Add these settings to the Settings class after the GraphRAG configuration section:
+
+```python
+# Reranking Configuration (Feature 123)
+ENABLE_RERANKING: bool = False  # Off by default
+RERANKER_PROVIDER: str = "sentence-transformers"  # or "ollama"
+RERANKER_MODEL: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+RERANKER_TOP_K_MULTIPLIER: int = 10  # Retrieve top_k * this for Stage 1
+RERANKER_MAX_CANDIDATES: int = 100  # Cap on Stage 1 candidates
+RERANKER_BATCH_SIZE: int = 32  # Batch size for reranking inference
+```
+
+Add a comment block like the existing sections (e.g., "# GraphRAG Configuration (Feature 113)").
+  </action>
+  <verify>Run `poetry run python -c "from agent_brain_server.config.settings import Settings; s = Settings(); print(s.ENABLE_RERANKING, s.RERANKER_PROVIDER)"` to verify settings load correctly and default to False and "sentence-transformers".</verify>
+  <done>Settings class includes all RERANKER_* fields with correct defaults.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add RerankerProviderType enum to base.py</name>
+  <files>agent-brain-server/agent_brain_server/providers/base.py</files>
+  <action>
+Add a new enum after SummarizationProviderType:
+
+```python
+class RerankerProviderType(str, Enum):
+    """Supported reranking providers."""
+
+    SENTENCE_TRANSFORMERS = "sentence-transformers"
+    OLLAMA = "ollama"
+```
+
+This follows the pattern of EmbeddingProviderType and SummarizationProviderType.
+  </action>
+  <verify>Run `poetry run python -c "from agent_brain_server.providers.base import RerankerProviderType; print(RerankerProviderType.SENTENCE_TRANSFORMERS.value)"` to verify the enum is importable and has correct values.</verify>
+  <done>RerankerProviderType enum exists with SENTENCE_TRANSFORMERS and OLLAMA values.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Add RerankerConfig class to provider_config.py</name>
+  <files>agent-brain-server/agent_brain_server/config/provider_config.py</files>
+  <action>
+1. Add RerankerProviderType to the imports from base.py:
+   ```python
+   from agent_brain_server.providers.base import (
+       EmbeddingProviderType,
+       SummarizationProviderType,
+       RerankerProviderType,
+   )
+   ```
+
+2. Add RerankerConfig class after SummarizationConfig:
+   ```python
+   class RerankerConfig(BaseModel):
+       """Configuration for reranking provider."""
+
+       provider: RerankerProviderType = Field(
+           default=RerankerProviderType.SENTENCE_TRANSFORMERS,
+           description="Reranking provider to use",
+       )
+       model: str = Field(
+           default="cross-encoder/ms-marco-MiniLM-L-6-v2",
+           description="Model name for reranking",
+       )
+       base_url: Optional[str] = Field(
+           default=None,
+           description="Custom base URL (for Ollama)",
+       )
+       params: dict[str, Any] = Field(
+           default_factory=dict,
+           description="Provider-specific parameters (batch_size, etc.)",
+       )
+
+       model_config = {"use_enum_values": True}
+
+       @field_validator("provider", mode="before")
+       @classmethod
+       def validate_provider(cls, v: Any) -> RerankerProviderType:
+           """Convert string to enum if needed."""
+           if isinstance(v, str):
+               return RerankerProviderType(v.lower())
+           if isinstance(v, RerankerProviderType):
+               return v
+           return RerankerProviderType(v)
+
+       def get_base_url(self) -> Optional[str]:
+           """Get base URL with defaults for specific providers."""
+           if self.base_url:
+               return self.base_url
+           if self.provider == RerankerProviderType.OLLAMA:
+               return "http://localhost:11434"
+           return None
+   ```
+
+3. Add reranker field to ProviderSettings:
+   ```python
+   class ProviderSettings(BaseModel):
+       """Top-level provider configuration."""
+
+       embedding: EmbeddingConfig = Field(...)
+       summarization: SummarizationConfig = Field(...)
+       reranker: RerankerConfig = Field(
+           default_factory=RerankerConfig,
+           description="Reranking provider configuration (optional)",
+       )
+   ```
+
+4. Add reranker to the logging in load_provider_settings():
+   ```python
+   if settings.reranker:
+       logger.info(
+           f"Active reranker provider: {settings.reranker.provider} "
+           f"(model: {settings.reranker.model})"
+       )
+   ```
+  </action>
+  <verify>Run `poetry run python -c "from agent_brain_server.config.provider_config import RerankerConfig, ProviderSettings; r = RerankerConfig(); print(r.provider, r.model); p = ProviderSettings(); print(p.reranker.provider)"` to verify the config loads with defaults.</verify>
+  <done>RerankerConfig class exists, follows provider pattern, integrated into ProviderSettings.</done>
+</task>
+
+</tasks>
+
+<verification>
+1. All imports resolve without errors
+2. Default values match research recommendations (sentence-transformers, cross-encoder/ms-marco-MiniLM-L-6-v2)
+3. ENABLE_RERANKING defaults to False
+4. Pattern matches existing EmbeddingConfig and SummarizationConfig
+</verification>
+
+<success_criteria>
+- Settings class has ENABLE_RERANKING=False default
+- RerankerProviderType enum has SENTENCE_TRANSFORMERS and OLLAMA
+- RerankerConfig follows existing provider config pattern
+- ProviderSettings includes optional reranker field
+- All imports and types resolve correctly
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/01-two-stage-reranking/01-01-SUMMARY.md`
+</output>

--- a/.planning/phases/01-two-stage-reranking/01-01-SUMMARY.md
+++ b/.planning/phases/01-two-stage-reranking/01-01-SUMMARY.md
@@ -1,0 +1,108 @@
+---
+phase: 01-two-stage-reranking
+plan: 01
+subsystem: config
+tags: [reranking, configuration, pydantic, enum, provider-pattern]
+
+# Dependency graph
+requires: []
+provides:
+  - ENABLE_RERANKING setting (disabled by default)
+  - RERANKER_* environment variable settings
+  - RerankerProviderType enum (SENTENCE_TRANSFORMERS, OLLAMA)
+  - RerankerConfig class following provider pattern
+  - ProviderSettings.reranker field
+affects: [01-02, 01-03, 01-04, 01-05]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Provider configuration pattern (RerankerConfig mirrors EmbeddingConfig/SummarizationConfig)"
+    - "Feature flag pattern (ENABLE_RERANKING=False by default)"
+
+key-files:
+  created: []
+  modified:
+    - "agent-brain-server/agent_brain_server/config/settings.py"
+    - "agent-brain-server/agent_brain_server/config/provider_config.py"
+    - "agent-brain-server/agent_brain_server/providers/base.py"
+
+key-decisions:
+  - "ENABLE_RERANKING defaults to False for backward compatibility"
+  - "sentence-transformers is the default provider (local, no API key needed)"
+  - "cross-encoder/ms-marco-MiniLM-L-6-v2 is the default reranker model"
+
+patterns-established:
+  - "RerankerConfig follows same structure as EmbeddingConfig and SummarizationConfig"
+
+# Metrics
+duration: 4min
+completed: 2026-02-08
+---
+
+# Phase 1 Plan 01: Add Reranking Configuration Summary
+
+**Configuration settings and types for two-stage reranking feature, following existing provider patterns with ENABLE_RERANKING off by default**
+
+## Performance
+
+- **Duration:** 4 min
+- **Started:** 2026-02-08T00:43:11Z
+- **Completed:** 2026-02-08T00:47:02Z
+- **Tasks:** 3
+- **Files modified:** 3
+
+## Accomplishments
+- Added 6 reranking settings to Settings class (ENABLE_RERANKING, RERANKER_PROVIDER, RERANKER_MODEL, etc.)
+- Created RerankerProviderType enum with SENTENCE_TRANSFORMERS and OLLAMA values
+- Implemented RerankerConfig class with field validation, base_url resolution, and provider-specific defaults
+- Integrated reranker into ProviderSettings with logging support
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Add reranking settings to Settings class** - `1f9677a` (feat)
+2. **Task 2: Add RerankerProviderType enum to base.py** - `e3e74f4` (feat)
+3. **Task 3: Add RerankerConfig class to provider_config.py** - `ec4958c` (feat)
+
+## Files Created/Modified
+- `agent-brain-server/agent_brain_server/config/settings.py` - Added ENABLE_RERANKING and 5 RERANKER_* settings
+- `agent-brain-server/agent_brain_server/providers/base.py` - Added RerankerProviderType enum
+- `agent-brain-server/agent_brain_server/config/provider_config.py` - Added RerankerConfig class, updated ProviderSettings, added logging
+
+## Decisions Made
+- ENABLE_RERANKING defaults to False (feature is opt-in, backward compatible)
+- Default provider is "sentence-transformers" (local-first, no API key required)
+- Default model is "cross-encoder/ms-marco-MiniLM-L-6-v2" (fast, good quality)
+- RERANKER_TOP_K_MULTIPLIER=10, MAX_CANDIDATES=100, BATCH_SIZE=32 (research-backed defaults)
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None - all tasks completed successfully.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+- Configuration infrastructure complete for reranking feature
+- Ready for Plan 01-02: Create RerankerProvider protocol and base class (already exists in providers/reranker/base.py)
+- All imports and types resolve correctly
+- All 383 server tests pass, 74 CLI tests pass
+
+## Self-Check: PASSED
+
+- [x] settings.py exists
+- [x] base.py exists
+- [x] provider_config.py exists
+- [x] 4 commits found for plan 01-01
+
+---
+*Phase: 01-two-stage-reranking*
+*Completed: 2026-02-08*

--- a/.planning/phases/01-two-stage-reranking/01-02-PLAN.md
+++ b/.planning/phases/01-two-stage-reranking/01-02-PLAN.md
@@ -1,0 +1,318 @@
+---
+phase: 01-two-stage-reranking
+plan: 02
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - agent-brain-server/agent_brain_server/providers/reranker/__init__.py
+  - agent-brain-server/agent_brain_server/providers/reranker/base.py
+  - agent-brain-server/agent_brain_server/providers/factory.py
+autonomous: true
+
+must_haves:
+  truths:
+    - "RerankerProvider protocol defines async rerank method"
+    - "BaseRerankerProvider provides common functionality"
+    - "ProviderRegistry can register and retrieve reranker providers"
+  artifacts:
+    - path: "agent-brain-server/agent_brain_server/providers/reranker/__init__.py"
+      provides: "Package exports"
+      contains: "RerankerProvider"
+    - path: "agent-brain-server/agent_brain_server/providers/reranker/base.py"
+      provides: "RerankerProvider protocol and BaseRerankerProvider class"
+      contains: "class RerankerProvider"
+    - path: "agent-brain-server/agent_brain_server/providers/factory.py"
+      provides: "Reranker provider registry methods"
+      contains: "register_reranker_provider"
+  key_links:
+    - from: "providers/factory.py"
+      to: "providers/reranker/base.py"
+      via: "RerankerProvider import"
+      pattern: "from.*reranker.*import"
+---
+
+<objective>
+Create the reranker provider protocol and base class following existing provider patterns.
+
+Purpose: Establish the abstraction layer for reranking providers that enables pluggable implementations.
+Output: RerankerProvider protocol, BaseRerankerProvider, and registry integration.
+</objective>
+
+<execution_context>
+@/Users/richardhightower/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/richardhightower/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/01-two-stage-reranking/01-RESEARCH.md
+@agent-brain-server/agent_brain_server/providers/base.py
+@agent-brain-server/agent_brain_server/providers/factory.py
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create reranker package with base module</name>
+  <files>
+    agent-brain-server/agent_brain_server/providers/reranker/__init__.py
+    agent-brain-server/agent_brain_server/providers/reranker/base.py
+  </files>
+  <action>
+Create the reranker package directory and files:
+
+1. Create `agent-brain-server/agent_brain_server/providers/reranker/__init__.py`:
+```python
+"""Reranking providers package."""
+
+from agent_brain_server.providers.reranker.base import (
+    BaseRerankerProvider,
+    RerankerProvider,
+)
+
+__all__ = [
+    "BaseRerankerProvider",
+    "RerankerProvider",
+]
+```
+
+2. Create `agent-brain-server/agent_brain_server/providers/reranker/base.py`:
+```python
+"""Base protocol and class for reranking providers."""
+
+import logging
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from agent_brain_server.config.provider_config import RerankerConfig
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class RerankerProvider(Protocol):
+    """Protocol for reranking providers.
+
+    All reranking providers must implement this interface to be usable
+    by the Agent Brain query system for two-stage retrieval.
+    """
+
+    async def rerank(
+        self,
+        query: str,
+        documents: list[str],
+        top_k: int = 10,
+    ) -> list[tuple[int, float]]:
+        """Rerank documents for a query.
+
+        Args:
+            query: The search query.
+            documents: List of document texts to rerank.
+            top_k: Number of top results to return.
+
+        Returns:
+            List of (original_index, score) tuples, sorted by score descending.
+            The original_index refers to the position in the input documents list.
+
+        Raises:
+            ProviderError: If reranking fails.
+        """
+        ...
+
+    @property
+    def provider_name(self) -> str:
+        """Human-readable provider name for logging."""
+        ...
+
+    @property
+    def model_name(self) -> str:
+        """Model identifier being used."""
+        ...
+
+    def is_available(self) -> bool:
+        """Check if the provider is available and ready.
+
+        Returns:
+            True if provider can perform reranking, False otherwise.
+        """
+        ...
+
+
+class BaseRerankerProvider(ABC):
+    """Base class for reranking providers with common functionality."""
+
+    def __init__(self, config: "RerankerConfig") -> None:
+        """Initialize the reranker provider.
+
+        Args:
+            config: Reranker configuration.
+        """
+        self._model = config.model
+        self._batch_size = config.params.get("batch_size", 32)
+        self._config = config
+        logger.info(
+            f"Initialized {self.provider_name} reranker with model {self._model}"
+        )
+
+    @property
+    def model_name(self) -> str:
+        """Model identifier being used."""
+        return self._model
+
+    @abstractmethod
+    async def rerank(
+        self,
+        query: str,
+        documents: list[str],
+        top_k: int = 10,
+    ) -> list[tuple[int, float]]:
+        """Provider-specific reranking implementation."""
+        ...
+
+    @property
+    @abstractmethod
+    def provider_name(self) -> str:
+        """Human-readable provider name for logging."""
+        ...
+
+    def is_available(self) -> bool:
+        """Default implementation - override if availability check needed."""
+        return True
+```
+
+Create the directory first if needed:
+```bash
+mkdir -p agent-brain-server/agent_brain_server/providers/reranker
+```
+  </action>
+  <verify>Run `poetry run python -c "from agent_brain_server.providers.reranker import RerankerProvider, BaseRerankerProvider; print('Imports work')"` to verify the package is importable.</verify>
+  <done>Reranker package exists with RerankerProvider protocol and BaseRerankerProvider class.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add reranker registry methods to ProviderRegistry</name>
+  <files>agent-brain-server/agent_brain_server/providers/factory.py</files>
+  <action>
+Update the ProviderRegistry class to support reranker providers:
+
+1. Add RerankerConfig to TYPE_CHECKING imports:
+```python
+if TYPE_CHECKING:
+    from agent_brain_server.config.provider_config import (
+        EmbeddingConfig,
+        SummarizationConfig,
+        RerankerConfig,
+    )
+    from agent_brain_server.providers.base import (
+        EmbeddingProvider,
+        SummarizationProvider,
+    )
+    from agent_brain_server.providers.reranker.base import RerankerProvider
+```
+
+2. Add reranker provider registry dict:
+```python
+class ProviderRegistry:
+    """Registry for provider implementations..."""
+
+    _embedding_providers: dict[str, type[Any]] = {}
+    _summarization_providers: dict[str, type[Any]] = {}
+    _reranker_providers: dict[str, type[Any]] = {}  # NEW
+    _instances: dict[str, Any] = {}
+```
+
+3. Add register method:
+```python
+@classmethod
+def register_reranker_provider(
+    cls,
+    provider_type: str,
+    provider_class: type["RerankerProvider"],
+) -> None:
+    """Register a reranking provider class.
+
+    Args:
+        provider_type: Provider identifier (e.g., 'sentence-transformers', 'ollama')
+        provider_class: Provider class implementing RerankerProvider protocol
+    """
+    cls._reranker_providers[provider_type] = provider_class
+    logger.debug(f"Registered reranker provider: {provider_type}")
+```
+
+4. Add get method:
+```python
+@classmethod
+def get_reranker_provider(cls, config: "RerankerConfig") -> "RerankerProvider":
+    """Get or create reranker provider instance.
+
+    Args:
+        config: Reranker provider configuration
+
+    Returns:
+        Configured RerankerProvider instance
+
+    Raises:
+        ProviderNotFoundError: If provider type is not registered
+    """
+    # Get provider type as string value
+    provider_type = (
+        config.provider.value
+        if hasattr(config.provider, "value")
+        else str(config.provider)
+    )
+    cache_key = f"rerank:{provider_type}:{config.model}"
+
+    if cache_key not in cls._instances:
+        provider_class = cls._reranker_providers.get(provider_type)
+        if not provider_class:
+            available = list(cls._reranker_providers.keys())
+            raise ProviderNotFoundError(
+                f"Unknown reranker provider: {provider_type}. "
+                f"Available: {', '.join(available) if available else 'none'}",
+                provider_type,
+            )
+        cls._instances[cache_key] = provider_class(config)
+        logger.info(
+            f"Created {provider_type} reranker provider with model {config.model}"
+        )
+
+    from agent_brain_server.providers.reranker.base import RerankerProvider
+
+    return cast(RerankerProvider, cls._instances[cache_key])
+```
+
+5. Add list method:
+```python
+@classmethod
+def get_available_reranker_providers(cls) -> list[str]:
+    """Get list of registered reranker provider types."""
+    return list(cls._reranker_providers.keys())
+```
+  </action>
+  <verify>Run `poetry run python -c "from agent_brain_server.providers.factory import ProviderRegistry; print(ProviderRegistry.get_available_reranker_providers())"` to verify the registry methods exist and return empty list initially.</verify>
+  <done>ProviderRegistry has register_reranker_provider, get_reranker_provider, and get_available_reranker_providers methods.</done>
+</task>
+
+</tasks>
+
+<verification>
+1. RerankerProvider protocol has async rerank method with correct signature
+2. BaseRerankerProvider has config initialization and abstract methods
+3. ProviderRegistry can register and retrieve reranker providers
+4. All imports resolve without circular dependencies
+</verification>
+
+<success_criteria>
+- RerankerProvider protocol is runtime_checkable
+- BaseRerankerProvider follows pattern of BaseEmbeddingProvider
+- Factory registry has all three reranker methods
+- No circular import issues between factory and reranker package
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/01-two-stage-reranking/01-02-SUMMARY.md`
+</output>

--- a/.planning/phases/01-two-stage-reranking/01-02-SUMMARY.md
+++ b/.planning/phases/01-two-stage-reranking/01-02-SUMMARY.md
@@ -1,0 +1,104 @@
+---
+phase: 01-two-stage-reranking
+plan: 02
+subsystem: api
+tags: [reranker, protocol, provider-pattern, factory, type-checking]
+
+# Dependency graph
+requires:
+  - phase: 01-01
+    provides: RerankerConfig, RerankerProviderType for type references
+provides:
+  - RerankerProvider protocol for defining reranker interface
+  - BaseRerankerProvider abstract class for shared functionality
+  - ProviderRegistry integration for reranker providers
+affects: [01-03, 01-04, 01-05]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Protocol with runtime_checkable for duck typing"
+    - "Abstract base class with common config initialization"
+    - "Factory registry pattern for pluggable providers"
+
+key-files:
+  created:
+    - agent-brain-server/agent_brain_server/providers/reranker/__init__.py
+    - agent-brain-server/agent_brain_server/providers/reranker/base.py
+  modified:
+    - agent-brain-server/agent_brain_server/providers/factory.py
+
+key-decisions:
+  - "RerankerProvider protocol matches existing EmbeddingProvider pattern"
+  - "Added is_available() method for graceful degradation checks"
+  - "Return type list[tuple[int, float]] preserves original indices for reordering"
+
+patterns-established:
+  - "Reranker provider protocol with async rerank method"
+  - "BaseRerankerProvider initializes from RerankerConfig"
+
+# Metrics
+duration: 2min
+completed: 2026-02-08
+---
+
+# Phase 01 Plan 02: Reranker Provider Protocol Summary
+
+**RerankerProvider protocol and BaseRerankerProvider class with ProviderRegistry integration following existing provider patterns**
+
+## Performance
+
+- **Duration:** 2 min
+- **Started:** 2026-02-08T00:43:16Z
+- **Completed:** 2026-02-08T00:45:34Z
+- **Tasks:** 2
+- **Files modified:** 3
+
+## Accomplishments
+
+- Created RerankerProvider protocol with async rerank method and runtime_checkable decorator
+- Implemented BaseRerankerProvider abstract class with config initialization and common properties
+- Added register_reranker_provider, get_reranker_provider, and get_available_reranker_providers to ProviderRegistry
+- All imports resolve without circular dependencies
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Create reranker package with base module** - `7936c84` (feat)
+2. **Task 2: Add reranker registry methods to ProviderRegistry** - `6b54243` (feat)
+
+## Files Created/Modified
+
+- `agent-brain-server/agent_brain_server/providers/reranker/__init__.py` - Package exports for RerankerProvider and BaseRerankerProvider
+- `agent-brain-server/agent_brain_server/providers/reranker/base.py` - Protocol definition and abstract base class
+- `agent-brain-server/agent_brain_server/providers/factory.py` - Added reranker provider registry methods
+
+## Decisions Made
+
+- **Protocol signature:** `rerank(query, documents, top_k) -> list[tuple[int, float]]` returns original indices with scores for flexible reordering
+- **is_available() method:** Added to protocol for runtime availability checking (graceful degradation)
+- **Batch size default:** 32 in BaseRerankerProvider, configurable via params
+
+## Deviations from Plan
+
+None - plan executed exactly as written. The required RerankerConfig and RerankerProviderType already existed from plan 01-01.
+
+## Issues Encountered
+
+None
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+- RerankerProvider protocol ready for SentenceTransformers implementation (plan 01-03)
+- RerankerProvider protocol ready for Ollama implementation (plan 01-04)
+- ProviderRegistry integration complete for provider registration
+
+---
+*Phase: 01-two-stage-reranking*
+*Completed: 2026-02-08*

--- a/.planning/phases/01-two-stage-reranking/01-03-PLAN.md
+++ b/.planning/phases/01-two-stage-reranking/01-03-PLAN.md
@@ -1,0 +1,281 @@
+---
+phase: 01-two-stage-reranking
+plan: 03
+type: execute
+wave: 2
+depends_on: ["01-01", "01-02"]
+files_modified:
+  - agent-brain-server/agent_brain_server/providers/reranker/sentence_transformers.py
+  - agent-brain-server/agent_brain_server/providers/reranker/__init__.py
+  - agent-brain-server/pyproject.toml
+autonomous: true
+
+must_haves:
+  truths:
+    - "SentenceTransformerRerankerProvider uses CrossEncoder.rank() method"
+    - "Reranking runs in thread pool to avoid blocking async loop"
+    - "Provider is registered with ProviderRegistry on import"
+  artifacts:
+    - path: "agent-brain-server/agent_brain_server/providers/reranker/sentence_transformers.py"
+      provides: "SentenceTransformerRerankerProvider implementation"
+      contains: "class SentenceTransformerRerankerProvider"
+    - path: "agent-brain-server/pyproject.toml"
+      provides: "sentence-transformers dependency"
+      contains: "sentence-transformers"
+  key_links:
+    - from: "providers/reranker/sentence_transformers.py"
+      to: "sentence_transformers.CrossEncoder"
+      via: "import"
+      pattern: "from sentence_transformers import CrossEncoder"
+---
+
+<objective>
+Implement SentenceTransformerRerankerProvider using the sentence-transformers CrossEncoder.
+
+Purpose: Provide the primary reranking implementation using industry-standard cross-encoder models.
+Output: Working sentence-transformers reranker provider with proper async handling.
+</objective>
+
+<execution_context>
+@/Users/richardhightower/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/richardhightower/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/01-two-stage-reranking/01-RESEARCH.md
+@.planning/phases/01-two-stage-reranking/01-01-SUMMARY.md
+@.planning/phases/01-two-stage-reranking/01-02-SUMMARY.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add sentence-transformers dependency</name>
+  <files>agent-brain-server/pyproject.toml</files>
+  <action>
+Add sentence-transformers to the dependencies in pyproject.toml:
+
+```toml
+[tool.poetry.dependencies]
+# ... existing dependencies ...
+sentence-transformers = "^3.4.0"
+```
+
+Then run `cd agent-brain-server && poetry lock --no-update && poetry install` to update the lock file and install.
+
+Note: sentence-transformers pulls in torch which is large. This is expected.
+  </action>
+  <verify>Run `cd agent-brain-server && poetry run python -c "from sentence_transformers import CrossEncoder; print('sentence-transformers installed')"` to verify the package is available.</verify>
+  <done>sentence-transformers is listed in pyproject.toml and installed.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Implement SentenceTransformerRerankerProvider</name>
+  <files>agent-brain-server/agent_brain_server/providers/reranker/sentence_transformers.py</files>
+  <action>
+Create the sentence-transformers reranker implementation:
+
+```python
+"""SentenceTransformer CrossEncoder reranking provider."""
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from sentence_transformers import CrossEncoder
+
+from agent_brain_server.providers.factory import ProviderRegistry
+from agent_brain_server.providers.reranker.base import BaseRerankerProvider
+
+if TYPE_CHECKING:
+    from agent_brain_server.config.provider_config import RerankerConfig
+
+logger = logging.getLogger(__name__)
+
+
+class SentenceTransformerRerankerProvider(BaseRerankerProvider):
+    """Reranker using sentence-transformers CrossEncoder.
+
+    Uses pre-trained cross-encoder models for accurate document reranking.
+    The CrossEncoder scores query-document pairs directly, providing
+    more accurate relevance scores than bi-encoder similarity.
+
+    Default model: cross-encoder/ms-marco-MiniLM-L-6-v2 (fast, good accuracy)
+    Alternative: cross-encoder/ms-marco-MiniLM-L-12-v2 (slower, better accuracy)
+    """
+
+    def __init__(self, config: "RerankerConfig") -> None:
+        """Initialize the CrossEncoder reranker.
+
+        Args:
+            config: Reranker configuration.
+        """
+        super().__init__(config)
+        self._cross_encoder: CrossEncoder | None = None
+        self._model_loaded = False
+
+    def _ensure_model_loaded(self) -> CrossEncoder:
+        """Lazy-load the CrossEncoder model.
+
+        Returns:
+            Loaded CrossEncoder instance.
+        """
+        if self._cross_encoder is None:
+            logger.info(f"Loading CrossEncoder model: {self._model}")
+            self._cross_encoder = CrossEncoder(self._model)
+            self._model_loaded = True
+            logger.info(f"CrossEncoder model loaded: {self._model}")
+        return self._cross_encoder
+
+    async def rerank(
+        self,
+        query: str,
+        documents: list[str],
+        top_k: int = 10,
+    ) -> list[tuple[int, float]]:
+        """Rerank documents using CrossEncoder.
+
+        Uses CrossEncoder.rank() for efficient batch scoring and sorting.
+        Runs in thread pool to avoid blocking the async event loop.
+
+        Args:
+            query: The search query.
+            documents: List of document texts to rerank.
+            top_k: Number of top results to return.
+
+        Returns:
+            List of (original_index, score) tuples, sorted by score descending.
+        """
+        if not documents:
+            return []
+
+        # Limit top_k to document count
+        effective_top_k = min(top_k, len(documents))
+
+        # Run CrossEncoder in thread pool (CPU-bound operation)
+        results = await asyncio.to_thread(
+            self._rerank_sync,
+            query,
+            documents,
+            effective_top_k,
+        )
+
+        logger.debug(
+            f"Reranked {len(documents)} documents, returning top {effective_top_k}"
+        )
+
+        return results
+
+    def _rerank_sync(
+        self,
+        query: str,
+        documents: list[str],
+        top_k: int,
+    ) -> list[tuple[int, float]]:
+        """Synchronous reranking implementation.
+
+        Args:
+            query: The search query.
+            documents: List of document texts.
+            top_k: Number of results to return.
+
+        Returns:
+            List of (corpus_id, score) tuples.
+        """
+        model = self._ensure_model_loaded()
+
+        # CrossEncoder.rank() returns sorted results with corpus_id and score
+        # return_documents=False for efficiency (we don't need the text back)
+        ranked = model.rank(
+            query,
+            documents,
+            top_k=top_k,
+            return_documents=False,
+        )
+
+        # Convert to (index, score) tuples
+        return [(r["corpus_id"], float(r["score"])) for r in ranked]
+
+    @property
+    def provider_name(self) -> str:
+        """Human-readable provider name."""
+        return "SentenceTransformers"
+
+    def is_available(self) -> bool:
+        """Check if CrossEncoder can be loaded.
+
+        Returns:
+            True if model can be loaded, False otherwise.
+        """
+        try:
+            self._ensure_model_loaded()
+            return True
+        except Exception as e:
+            logger.warning(f"CrossEncoder not available: {e}")
+            return False
+
+
+# Register provider on import
+ProviderRegistry.register_reranker_provider(
+    "sentence-transformers",
+    SentenceTransformerRerankerProvider,
+)
+```
+  </action>
+  <verify>Run `cd agent-brain-server && poetry run python -c "from agent_brain_server.providers.reranker.sentence_transformers import SentenceTransformerRerankerProvider; from agent_brain_server.providers.factory import ProviderRegistry; print(ProviderRegistry.get_available_reranker_providers())"` to verify the provider is registered.</verify>
+  <done>SentenceTransformerRerankerProvider is implemented and registered with factory.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Update reranker package exports</name>
+  <files>agent-brain-server/agent_brain_server/providers/reranker/__init__.py</files>
+  <action>
+Update the package __init__.py to export the new provider:
+
+```python
+"""Reranking providers package."""
+
+from agent_brain_server.providers.reranker.base import (
+    BaseRerankerProvider,
+    RerankerProvider,
+)
+from agent_brain_server.providers.reranker.sentence_transformers import (
+    SentenceTransformerRerankerProvider,
+)
+
+__all__ = [
+    "BaseRerankerProvider",
+    "RerankerProvider",
+    "SentenceTransformerRerankerProvider",
+]
+```
+
+The import of sentence_transformers module triggers provider registration.
+  </action>
+  <verify>Run `cd agent-brain-server && poetry run python -c "from agent_brain_server.providers.reranker import SentenceTransformerRerankerProvider; print('Export works')"` to verify the export is available.</verify>
+  <done>SentenceTransformerRerankerProvider is exported from reranker package.</done>
+</task>
+
+</tasks>
+
+<verification>
+1. sentence-transformers is installed and importable
+2. SentenceTransformerRerankerProvider uses CrossEncoder.rank() method
+3. Provider runs inference in thread pool (asyncio.to_thread)
+4. Provider is registered with ProviderRegistry on import
+5. Lazy model loading prevents startup overhead
+</verification>
+
+<success_criteria>
+- poetry install succeeds with sentence-transformers
+- CrossEncoder model can be loaded (first call may be slow due to download)
+- rerank() method returns correctly sorted (index, score) tuples
+- Provider registration happens automatically on import
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/01-two-stage-reranking/01-03-SUMMARY.md`
+</output>

--- a/.planning/phases/01-two-stage-reranking/01-03-SUMMARY.md
+++ b/.planning/phases/01-two-stage-reranking/01-03-SUMMARY.md
@@ -1,0 +1,149 @@
+---
+phase: 01-two-stage-reranking
+plan: 03
+subsystem: api
+tags: [reranker, sentence-transformers, cross-encoder, provider-pattern]
+
+# Dependency graph
+requires:
+  - phase: 01-01
+    provides: RerankerConfig for provider configuration
+  - phase: 01-02
+    provides: BaseRerankerProvider class and ProviderRegistry
+provides:
+  - SentenceTransformerRerankerProvider using CrossEncoder
+  - sentence-transformers dependency in pyproject.toml
+affects: [01-05, 01-06, 01-07]
+
+# Tech tracking
+tech-stack:
+  added:
+    - sentence-transformers ^3.4.0
+  patterns:
+    - "CrossEncoder.rank() for efficient batch reranking"
+    - "asyncio.to_thread() for non-blocking CPU-bound inference"
+    - "Lazy model loading to avoid startup overhead"
+
+key-files:
+  created:
+    - agent-brain-server/agent_brain_server/providers/reranker/sentence_transformers.py
+  modified:
+    - agent-brain-server/pyproject.toml
+    - agent-brain-server/agent_brain_server/providers/reranker/__init__.py
+
+key-decisions:
+  - "CrossEncoder.rank() returns sorted results with corpus_id and score"
+  - "Thread pool execution via asyncio.to_thread for CPU-bound operations"
+  - "Lazy model loading delays ~500MB model download until first use"
+
+patterns-established:
+  - "Reranker runs inference in thread pool to avoid blocking async loop"
+  - "Model loading deferred until first rerank call"
+
+# Metrics
+duration: 8min
+completed: 2026-02-07
+---
+
+# Phase 01 Plan 03: SentenceTransformer Reranker Provider Summary
+
+**SentenceTransformerRerankerProvider using CrossEncoder with async thread pool execution**
+
+## Performance
+
+- **Duration:** 8 min
+- **Started:** 2026-02-07T18:50:00Z
+- **Completed:** 2026-02-07T18:58:00Z
+- **Tasks:** 3
+- **Files modified:** 3
+
+## Accomplishments
+
+- Added sentence-transformers ^3.4.0 to pyproject.toml dependencies
+- Created SentenceTransformerRerankerProvider using CrossEncoder.rank() method
+- Implemented async reranking with asyncio.to_thread() for non-blocking inference
+- Lazy model loading to avoid startup overhead
+- Provider auto-registers with ProviderRegistry on import
+- All verification commands passed successfully
+
+## Task Commits
+
+Each task corresponds to the plan specification:
+
+1. **Task 1: Add sentence-transformers dependency** - pyproject.toml updated with `sentence-transformers = "^3.4.0"`
+2. **Task 2: Implement SentenceTransformerRerankerProvider** - Full implementation with CrossEncoder.rank()
+3. **Task 3: Update reranker package exports** - __init__.py updated (also includes OllamaRerankerProvider from parallel wave)
+
+## Files Created/Modified
+
+- `agent-brain-server/pyproject.toml` - Added sentence-transformers ^3.4.0 under "Reranking dependencies" section
+- `agent-brain-server/agent_brain_server/providers/reranker/sentence_transformers.py` - Full provider implementation
+- `agent-brain-server/agent_brain_server/providers/reranker/__init__.py` - Updated exports
+
+## Key Implementation Details
+
+### CrossEncoder Usage
+```python
+ranked = model.rank(
+    query,
+    documents,
+    top_k=top_k,
+    return_documents=False,  # Efficiency: don't return text
+)
+return [(int(r["corpus_id"]), float(r["score"])) for r in ranked]
+```
+
+### Async Thread Pool Pattern
+```python
+results = await asyncio.to_thread(
+    self._rerank_sync,
+    query,
+    documents,
+    effective_top_k,
+)
+```
+
+### Lazy Model Loading
+```python
+def _ensure_model_loaded(self) -> CrossEncoder:
+    if self._cross_encoder is None:
+        self._cross_encoder = CrossEncoder(self._model)
+    return self._cross_encoder
+```
+
+## Verification Results
+
+All verification commands passed:
+- `from sentence_transformers import CrossEncoder` - Success
+- `from agent_brain_server.providers.reranker.sentence_transformers import SentenceTransformerRerankerProvider` - Success
+- `from agent_brain_server.providers.reranker import SentenceTransformerRerankerProvider` - Success
+- `ProviderRegistry.get_available_reranker_providers()` returns `['ollama', 'sentence-transformers']`
+
+## Quality Checks
+
+- black: All files properly formatted
+- ruff: No linting issues in new file
+- mypy: No type errors in new file
+
+## Deviations from Plan
+
+None - plan executed exactly as written. Note: OllamaRerankerProvider was added in parallel by another wave (01-04), so __init__.py includes both providers.
+
+## Issues Encountered
+
+- Poetry environment was linked to wrong project directory; resolved by creating local .venv with pip install -e .
+- sentence-transformers pulls in torch (~2GB) as expected; installation completed successfully
+
+## User Setup Required
+
+None - sentence-transformers auto-downloads models on first use. Default model is `cross-encoder/ms-marco-MiniLM-L-6-v2` (~80MB download on first use).
+
+## Next Phase Readiness
+
+- SentenceTransformerRerankerProvider ready for integration with QueryService (plan 01-05)
+- Provider can be selected via RERANKER_PROVIDER=sentence-transformers environment variable
+- Default model can be overridden via RERANKER_MODEL setting
+
+---
+*Phase: 01-two-stage-reranking*
+*Completed: 2026-02-07*

--- a/.planning/phases/01-two-stage-reranking/01-04-PLAN.md
+++ b/.planning/phases/01-two-stage-reranking/01-04-PLAN.md
@@ -1,0 +1,327 @@
+---
+phase: 01-two-stage-reranking
+plan: 04
+type: execute
+wave: 2
+depends_on: ["01-01", "01-02"]
+files_modified:
+  - agent-brain-server/agent_brain_server/providers/reranker/ollama.py
+  - agent-brain-server/agent_brain_server/providers/reranker/__init__.py
+autonomous: true
+
+must_haves:
+  truths:
+    - "OllamaRerankerProvider uses chat completions for scoring"
+    - "Provider gracefully handles Ollama connection failures"
+    - "Provider is registered with ProviderRegistry on import"
+  artifacts:
+    - path: "agent-brain-server/agent_brain_server/providers/reranker/ollama.py"
+      provides: "OllamaRerankerProvider implementation"
+      contains: "class OllamaRerankerProvider"
+  key_links:
+    - from: "providers/reranker/ollama.py"
+      to: "ollama client"
+      via: "httpx or ollama SDK"
+      pattern: "httpx|ollama"
+---
+
+<objective>
+Implement OllamaRerankerProvider using chat completions for fully local reranking.
+
+Purpose: Provide an alternative reranker for users who want fully local inference without downloading HuggingFace models.
+Output: Working Ollama-based reranker using chat-based relevance scoring.
+</objective>
+
+<execution_context>
+@/Users/richardhightower/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/richardhightower/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/01-two-stage-reranking/01-RESEARCH.md
+@.planning/phases/01-two-stage-reranking/01-01-SUMMARY.md
+@.planning/phases/01-two-stage-reranking/01-02-SUMMARY.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Implement OllamaRerankerProvider</name>
+  <files>agent-brain-server/agent_brain_server/providers/reranker/ollama.py</files>
+  <action>
+Create the Ollama reranker implementation using httpx (already a dependency):
+
+```python
+"""Ollama-based reranking provider using chat completions."""
+
+import asyncio
+import logging
+import re
+from typing import TYPE_CHECKING
+
+import httpx
+
+from agent_brain_server.providers.factory import ProviderRegistry
+from agent_brain_server.providers.reranker.base import BaseRerankerProvider
+
+if TYPE_CHECKING:
+    from agent_brain_server.config.provider_config import RerankerConfig
+
+logger = logging.getLogger(__name__)
+
+
+class OllamaRerankerProvider(BaseRerankerProvider):
+    """Reranker using Ollama chat completions for relevance scoring.
+
+    Uses prompt-based scoring to rank documents by relevance to the query.
+    This approach works with any Ollama model but is slower than CrossEncoder.
+
+    Recommended models:
+    - qwen3:0.6b-reranker (if available)
+    - llama3.2:1b (general purpose, good for scoring)
+    - gemma2:2b (good instruction following)
+
+    Note: This is slower than sentence-transformers but fully local without
+    needing to download HuggingFace models.
+    """
+
+    RERANK_PROMPT = '''You are a relevance scoring system. Score how relevant the document is to the query.
+
+Query: {query}
+
+Document: {document}
+
+Instructions:
+- Output ONLY a single number from 0 to 10
+- 10 = perfectly relevant, directly answers the query
+- 5 = somewhat relevant, related topic
+- 0 = completely irrelevant
+- Do not output any other text, just the number
+
+Score:'''
+
+    def __init__(self, config: "RerankerConfig") -> None:
+        """Initialize the Ollama reranker.
+
+        Args:
+            config: Reranker configuration.
+        """
+        super().__init__(config)
+        self._base_url = config.get_base_url() or "http://localhost:11434"
+        self._timeout = config.params.get("timeout", 30.0)
+        self._max_concurrent = config.params.get("max_concurrent", 5)
+        self._client: httpx.AsyncClient | None = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        """Get or create HTTP client."""
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                base_url=self._base_url,
+                timeout=httpx.Timeout(self._timeout),
+            )
+        return self._client
+
+    async def _score_document(
+        self,
+        query: str,
+        document: str,
+        doc_index: int,
+    ) -> tuple[int, float]:
+        """Score a single document for relevance.
+
+        Args:
+            query: The search query.
+            document: Document text to score.
+            doc_index: Original index in the document list.
+
+        Returns:
+            Tuple of (doc_index, score).
+        """
+        # Truncate document to avoid context overflow
+        max_doc_len = 2000
+        doc_text = document[:max_doc_len] if len(document) > max_doc_len else document
+
+        prompt = self.RERANK_PROMPT.format(query=query, document=doc_text)
+
+        try:
+            client = self._get_client()
+            response = await client.post(
+                "/api/chat",
+                json={
+                    "model": self._model,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "stream": False,
+                    "options": {"temperature": 0.0},
+                },
+            )
+            response.raise_for_status()
+            result = response.json()
+
+            # Parse score from response
+            content = result.get("message", {}).get("content", "").strip()
+            score = self._parse_score(content)
+            return (doc_index, score)
+
+        except httpx.HTTPError as e:
+            logger.warning(f"Ollama request failed for doc {doc_index}: {e}")
+            return (doc_index, 0.0)
+        except Exception as e:
+            logger.warning(f"Error scoring doc {doc_index}: {e}")
+            return (doc_index, 0.0)
+
+    def _parse_score(self, content: str) -> float:
+        """Parse numeric score from model output.
+
+        Args:
+            content: Raw model response.
+
+        Returns:
+            Parsed score (0-10), or 0.0 on failure.
+        """
+        try:
+            # Try to extract first number from response
+            match = re.search(r"(\d+(?:\.\d+)?)", content)
+            if match:
+                score = float(match.group(1))
+                # Clamp to 0-10 range
+                return min(max(score, 0.0), 10.0)
+            return 0.0
+        except (ValueError, AttributeError):
+            return 0.0
+
+    async def rerank(
+        self,
+        query: str,
+        documents: list[str],
+        top_k: int = 10,
+    ) -> list[tuple[int, float]]:
+        """Rerank documents using Ollama chat completions.
+
+        Scores each document concurrently with rate limiting.
+
+        Args:
+            query: The search query.
+            documents: List of document texts to rerank.
+            top_k: Number of top results to return.
+
+        Returns:
+            List of (original_index, score) tuples, sorted by score descending.
+        """
+        if not documents:
+            return []
+
+        # Create scoring tasks with semaphore for rate limiting
+        semaphore = asyncio.Semaphore(self._max_concurrent)
+
+        async def score_with_limit(idx: int, doc: str) -> tuple[int, float]:
+            async with semaphore:
+                return await self._score_document(query, doc, idx)
+
+        # Score all documents concurrently
+        tasks = [score_with_limit(i, doc) for i, doc in enumerate(documents)]
+        scores = await asyncio.gather(*tasks)
+
+        # Sort by score descending and take top_k
+        sorted_scores = sorted(scores, key=lambda x: x[1], reverse=True)
+
+        logger.debug(
+            f"Ollama reranked {len(documents)} documents, returning top {top_k}"
+        )
+
+        return sorted_scores[:top_k]
+
+    @property
+    def provider_name(self) -> str:
+        """Human-readable provider name."""
+        return "Ollama"
+
+    def is_available(self) -> bool:
+        """Check if Ollama is running and model is available.
+
+        Returns:
+            True if Ollama responds to health check, False otherwise.
+        """
+        try:
+            import httpx as sync_httpx
+
+            with sync_httpx.Client(base_url=self._base_url, timeout=5.0) as client:
+                response = client.get("/api/tags")
+                return response.status_code == 200
+        except Exception as e:
+            logger.debug(f"Ollama not available: {e}")
+            return False
+
+    async def close(self) -> None:
+        """Close the HTTP client."""
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+
+
+# Register provider on import
+ProviderRegistry.register_reranker_provider(
+    "ollama",
+    OllamaRerankerProvider,
+)
+```
+  </action>
+  <verify>Run `cd agent-brain-server && poetry run python -c "from agent_brain_server.providers.reranker.ollama import OllamaRerankerProvider; from agent_brain_server.providers.factory import ProviderRegistry; print(ProviderRegistry.get_available_reranker_providers())"` to verify the provider is registered. Should show both 'sentence-transformers' and 'ollama'.</verify>
+  <done>OllamaRerankerProvider is implemented with chat-based scoring and registered.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Update reranker package exports</name>
+  <files>agent-brain-server/agent_brain_server/providers/reranker/__init__.py</files>
+  <action>
+Update the package __init__.py to export the Ollama provider:
+
+```python
+"""Reranking providers package."""
+
+from agent_brain_server.providers.reranker.base import (
+    BaseRerankerProvider,
+    RerankerProvider,
+)
+from agent_brain_server.providers.reranker.ollama import OllamaRerankerProvider
+from agent_brain_server.providers.reranker.sentence_transformers import (
+    SentenceTransformerRerankerProvider,
+)
+
+__all__ = [
+    "BaseRerankerProvider",
+    "RerankerProvider",
+    "OllamaRerankerProvider",
+    "SentenceTransformerRerankerProvider",
+]
+```
+
+Both imports trigger provider registration with the factory.
+  </action>
+  <verify>Run `cd agent-brain-server && poetry run python -c "from agent_brain_server.providers.reranker import OllamaRerankerProvider; print('Export works')"` to verify the export.</verify>
+  <done>OllamaRerankerProvider is exported from reranker package.</done>
+</task>
+
+</tasks>
+
+<verification>
+1. OllamaRerankerProvider uses httpx for async HTTP requests
+2. Chat completions API used with relevance scoring prompt
+3. Concurrent scoring with semaphore rate limiting
+4. Graceful error handling returns score 0.0 on failure
+5. Provider registered with ProviderRegistry on import
+</verification>
+
+<success_criteria>
+- OllamaRerankerProvider class exists and is importable
+- Provider uses Ollama chat completions API correctly
+- Score parsing handles various model output formats
+- is_available() checks Ollama connectivity
+- Both providers registered: ['sentence-transformers', 'ollama']
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/01-two-stage-reranking/01-04-SUMMARY.md`
+</output>

--- a/.planning/phases/01-two-stage-reranking/01-04-SUMMARY.md
+++ b/.planning/phases/01-two-stage-reranking/01-04-SUMMARY.md
@@ -1,0 +1,90 @@
+# 01-04 Summary: OllamaRerankerProvider Implementation
+
+## Status: COMPLETE
+
+## What Was Done
+
+### Task 1: Implemented OllamaRerankerProvider
+
+Created `/agent-brain-server/agent_brain_server/providers/reranker/ollama.py`:
+
+- **OllamaRerankerProvider class** - Uses Ollama chat completions API for relevance scoring
+- **Prompt-based scoring** - Uses a structured prompt that instructs the model to output a 0-10 score
+- **Concurrent scoring with rate limiting** - Uses `asyncio.Semaphore` to limit concurrent requests (default 5)
+- **Graceful error handling** - Returns 0.0 score on any failure (connection, HTTP, parsing)
+- **Score parsing** - Regex-based extraction handles various model output formats
+- **Document truncation** - Limits document length to 2000 chars to avoid context overflow
+- **is_available()** - Checks Ollama connectivity via `/api/tags` endpoint
+- **close()** method - Properly closes httpx AsyncClient
+- **Provider registration** - Automatically registers with ProviderRegistry on import
+
+Key implementation details:
+```python
+RERANK_PROMPT = (
+    "You are a relevance scoring system. "
+    "Score how relevant the document is to the query.\n\n"
+    "Query: {query}\n\n"
+    "Document: {document}\n\n"
+    "Instructions:\n"
+    "- Output ONLY a single number from 0 to 10\n"
+    "- 10 = perfectly relevant, directly answers the query\n"
+    "- 5 = somewhat relevant, related topic\n"
+    "- 0 = completely irrelevant\n"
+    "- Do not output any other text, just the number\n\n"
+    "Score:"
+)
+```
+
+### Task 2: Updated Package Exports
+
+Updated `/agent-brain-server/agent_brain_server/providers/reranker/__init__.py`:
+- Added export for `OllamaRerankerProvider`
+- Import triggers automatic registration with ProviderRegistry
+
+### Bonus Fix: SentenceTransformerRerankerProvider Type Error
+
+Fixed a mypy type error in `sentence_transformers.py` line 119:
+- Changed `r["corpus_id"]` to `int(r["corpus_id"])` for proper type inference
+
+## Files Modified
+
+1. **Created**: `agent-brain-server/agent_brain_server/providers/reranker/ollama.py`
+   - OllamaRerankerProvider implementation (210 lines)
+
+2. **Modified**: `agent-brain-server/agent_brain_server/providers/reranker/__init__.py`
+   - Added OllamaRerankerProvider export
+
+3. **Fixed**: `agent-brain-server/agent_brain_server/providers/reranker/sentence_transformers.py`
+   - Type cast fix for corpus_id (mypy error)
+
+## Verification Results
+
+### All Quality Checks Pass
+```
+task before-push
+- Format: OK
+- Lint: OK
+- Typecheck: OK
+- Server tests: 383 passed
+- CLI tests: 74 passed
+```
+
+### Registered Providers
+Both reranker providers are now registered:
+- `sentence-transformers` - CrossEncoder-based (fast, accurate)
+- `ollama` - Chat completion-based (local, any model)
+
+## Must-Haves Verification
+
+| Requirement | Status |
+|-------------|--------|
+| OllamaRerankerProvider uses chat completions for scoring | DONE |
+| Provider gracefully handles Ollama connection failures | DONE |
+| Provider is registered with ProviderRegistry on import | DONE |
+
+## Notes
+
+- The Ollama provider is slower than SentenceTransformers but offers fully local inference without HuggingFace model downloads
+- Recommended models: `llama3.2:1b`, `gemma2:2b`, or specialized reranker models if available
+- Concurrent scoring uses semaphore rate limiting to prevent overwhelming Ollama
+- Score parsing uses regex to handle various output formats (integer, decimal, with/without text)

--- a/.planning/phases/01-two-stage-reranking/01-05-PLAN.md
+++ b/.planning/phases/01-two-stage-reranking/01-05-PLAN.md
@@ -1,0 +1,312 @@
+---
+phase: 01-two-stage-reranking
+plan: 05
+type: execute
+wave: 3
+depends_on: ["01-03", "01-04"]
+files_modified:
+  - agent-brain-server/agent_brain_server/services/query_service.py
+  - agent-brain-server/agent_brain_server/models/query.py
+autonomous: true
+
+must_haves:
+  truths:
+    - "Reranking is applied after RRF fusion when ENABLE_RERANKING=true"
+    - "Stage 1 retrieves top_k * multiplier candidates (capped at 100)"
+    - "Reranking failures fall back to stage 1 results gracefully"
+    - "QueryResult includes rerank_score and original_rank fields"
+  artifacts:
+    - path: "agent-brain-server/agent_brain_server/services/query_service.py"
+      provides: "_rerank_results() method and integration"
+      contains: "_rerank_results"
+    - path: "agent-brain-server/agent_brain_server/models/query.py"
+      provides: "rerank_score and original_rank fields"
+      contains: "rerank_score"
+  key_links:
+    - from: "services/query_service.py"
+      to: "providers/factory.py"
+      via: "ProviderRegistry.get_reranker_provider"
+      pattern: "ProviderRegistry.get_reranker_provider"
+    - from: "services/query_service.py"
+      to: "config/settings.py"
+      via: "settings.ENABLE_RERANKING check"
+      pattern: "settings.ENABLE_RERANKING"
+---
+
+<objective>
+Integrate reranking into the query service as optional two-stage retrieval.
+
+Purpose: Enable users to get more accurate search results when reranking is enabled.
+Output: Working two-stage retrieval with graceful fallback on failure.
+</objective>
+
+<execution_context>
+@/Users/richardhightower/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/richardhightower/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/01-two-stage-reranking/01-RESEARCH.md
+@.planning/phases/01-two-stage-reranking/01-03-SUMMARY.md
+@.planning/phases/01-two-stage-reranking/01-04-SUMMARY.md
+@agent-brain-server/agent_brain_server/services/query_service.py
+@agent-brain-server/agent_brain_server/models/query.py
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add rerank_score and original_rank to QueryResult</name>
+  <files>agent-brain-server/agent_brain_server/models/query.py</files>
+  <action>
+Add new fields to the QueryResult model after the existing graph_score field:
+
+```python
+class QueryResult(BaseModel):
+    """Single query result with source and score."""
+
+    text: str = Field(..., description="The chunk text content")
+    source: str = Field(..., description="Source file path")
+    score: float = Field(..., description="Primary score (rank or similarity)")
+    vector_score: float | None = Field(
+        default=None, description="Score from vector search"
+    )
+    bm25_score: float | None = Field(default=None, description="Score from BM25 search")
+    chunk_id: str = Field(..., description="Unique chunk identifier")
+
+    # Content type information
+    source_type: str = Field(
+        default="doc", description="Type of content: 'doc', 'code', or 'test'"
+    )
+    language: str | None = Field(
+        default=None, description="Programming language for code files"
+    )
+
+    # GraphRAG fields (Feature 113)
+    graph_score: float | None = Field(
+        default=None, description="Score from graph-based retrieval"
+    )
+    related_entities: list[str] | None = Field(
+        default=None, description="Related entities from knowledge graph"
+    )
+    relationship_path: list[str] | None = Field(
+        default=None, description="Relationship paths in the graph"
+    )
+
+    # Reranking fields (Feature 123)
+    rerank_score: float | None = Field(
+        default=None, description="Score from reranking stage (if enabled)"
+    )
+    original_rank: int | None = Field(
+        default=None, description="Position before reranking (1-indexed)"
+    )
+
+    # Additional metadata
+    metadata: dict[str, Any] = Field(
+        default_factory=dict, description="Additional metadata"
+    )
+```
+
+Also update the JSON schema example to show the new fields (optional).
+  </action>
+  <verify>Run `cd agent-brain-server && poetry run python -c "from agent_brain_server.models.query import QueryResult; r = QueryResult(text='test', source='test.py', score=0.9, chunk_id='c1'); print(r.rerank_score, r.original_rank)"` to verify the new fields are accessible and default to None.</verify>
+  <done>QueryResult has rerank_score and original_rank fields with None defaults.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add _rerank_results method to QueryService</name>
+  <files>agent-brain-server/agent_brain_server/services/query_service.py</files>
+  <action>
+Add imports at the top of the file:
+
+```python
+from agent_brain_server.config.provider_config import load_provider_settings
+from agent_brain_server.providers.factory import ProviderRegistry
+# Note: reranker package import triggers provider registration
+import agent_brain_server.providers.reranker  # noqa: F401
+```
+
+Add the _rerank_results method to the QueryService class:
+
+```python
+async def _rerank_results(
+    self,
+    results: list[QueryResult],
+    query: str,
+    top_k: int,
+) -> list[QueryResult]:
+    """Apply two-stage reranking to search results.
+
+    Args:
+        results: Stage 1 results (more than needed).
+        query: Original search query.
+        top_k: Final number of results to return.
+
+    Returns:
+        Reranked results with rerank_score and original_rank populated.
+        Falls back to truncated stage 1 results on any failure.
+    """
+    if not results:
+        return results
+
+    try:
+        # Get reranker provider from config
+        provider_settings = load_provider_settings()
+        reranker = ProviderRegistry.get_reranker_provider(
+            provider_settings.reranker
+        )
+
+        # Check if reranker is available
+        if not reranker.is_available():
+            logger.warning(
+                f"Reranker {reranker.provider_name} not available, "
+                "using stage 1 results"
+            )
+            return results[:top_k]
+
+        # Extract document texts for reranking
+        documents = [r.text for r in results]
+
+        # Perform reranking
+        import time
+        start = time.time()
+        reranked = await reranker.rerank(query, documents, top_k=top_k)
+        rerank_time_ms = (time.time() - start) * 1000
+
+        logger.info(
+            f"Reranked {len(documents)} candidates to top {top_k} "
+            f"in {rerank_time_ms:.1f}ms using {reranker.provider_name}"
+        )
+
+        # Build reranked results with scores
+        reranked_results: list[QueryResult] = []
+        for new_rank, (original_idx, rerank_score) in enumerate(reranked):
+            result = results[original_idx]
+            # Update result with reranking info
+            result.rerank_score = rerank_score
+            result.original_rank = original_idx + 1  # 1-indexed
+            # Update primary score to rerank score
+            result.score = rerank_score
+            reranked_results.append(result)
+
+        return reranked_results
+
+    except Exception as e:
+        # Graceful fallback: return stage 1 results
+        logger.warning(
+            f"Reranking failed, using stage 1 results: {e}"
+        )
+        return results[:top_k]
+```
+  </action>
+  <verify>Run `cd agent-brain-server && poetry run python -c "from agent_brain_server.services.query_service import QueryService; qs = QueryService(); print(hasattr(qs, '_rerank_results'))"` to verify the method exists.</verify>
+  <done>_rerank_results method exists with graceful fallback on failure.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Integrate reranking into execute_query flow</name>
+  <files>agent-brain-server/agent_brain_server/services/query_service.py</files>
+  <action>
+Modify the execute_query method to apply reranking when enabled. Update the method to:
+
+1. Determine stage 1 top_k based on settings:
+```python
+async def execute_query(self, request: QueryRequest) -> QueryResponse:
+    """Execute a search query with optional reranking."""
+    if not self.is_ready():
+        raise RuntimeError(
+            "Query service not ready. Please wait for indexing to complete."
+        )
+
+    start_time = time.time()
+
+    # Calculate stage 1 top_k if reranking is enabled
+    stage1_top_k = request.top_k
+    if settings.ENABLE_RERANKING:
+        # Retrieve more candidates for reranking
+        stage1_top_k = min(
+            request.top_k * settings.RERANKER_TOP_K_MULTIPLIER,
+            settings.RERANKER_MAX_CANDIDATES,
+        )
+        logger.debug(
+            f"Reranking enabled: retrieving {stage1_top_k} candidates for stage 1"
+        )
+
+    # Create modified request for stage 1 retrieval
+    stage1_request = QueryRequest(
+        query=request.query,
+        top_k=stage1_top_k,
+        similarity_threshold=request.similarity_threshold,
+        mode=request.mode,
+        alpha=request.alpha,
+        source_types=request.source_types,
+        languages=request.languages,
+        file_paths=request.file_paths,
+    )
+
+    # Execute retrieval based on mode
+    if request.mode == QueryMode.BM25:
+        results = await self._execute_bm25_query(stage1_request)
+    elif request.mode == QueryMode.VECTOR:
+        results = await self._execute_vector_query(stage1_request)
+    elif request.mode == QueryMode.GRAPH:
+        results = await self._execute_graph_query(stage1_request)
+    elif request.mode == QueryMode.MULTI:
+        results = await self._execute_multi_query(stage1_request)
+    else:  # HYBRID
+        results = await self._execute_hybrid_query(stage1_request)
+
+    # Apply reranking if enabled
+    if settings.ENABLE_RERANKING and len(results) > request.top_k:
+        results = await self._rerank_results(results, request.query, request.top_k)
+    else:
+        # Truncate to requested top_k
+        results = results[:request.top_k]
+
+    # Apply content filters if specified
+    if any([request.source_types, request.languages, request.file_paths]):
+        results = self._filter_results(results, request)
+
+    query_time_ms = (time.time() - start_time) * 1000
+
+    logger.debug(
+        f"Query ({request.mode}) '{request.query[:50]}...' returned "
+        f"{len(results)} results in {query_time_ms:.2f}ms"
+        f"{' (reranked)' if settings.ENABLE_RERANKING else ''}"
+    )
+
+    return QueryResponse(
+        results=results,
+        query_time_ms=query_time_ms,
+        total_results=len(results),
+    )
+```
+  </action>
+  <verify>Run `cd agent-brain-server && poetry run python -c "from agent_brain_server.services.query_service import QueryService; from agent_brain_server.models import QueryRequest; import asyncio; qs = QueryService(); print('Query service loads with reranking integration')"` to verify the integration doesn't break existing functionality.</verify>
+  <done>execute_query integrates reranking when ENABLE_RERANKING=true with correct stage 1 retrieval multiplier.</done>
+</task>
+
+</tasks>
+
+<verification>
+1. QueryResult has rerank_score and original_rank fields
+2. _rerank_results method wraps reranker call with try/except
+3. execute_query retrieves extra candidates when reranking enabled
+4. Graceful fallback returns stage 1 results on any failure
+5. Reranking is skipped when results <= top_k
+</verification>
+
+<success_criteria>
+- With ENABLE_RERANKING=false: queries work exactly as before
+- With ENABLE_RERANKING=true: stage 1 retrieves 10x candidates, stage 2 reranks
+- Reranker failure logs warning and returns stage 1 results
+- Results include rerank_score when reranking was applied
+- Query time includes reranking latency
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/01-two-stage-reranking/01-05-SUMMARY.md`
+</output>

--- a/.planning/phases/01-two-stage-reranking/01-06-PLAN.md
+++ b/.planning/phases/01-two-stage-reranking/01-06-PLAN.md
@@ -1,0 +1,553 @@
+---
+phase: 01-two-stage-reranking
+plan: 06
+type: execute
+wave: 4
+depends_on: ["01-05"]
+files_modified:
+  - agent-brain-server/tests/unit/providers/test_reranker_providers.py
+  - agent-brain-server/tests/unit/services/test_query_service_reranking.py
+  - agent-brain-server/tests/contract/test_query_modes.py
+autonomous: true
+
+must_haves:
+  truths:
+    - "Unit tests cover both reranker providers"
+    - "Integration test validates two-stage retrieval flow"
+    - "Graceful degradation is tested"
+    - "All tests pass with pytest"
+  artifacts:
+    - path: "agent-brain-server/tests/unit/providers/test_reranker_providers.py"
+      provides: "Reranker provider unit tests"
+      contains: "test_sentence_transformer_reranker"
+    - path: "agent-brain-server/tests/unit/services/test_query_service_reranking.py"
+      provides: "Query service reranking integration tests"
+      contains: "test_reranking_enabled"
+  key_links:
+    - from: "tests/unit/providers/test_reranker_providers.py"
+      to: "providers/reranker/"
+      via: "import and test"
+      pattern: "from agent_brain_server.providers.reranker"
+---
+
+<objective>
+Add comprehensive tests for reranking functionality.
+
+Purpose: Ensure reranking works correctly and degrades gracefully on failure.
+Output: Unit tests for providers and integration tests for query service.
+</objective>
+
+<execution_context>
+@/Users/richardhightower/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/richardhightower/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/01-two-stage-reranking/01-RESEARCH.md
+@.planning/phases/01-two-stage-reranking/01-05-SUMMARY.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create reranker provider unit tests</name>
+  <files>agent-brain-server/tests/unit/providers/test_reranker_providers.py</files>
+  <action>
+Create the test file with tests for both providers:
+
+```python
+"""Unit tests for reranker providers."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from agent_brain_server.config.provider_config import RerankerConfig
+from agent_brain_server.providers.base import RerankerProviderType
+from agent_brain_server.providers.factory import ProviderRegistry
+from agent_brain_server.providers.reranker import (
+    RerankerProvider,
+    SentenceTransformerRerankerProvider,
+    OllamaRerankerProvider,
+)
+
+
+class TestRerankerProtocol:
+    """Test RerankerProvider protocol."""
+
+    def test_sentence_transformer_implements_protocol(self):
+        """SentenceTransformerRerankerProvider implements RerankerProvider."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.SENTENCE_TRANSFORMERS,
+            model="cross-encoder/ms-marco-MiniLM-L-6-v2",
+        )
+        provider = SentenceTransformerRerankerProvider(config)
+        assert isinstance(provider, RerankerProvider)
+
+    def test_ollama_implements_protocol(self):
+        """OllamaRerankerProvider implements RerankerProvider."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.OLLAMA,
+            model="llama3.2:1b",
+        )
+        provider = OllamaRerankerProvider(config)
+        assert isinstance(provider, RerankerProvider)
+
+
+class TestProviderRegistry:
+    """Test provider registration."""
+
+    def test_sentence_transformers_registered(self):
+        """SentenceTransformers provider is registered."""
+        available = ProviderRegistry.get_available_reranker_providers()
+        assert "sentence-transformers" in available
+
+    def test_ollama_registered(self):
+        """Ollama provider is registered."""
+        available = ProviderRegistry.get_available_reranker_providers()
+        assert "ollama" in available
+
+    def test_get_reranker_provider(self):
+        """Can get reranker provider from registry."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.SENTENCE_TRANSFORMERS,
+            model="cross-encoder/ms-marco-MiniLM-L-6-v2",
+        )
+        provider = ProviderRegistry.get_reranker_provider(config)
+        assert provider.provider_name == "SentenceTransformers"
+
+    def test_provider_caching(self):
+        """Provider instances are cached."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.SENTENCE_TRANSFORMERS,
+            model="cross-encoder/ms-marco-MiniLM-L-6-v2",
+        )
+        provider1 = ProviderRegistry.get_reranker_provider(config)
+        provider2 = ProviderRegistry.get_reranker_provider(config)
+        assert provider1 is provider2
+
+
+class TestSentenceTransformerReranker:
+    """Test SentenceTransformerRerankerProvider."""
+
+    @pytest.fixture
+    def provider(self):
+        """Create provider with mocked CrossEncoder."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.SENTENCE_TRANSFORMERS,
+            model="cross-encoder/ms-marco-MiniLM-L-6-v2",
+        )
+        return SentenceTransformerRerankerProvider(config)
+
+    def test_provider_name(self, provider):
+        """Provider returns correct name."""
+        assert provider.provider_name == "SentenceTransformers"
+
+    def test_model_name(self, provider):
+        """Provider returns correct model."""
+        assert provider.model_name == "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+    @pytest.mark.asyncio
+    async def test_rerank_empty_documents(self, provider):
+        """Reranking empty list returns empty list."""
+        result = await provider.rerank("query", [], top_k=5)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_rerank_returns_tuples(self, provider):
+        """Rerank returns list of (index, score) tuples."""
+        # Mock the CrossEncoder
+        with patch.object(provider, "_ensure_model_loaded") as mock_load:
+            mock_encoder = MagicMock()
+            mock_encoder.rank.return_value = [
+                {"corpus_id": 1, "score": 0.9},
+                {"corpus_id": 0, "score": 0.7},
+            ]
+            mock_load.return_value = mock_encoder
+
+            result = await provider.rerank(
+                "test query",
+                ["doc1", "doc2"],
+                top_k=2,
+            )
+
+            assert len(result) == 2
+            assert result[0] == (1, 0.9)
+            assert result[1] == (0, 0.7)
+
+
+class TestOllamaReranker:
+    """Test OllamaRerankerProvider."""
+
+    @pytest.fixture
+    def provider(self):
+        """Create provider."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.OLLAMA,
+            model="llama3.2:1b",
+        )
+        return OllamaRerankerProvider(config)
+
+    def test_provider_name(self, provider):
+        """Provider returns correct name."""
+        assert provider.provider_name == "Ollama"
+
+    def test_model_name(self, provider):
+        """Provider returns correct model."""
+        assert provider.model_name == "llama3.2:1b"
+
+    def test_parse_score_valid_integer(self, provider):
+        """Parse score handles integer."""
+        assert provider._parse_score("8") == 8.0
+
+    def test_parse_score_valid_float(self, provider):
+        """Parse score handles float."""
+        assert provider._parse_score("7.5") == 7.5
+
+    def test_parse_score_with_text(self, provider):
+        """Parse score extracts number from text."""
+        assert provider._parse_score("The score is 9") == 9.0
+
+    def test_parse_score_invalid(self, provider):
+        """Parse score returns 0 for invalid input."""
+        assert provider._parse_score("no number here") == 0.0
+
+    def test_parse_score_clamps_high(self, provider):
+        """Parse score clamps to max 10."""
+        assert provider._parse_score("15") == 10.0
+
+    @pytest.mark.asyncio
+    async def test_rerank_empty_documents(self, provider):
+        """Reranking empty list returns empty list."""
+        result = await provider.rerank("query", [], top_k=5)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_rerank_with_mock_response(self, provider):
+        """Rerank works with mocked HTTP response."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "message": {"content": "8"}
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(provider, "_get_client") as mock_client:
+            mock_http = AsyncMock()
+            mock_http.post = AsyncMock(return_value=mock_response)
+            mock_client.return_value = mock_http
+
+            result = await provider.rerank(
+                "test query",
+                ["doc1", "doc2"],
+                top_k=2,
+            )
+
+            # Both docs should have scores
+            assert len(result) == 2
+            # Scores should be parsed correctly
+            scores = [r[1] for r in result]
+            assert all(s == 8.0 for s in scores)
+
+
+class TestGracefulDegradation:
+    """Test graceful degradation scenarios."""
+
+    @pytest.mark.asyncio
+    async def test_ollama_handles_connection_error(self):
+        """Ollama provider handles connection errors gracefully."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.OLLAMA,
+            model="llama3.2:1b",
+        )
+        provider = OllamaRerankerProvider(config)
+
+        # Mock connection failure
+        with patch.object(provider, "_get_client") as mock_client:
+            mock_http = AsyncMock()
+            mock_http.post = AsyncMock(
+                side_effect=Exception("Connection refused")
+            )
+            mock_client.return_value = mock_http
+
+            result = await provider.rerank(
+                "test query",
+                ["doc1", "doc2"],
+                top_k=2,
+            )
+
+            # Should return results with 0.0 scores (fallback)
+            assert len(result) == 2
+            assert all(r[1] == 0.0 for r in result)
+```
+
+Create the directory if needed:
+```bash
+mkdir -p agent-brain-server/tests/unit/providers
+touch agent-brain-server/tests/unit/providers/__init__.py
+```
+  </action>
+  <verify>Run `cd agent-brain-server && poetry run pytest tests/unit/providers/test_reranker_providers.py -v` to verify all tests pass.</verify>
+  <done>Reranker provider unit tests exist and pass.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Create query service reranking tests</name>
+  <files>agent-brain-server/tests/unit/services/test_query_service_reranking.py</files>
+  <action>
+Create integration tests for reranking in query service:
+
+```python
+"""Tests for query service reranking integration."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from agent_brain_server.models import QueryRequest, QueryResult, QueryMode
+from agent_brain_server.services.query_service import QueryService
+
+
+class TestQueryServiceReranking:
+    """Test query service reranking integration."""
+
+    @pytest.fixture
+    def mock_query_service(self):
+        """Create query service with mocked dependencies."""
+        with patch(
+            "agent_brain_server.services.query_service.get_vector_store"
+        ) as mock_vs, patch(
+            "agent_brain_server.services.query_service.get_embedding_generator"
+        ) as mock_eg, patch(
+            "agent_brain_server.services.query_service.get_bm25_manager"
+        ) as mock_bm25, patch(
+            "agent_brain_server.services.query_service.get_graph_index_manager"
+        ) as mock_graph:
+            mock_vs.return_value.is_initialized = True
+            mock_vs.return_value.get_count = AsyncMock(return_value=100)
+            mock_vs.return_value.similarity_search = AsyncMock(return_value=[])
+            mock_eg.return_value.embed_query = AsyncMock(return_value=[0.1] * 768)
+            mock_bm25.return_value.is_initialized = True
+            mock_bm25.return_value.search_with_filters = AsyncMock(return_value=[])
+            mock_graph.return_value = MagicMock()
+
+            yield QueryService()
+
+    @pytest.fixture
+    def sample_results(self):
+        """Create sample query results."""
+        return [
+            QueryResult(
+                text=f"Document {i}",
+                source=f"doc{i}.txt",
+                score=1.0 - (i * 0.1),
+                chunk_id=f"chunk_{i}",
+            )
+            for i in range(10)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_rerank_results_success(self, mock_query_service, sample_results):
+        """_rerank_results applies reranking correctly."""
+        # Mock the reranker
+        mock_reranker = MagicMock()
+        mock_reranker.is_available.return_value = True
+        mock_reranker.provider_name = "Mock"
+        mock_reranker.rerank = AsyncMock(
+            return_value=[(5, 0.95), (2, 0.85), (0, 0.75)]
+        )
+
+        with patch(
+            "agent_brain_server.services.query_service.load_provider_settings"
+        ) as mock_settings, patch(
+            "agent_brain_server.services.query_service.ProviderRegistry"
+        ) as mock_registry:
+            mock_registry.get_reranker_provider.return_value = mock_reranker
+
+            result = await mock_query_service._rerank_results(
+                sample_results, "test query", top_k=3
+            )
+
+            assert len(result) == 3
+            # Check documents are reordered
+            assert result[0].text == "Document 5"
+            assert result[1].text == "Document 2"
+            assert result[2].text == "Document 0"
+            # Check rerank scores are set
+            assert result[0].rerank_score == 0.95
+            # Check original ranks are set
+            assert result[0].original_rank == 6  # 1-indexed
+
+    @pytest.mark.asyncio
+    async def test_rerank_results_fallback_on_error(
+        self, mock_query_service, sample_results
+    ):
+        """_rerank_results falls back to stage 1 on error."""
+        with patch(
+            "agent_brain_server.services.query_service.load_provider_settings"
+        ) as mock_settings, patch(
+            "agent_brain_server.services.query_service.ProviderRegistry"
+        ) as mock_registry:
+            mock_registry.get_reranker_provider.side_effect = Exception(
+                "Provider not found"
+            )
+
+            result = await mock_query_service._rerank_results(
+                sample_results, "test query", top_k=3
+            )
+
+            # Should return first 3 results unchanged
+            assert len(result) == 3
+            assert result[0].text == "Document 0"
+
+    @pytest.mark.asyncio
+    async def test_rerank_results_provider_unavailable(
+        self, mock_query_service, sample_results
+    ):
+        """_rerank_results falls back when provider unavailable."""
+        mock_reranker = MagicMock()
+        mock_reranker.is_available.return_value = False
+        mock_reranker.provider_name = "Mock"
+
+        with patch(
+            "agent_brain_server.services.query_service.load_provider_settings"
+        ) as mock_settings, patch(
+            "agent_brain_server.services.query_service.ProviderRegistry"
+        ) as mock_registry:
+            mock_registry.get_reranker_provider.return_value = mock_reranker
+
+            result = await mock_query_service._rerank_results(
+                sample_results, "test query", top_k=3
+            )
+
+            # Should return first 3 results unchanged
+            assert len(result) == 3
+            assert result[0].text == "Document 0"
+
+    @pytest.mark.asyncio
+    async def test_rerank_results_empty_input(self, mock_query_service):
+        """_rerank_results handles empty input."""
+        result = await mock_query_service._rerank_results([], "test query", top_k=5)
+        assert result == []
+
+
+class TestExecuteQueryWithReranking:
+    """Test execute_query with reranking enabled."""
+
+    @pytest.mark.asyncio
+    async def test_reranking_disabled_by_default(self):
+        """Reranking is disabled by default."""
+        from agent_brain_server.config.settings import settings
+
+        assert settings.ENABLE_RERANKING is False
+
+    @pytest.mark.asyncio
+    async def test_stage1_topk_calculation(self):
+        """Stage 1 top_k is multiplied when reranking enabled."""
+        from agent_brain_server.config.settings import Settings
+
+        # Create settings with reranking enabled
+        with patch(
+            "agent_brain_server.services.query_service.settings",
+            Settings(
+                ENABLE_RERANKING=True,
+                RERANKER_TOP_K_MULTIPLIER=10,
+                RERANKER_MAX_CANDIDATES=100,
+            ),
+        ):
+            # With top_k=5, stage1 should be 50
+            request = QueryRequest(query="test", top_k=5)
+            expected_stage1 = min(5 * 10, 100)
+            assert expected_stage1 == 50
+
+            # With top_k=15, stage1 should be capped at 100
+            request = QueryRequest(query="test", top_k=15)
+            expected_stage1 = min(15 * 10, 100)
+            assert expected_stage1 == 100
+```
+
+Create the directory if needed:
+```bash
+mkdir -p agent-brain-server/tests/unit/services
+touch agent-brain-server/tests/unit/services/__init__.py
+```
+  </action>
+  <verify>Run `cd agent-brain-server && poetry run pytest tests/unit/services/test_query_service_reranking.py -v` to verify all tests pass.</verify>
+  <done>Query service reranking integration tests exist and pass.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Add reranking mode to contract tests</name>
+  <files>agent-brain-server/tests/contract/test_query_modes.py</files>
+  <action>
+Add a test case for reranking in the existing contract tests. Find the test file and add:
+
+```python
+class TestRerankingMode:
+    """Test two-stage retrieval with reranking."""
+
+    @pytest.mark.asyncio
+    async def test_reranking_disabled_returns_normal_results(self):
+        """With ENABLE_RERANKING=false, results have no rerank_score."""
+        # This tests the default behavior
+        from agent_brain_server.config.settings import settings
+        assert settings.ENABLE_RERANKING is False
+
+    @pytest.mark.asyncio
+    async def test_query_result_has_rerank_fields(self):
+        """QueryResult model includes reranking fields."""
+        from agent_brain_server.models import QueryResult
+
+        result = QueryResult(
+            text="test",
+            source="test.py",
+            score=0.9,
+            chunk_id="c1",
+            rerank_score=0.85,
+            original_rank=3,
+        )
+        assert result.rerank_score == 0.85
+        assert result.original_rank == 3
+
+    @pytest.mark.asyncio
+    async def test_rerank_fields_optional(self):
+        """Reranking fields are optional (None by default)."""
+        from agent_brain_server.models import QueryResult
+
+        result = QueryResult(
+            text="test",
+            source="test.py",
+            score=0.9,
+            chunk_id="c1",
+        )
+        assert result.rerank_score is None
+        assert result.original_rank is None
+```
+
+If the file doesn't have a good place to add this, append it at the end.
+  </action>
+  <verify>Run `cd agent-brain-server && poetry run pytest tests/contract/test_query_modes.py -v -k rerank` to verify the new reranking tests pass.</verify>
+  <done>Contract tests include reranking mode validation.</done>
+</task>
+
+</tasks>
+
+<verification>
+1. All unit tests for providers pass
+2. All integration tests for query service pass
+3. Contract tests validate reranking fields
+4. Tests cover graceful degradation scenarios
+5. Run full test suite: `cd agent-brain-server && poetry run pytest`
+</verification>
+
+<success_criteria>
+- pytest runs without failures
+- Test coverage for reranker providers > 80%
+- Graceful fallback is explicitly tested
+- Empty input edge cases handled
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/01-two-stage-reranking/01-06-SUMMARY.md`
+</output>

--- a/.planning/phases/01-two-stage-reranking/01-06-SUMMARY.md
+++ b/.planning/phases/01-two-stage-reranking/01-06-SUMMARY.md
@@ -1,0 +1,168 @@
+---
+phase: 01-two-stage-reranking
+plan: 06
+type: summary
+wave: 4
+completed: 2025-02-07
+status: done
+tests_passed: true
+---
+
+# Wave 4 Summary: Reranking Tests
+
+## Objective
+Add comprehensive unit and integration tests for the two-stage reranking feature implemented in Waves 1-3.
+
+## What Was Done
+
+### 1. Created Reranker Provider Unit Tests
+**File:** `agent-brain-server/tests/unit/providers/test_reranker_providers.py`
+
+Tests created (39 tests):
+- **TestRerankerProtocol** (3 tests)
+  - Protocol implementation verification for SentenceTransformer and Ollama providers
+  - Abstract base class instantiation prevention
+
+- **TestProviderRegistry** (6 tests)
+  - Provider registration verification
+  - Provider caching behavior
+  - Different models create different instances
+  - Unregistered provider error handling
+
+- **TestSentenceTransformerReranker** (7 tests)
+  - Provider name and model name
+  - Empty document handling
+  - Rerank returns correctly ordered tuples
+  - top_k parameter handling
+  - Document count vs top_k edge cases
+
+- **TestOllamaReranker** (12 tests)
+  - Provider name and model name
+  - Base URL configuration (default and custom)
+  - Score parsing (integers, floats, text extraction, clamping)
+  - HTTP response mocking
+  - Score-based sorting verification
+  - top_k limiting
+
+- **TestGracefulDegradation** (4 tests)
+  - Connection error handling
+  - HTTP error handling
+  - Malformed response handling
+  - is_available() returns False on connection errors
+
+- **TestRerankerConfigParams** (4 tests)
+  - Batch size from params
+  - Default batch size
+  - Ollama timeout from params
+  - Ollama max_concurrent from params
+
+### 2. Created Query Service Reranking Tests
+**File:** `agent-brain-server/tests/unit/services/test_query_service_reranking.py`
+
+Tests created (16 tests):
+- **TestRerankerResultsMethod** (6 tests)
+  - Empty input handling
+  - Successful reranking with correct reordering
+  - Original score preservation
+  - Fallback on provider error
+  - Fallback on rerank failure
+  - Fallback when provider unavailable
+
+- **TestExecuteQueryWithReranking** (6 tests)
+  - ENABLE_RERANKING defaults to False
+  - Default reranker settings verification
+  - Stage 1 top_k calculation (basic and capped)
+  - execute_query calls _rerank_results when enabled
+  - execute_query skips reranking when disabled
+
+- **TestQueryResultRerankingFields** (4 tests)
+  - rerank_score field exists and works
+  - original_rank field exists and works
+  - Both fields are optional (None by default)
+  - All fields can be set together
+
+### 3. Added Contract Tests for Reranking
+**File:** `agent-brain-server/tests/contract/test_query_modes.py`
+
+Added two new test classes (15 new tests):
+- **TestRerankingContract** (9 tests)
+  - ENABLE_RERANKING disabled by default
+  - All reranker settings exist
+  - QueryResult has rerank fields
+  - Fields are optional
+  - Field types are correct
+  - Serialization includes rerank fields
+
+- **TestRerankerProviderContract** (6 tests)
+  - RerankerProviderType enum exists with correct values
+  - RerankerConfig exists with sensible defaults
+  - ProviderRegistry has reranker methods
+  - Both providers are registered
+
+## Test Coverage
+
+| Test File | Tests | Status |
+|-----------|-------|--------|
+| test_reranker_providers.py | 39 | All Pass |
+| test_query_service_reranking.py | 16 | All Pass |
+| test_query_modes.py (reranking) | 15 | All Pass |
+| **Total New Tests** | **70** | **All Pass** |
+
+## Verification
+
+All tests pass:
+```bash
+cd agent-brain-server && .venv/bin/python -m pytest tests/unit/providers/test_reranker_providers.py -v
+# 39 passed
+
+cd agent-brain-server && .venv/bin/python -m pytest tests/unit/services/test_query_service_reranking.py -v
+# 16 passed
+
+cd agent-brain-server && .venv/bin/python -m pytest tests/contract/test_query_modes.py -v -k rerank
+# 15 passed
+
+cd agent-brain-server && .venv/bin/python -m pytest tests/ -v
+# 453 passed (full suite)
+```
+
+## Key Testing Patterns Used
+
+1. **Mocking External Services**
+   - CrossEncoder mocked to avoid loading real ML models
+   - HTTP client mocked for Ollama provider tests
+   - Provider registry and settings mocked for query service tests
+
+2. **Graceful Degradation Testing**
+   - Connection errors return fallback scores (0.0)
+   - Provider unavailable returns stage 1 results
+   - Rerank failures fall back gracefully
+
+3. **Fixture-Based Setup**
+   - Shared fixtures for mock dependencies
+   - Sample results fixtures for consistent test data
+   - Provider fixtures for isolated testing
+
+4. **Contract Tests for API Stability**
+   - Settings defaults verification
+   - Model field existence and types
+   - Serialization behavior
+
+## Files Created/Modified
+
+### Created
+- `tests/unit/providers/test_reranker_providers.py` - 39 tests
+- `tests/unit/services/__init__.py` - Package init
+- `tests/unit/services/test_query_service_reranking.py` - 16 tests
+
+### Modified
+- `tests/contract/test_query_modes.py` - Added 15 reranking contract tests
+
+## Next Steps
+
+Phase 1 (Two-Stage Reranking) is now complete with all 4 waves:
+1. Wave 1: Core infrastructure (RerankerProvider, RerankerConfig, settings)
+2. Wave 2: Provider implementations (SentenceTransformer, Ollama)
+3. Wave 3: Query service integration (_rerank_results, execute_query)
+4. Wave 4: Comprehensive tests (unit, integration, contract)
+
+The feature is ready for integration testing and deployment.

--- a/.planning/phases/01-two-stage-reranking/01-07-PLAN.md
+++ b/.planning/phases/01-two-stage-reranking/01-07-PLAN.md
@@ -1,0 +1,235 @@
+---
+phase: 01-two-stage-reranking
+plan: 07
+type: execute
+wave: 4
+depends_on: ["01-05"]
+files_modified:
+  - agent-brain-server/README.md
+  - docs/USER_GUIDE.md
+autonomous: true
+
+must_haves:
+  truths:
+    - "README documents how to enable reranking"
+    - "USER_GUIDE explains two-stage retrieval concept"
+    - "Environment variables are documented"
+  artifacts:
+    - path: "agent-brain-server/README.md"
+      provides: "Reranking configuration section"
+      contains: "ENABLE_RERANKING"
+    - path: "docs/USER_GUIDE.md"
+      provides: "Two-stage retrieval explanation"
+      contains: "reranking"
+  key_links: []
+---
+
+<objective>
+Update documentation to cover reranking configuration and usage.
+
+Purpose: Enable users to understand and configure two-stage reranking.
+Output: Updated README and USER_GUIDE with reranking documentation.
+</objective>
+
+<execution_context>
+@/Users/richardhightower/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/richardhightower/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/01-two-stage-reranking/01-RESEARCH.md
+@.planning/phases/01-two-stage-reranking/01-05-SUMMARY.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Update server README with reranking section</name>
+  <files>agent-brain-server/README.md</files>
+  <action>
+Read the current README and add a new section for reranking configuration. Add this section after the existing configuration/environment variables section:
+
+```markdown
+## Two-Stage Reranking (Feature 123)
+
+Agent Brain supports optional two-stage retrieval with reranking for improved search precision. When enabled, the system:
+
+1. **Stage 1**: Retrieves more candidates than requested (e.g., 50 candidates for top_k=5)
+2. **Stage 2**: Reranks candidates using a cross-encoder model for more accurate relevance scoring
+
+### Enabling Reranking
+
+Set the following environment variables:
+
+```bash
+# Enable two-stage reranking (default: false)
+ENABLE_RERANKING=true
+
+# Choose provider (default: sentence-transformers)
+RERANKER_PROVIDER=sentence-transformers  # or "ollama"
+
+# Choose model (default: cross-encoder/ms-marco-MiniLM-L-6-v2)
+RERANKER_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
+
+# Stage 1 retrieval multiplier (default: 10)
+RERANKER_TOP_K_MULTIPLIER=10
+
+# Maximum candidates for Stage 1 (default: 100)
+RERANKER_MAX_CANDIDATES=100
+```
+
+### Provider Options
+
+| Provider | Model | Latency | Description |
+|----------|-------|---------|-------------|
+| sentence-transformers | cross-encoder/ms-marco-MiniLM-L-6-v2 | ~50ms | Recommended. Fast, accurate cross-encoder. |
+| sentence-transformers | cross-encoder/ms-marco-MiniLM-L-12-v2 | ~100ms | Slower but more accurate. |
+| ollama | llama3.2:1b | ~500ms | Fully local, no HuggingFace download. |
+
+### YAML Configuration
+
+You can also configure reranking in `config.yaml`:
+
+```yaml
+reranker:
+  provider: sentence-transformers
+  model: cross-encoder/ms-marco-MiniLM-L-6-v2
+  params:
+    batch_size: 32
+```
+
+### Graceful Degradation
+
+If the reranker fails (model unavailable, timeout, etc.), the system automatically falls back to Stage 1 results. This ensures queries never fail due to reranking issues.
+
+### Response Fields
+
+When reranking is enabled, query results include additional fields:
+
+- `rerank_score`: The cross-encoder relevance score
+- `original_rank`: The position before reranking (1-indexed)
+
+Example response:
+```json
+{
+  "results": [
+    {
+      "text": "Document content...",
+      "source": "docs/guide.md",
+      "score": 0.95,
+      "rerank_score": 0.95,
+      "original_rank": 5,
+      "chunk_id": "chunk_abc123"
+    }
+  ]
+}
+```
+```
+
+Place this section after the main configuration section but before advanced topics.
+  </action>
+  <verify>Read the updated README and confirm the reranking section is present with all environment variables documented.</verify>
+  <done>README includes comprehensive reranking documentation.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Update USER_GUIDE with reranking explanation</name>
+  <files>docs/USER_GUIDE.md</files>
+  <action>
+Read the current USER_GUIDE and add a section explaining two-stage reranking. Add this to the query configuration or advanced features section:
+
+```markdown
+## Two-Stage Retrieval with Reranking
+
+Agent Brain can optionally use two-stage retrieval to improve search precision by 15-20%.
+
+### How It Works
+
+**Without Reranking (Default)**:
+1. Query is embedded using the embedding model
+2. Vector similarity search finds top_k most similar documents
+3. Results are returned
+
+**With Reranking Enabled**:
+1. Query is embedded using the embedding model
+2. Vector + BM25 hybrid search retrieves 10x more candidates
+3. Cross-encoder model scores each candidate for relevance to the query
+4. Results are reordered by cross-encoder score
+5. Top_k results are returned
+
+### Why Reranking Helps
+
+Embedding models (bi-encoders) are fast but approximate. They encode the query and documents separately, then compare vectors. This can miss nuanced relevance.
+
+Cross-encoders process the query AND document together, allowing the model to attend across both texts. This is slower but more accurate.
+
+### When to Enable Reranking
+
+Enable reranking when:
+- Precision matters more than latency
+- Queries are complex or nuanced
+- Initial results seem "close but not quite right"
+
+Keep reranking disabled when:
+- Latency is critical (real-time search)
+- Running on resource-constrained hardware
+- Search quality is already acceptable
+
+### Configuration
+
+Enable with environment variable:
+```bash
+export ENABLE_RERANKING=true
+```
+
+Or in config.yaml:
+```yaml
+reranker:
+  provider: sentence-transformers
+  model: cross-encoder/ms-marco-MiniLM-L-6-v2
+```
+
+### Provider Choices
+
+**sentence-transformers (Recommended)**:
+- Uses HuggingFace CrossEncoder models
+- Downloads model on first use (~50MB)
+- Fast inference (~50ms for 100 candidates)
+
+**ollama (Fully Local)**:
+- Uses Ollama chat completions for scoring
+- No external downloads
+- Slower (~500ms for 100 candidates)
+- Requires Ollama running locally
+```
+
+Place this section in an appropriate location (after basic query usage, before API reference).
+  </action>
+  <verify>Read the updated USER_GUIDE and confirm the reranking explanation is present and clear.</verify>
+  <done>USER_GUIDE explains two-stage retrieval concept for users.</done>
+</task>
+
+</tasks>
+
+<verification>
+1. README has complete environment variable documentation
+2. README shows YAML config example
+3. USER_GUIDE explains the concept in user-friendly terms
+4. Both docs mention graceful degradation
+5. Provider options are documented with trade-offs
+</verification>
+
+<success_criteria>
+- Environment variables for reranking are documented
+- YAML configuration example is provided
+- Concept is explained clearly for non-technical users
+- Trade-offs between providers are documented
+- Graceful fallback behavior is mentioned
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/01-two-stage-reranking/01-07-SUMMARY.md`
+</output>

--- a/.planning/phases/01-two-stage-reranking/01-07-SUMMARY.md
+++ b/.planning/phases/01-two-stage-reranking/01-07-SUMMARY.md
@@ -1,0 +1,133 @@
+---
+phase: 01-two-stage-reranking
+plan: 07
+subsystem: documentation
+tags: [docs, readme, user-guide, reranking]
+
+# Dependency graph
+requires:
+  - phase: 01-05
+    provides: QueryService integration with reranking
+provides:
+  - README documentation for reranking configuration
+  - USER_GUIDE explanation of two-stage retrieval
+affects: []
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Documentation follows existing feature sections (GraphRAG pattern)"
+
+key-files:
+  modified:
+    - agent-brain-server/README.md
+    - docs/USER_GUIDE.md
+
+key-decisions:
+  - "README section placed after GraphRAG section, before Development Installation"
+  - "USER_GUIDE section placed after Search Modes, before Indexing"
+  - "Table of Contents updated to include new section"
+
+# Metrics
+duration: 5min
+completed: 2026-02-07
+---
+
+# Phase 01 Plan 07: Documentation Updates Summary
+
+**Updated README and USER_GUIDE with comprehensive two-stage reranking documentation**
+
+## Performance
+
+- **Duration:** 5 min
+- **Started:** 2026-02-07
+- **Completed:** 2026-02-07
+- **Tasks:** 2
+- **Files modified:** 2
+
+## Accomplishments
+
+### Task 1: Updated Server README
+
+Added new section "Two-Stage Reranking (Feature 123)" to `/agent-brain-server/README.md` with:
+
+- Feature overview explaining Stage 1 and Stage 2 retrieval
+- Complete environment variable documentation:
+  - `ENABLE_RERANKING` - Master switch (default: false)
+  - `RERANKER_PROVIDER` - Provider selection (sentence-transformers or ollama)
+  - `RERANKER_MODEL` - Model name for the provider
+  - `RERANKER_TOP_K_MULTIPLIER` - Stage 1 retrieval multiplier (default: 10)
+  - `RERANKER_MAX_CANDIDATES` - Cap on Stage 1 candidates (default: 100)
+  - `RERANKER_BATCH_SIZE` - Batch size for inference (default: 32)
+- Provider options table with latency estimates
+- YAML configuration example
+- Graceful degradation behavior explanation
+- Response fields documentation (`rerank_score`, `original_rank`)
+- Example JSON response
+
+Section placed after GraphRAG Configuration, before Development Installation.
+
+### Task 2: Updated USER_GUIDE
+
+Added new section "Two-Stage Retrieval with Reranking" to `/docs/USER_GUIDE.md` with:
+
+- Table of Contents entry for the new section
+- How it works explanation:
+  - Without reranking (default behavior)
+  - With reranking enabled (two-stage process)
+- Why reranking helps (bi-encoder vs cross-encoder)
+- When to enable/disable reranking guidelines
+- Configuration via environment variable and YAML
+- Provider choices comparison:
+  - sentence-transformers: Recommended, HuggingFace CrossEncoder, ~50ms
+  - ollama: Fully local, chat completions, ~500ms
+- Response fields documentation
+
+Section placed after Search Modes, before Indexing.
+
+## Files Modified
+
+1. **agent-brain-server/README.md**
+   - Added ~75 lines documenting reranking configuration
+   - Includes code examples, tables, and JSON samples
+
+2. **docs/USER_GUIDE.md**
+   - Updated Table of Contents with new section link
+   - Added ~65 lines explaining two-stage retrieval for users
+
+## Verification
+
+Both files contain:
+- [x] `ENABLE_RERANKING` environment variable documentation
+- [x] YAML configuration example
+- [x] Provider options with trade-offs
+- [x] Graceful degradation mention
+- [x] Response fields (`rerank_score`, `original_rank`)
+
+## Must-Haves Verification
+
+| Requirement | Status |
+|-------------|--------|
+| README documents how to enable reranking | DONE |
+| USER_GUIDE explains two-stage retrieval concept | DONE |
+| Environment variables are documented | DONE |
+| YAML config example is provided | DONE |
+| Provider options documented with latency | DONE |
+| Graceful degradation is explained | DONE |
+
+## Deviations from Plan
+
+- Added `RERANKER_BATCH_SIZE` to README (was defined in settings.py but not in original plan)
+- Added response fields section to USER_GUIDE (brief mention for user awareness)
+
+## Next Steps
+
+Phase 01 documentation is complete. Remaining work:
+- Plan 01-06: Unit tests for reranking functionality
+- Consider integration tests with reranking enabled
+
+---
+*Phase: 01-two-stage-reranking*
+*Wave: 4 (Documentation)*
+*Completed: 2026-02-07*

--- a/.planning/phases/01-two-stage-reranking/01-RESEARCH.md
+++ b/.planning/phases/01-two-stage-reranking/01-RESEARCH.md
@@ -1,0 +1,408 @@
+# Phase 1: Two-Stage Reranking - Research
+
+**Researched:** 2026-02-07
+**Domain:** RAG Retrieval Enhancement / Cross-Encoder Reranking
+**Confidence:** HIGH
+
+## Summary
+
+Two-stage retrieval with reranking is a well-established pattern in production RAG systems that improves precision by 15-20% (per industry benchmarks). The architecture uses a fast bi-encoder retriever (Stage 1) to fetch 50-100 candidates, followed by a slower but more accurate cross-encoder reranker (Stage 2) to score and reorder the top results.
+
+For Agent Brain's local-first philosophy, **Ollama does NOT have a native reranking API endpoint** as of 2026. However, there are two viable approaches: (1) Use `sentence-transformers` CrossEncoder directly (Python-native, well-integrated with LlamaIndex), or (2) Use Ollama's chat completions API with Qwen3 Reranker models via prompt-based scoring.
+
+**Primary recommendation:** Use `sentence-transformers` CrossEncoder with `cross-encoder/ms-marco-MiniLM-L-6-v2` as the default model, with optional Ollama support via Qwen3 Reranker for users who prefer fully local inference.
+
+<user_constraints>
+## User Constraints (from Phase Context)
+
+### Locked Decisions
+1. **Start with Ollama** (local-first philosophy, no API keys required)
+2. **Reranking is OPTIONAL** - off by default
+3. **Graceful fallback** to stage 1 results on any failure
+4. **Expected +3-4% precision improvement** (conservative target)
+
+### Claude's Discretion
+- Implementation details of reranker provider abstraction
+- Exact Ollama model to recommend (bge-reranker-v2-m3 suggested)
+- How to score/rank using Ollama (cross-encoder style via chat completions, or embedding similarity)
+- Integration point in query_service.py
+
+### Deferred Ideas (OUT OF SCOPE)
+- None specified
+</user_constraints>
+
+## Standard Stack
+
+The established libraries/tools for cross-encoder reranking:
+
+### Core
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| `sentence-transformers` | ^3.4.0 | CrossEncoder models for reranking | Industry standard, 913+ code snippets in docs, HIGH reputation |
+| `llama-index-postprocessor-sentencetransformer-rerank` | ^0.4.0 | LlamaIndex integration | Native NodePostprocessor for LlamaIndex pipelines |
+
+### Supporting (Ollama Option)
+| Library | Version | Purpose | When to Use |
+|---------|---------|---------|-------------|
+| `ollama` (Python) | ^0.4.0 | Local LLM inference | When user wants fully local reranking without downloading HuggingFace models |
+| Qwen3-Reranker-0.6B | latest | Lightweight local reranker | Balance of speed and local-first philosophy |
+
+### Alternatives Considered
+| Instead of | Could Use | Tradeoff |
+|------------|-----------|----------|
+| sentence-transformers CrossEncoder | Ollama Qwen3 Reranker | Ollama requires prompt-based scoring (slower), but fully local |
+| cross-encoder/ms-marco-MiniLM-L-6-v2 | bge-reranker-v2-m3 via Ollama embed API | BGE models on Ollama use embedding similarity, not true cross-encoder |
+| Local models | Cohere Rerank API | Cohere is more accurate but requires API key (violates local-first) |
+
+**Installation:**
+```bash
+# Core (sentence-transformers approach)
+poetry add sentence-transformers
+poetry add llama-index-postprocessor-sentencetransformer-rerank
+
+# Optional (Ollama approach)
+poetry add ollama
+```
+
+## Architecture Patterns
+
+### Recommended Integration Point
+
+```
+query_service.py
+├── _execute_hybrid_query()          # Existing - Stage 1 retrieval
+├── _execute_multi_query()           # Existing - Stage 1 retrieval
+└── _rerank_results()                # NEW - Stage 2 reranking (optional)
+    ├── Check ENABLE_RERANKING setting
+    ├── Get reranker provider (factory pattern)
+    └── Score and reorder results
+```
+
+### Pattern 1: Provider Abstraction (Matches Existing Codebase)
+
+The codebase already has `EmbeddingProvider` and `SummarizationProvider` protocols with a `ProviderRegistry` factory. Add a new `RerankerProvider` following the same pattern.
+
+**What:** Abstract reranker interface with factory pattern
+**When to use:** Always - maintains consistency with existing provider architecture
+**Example:**
+```python
+# Source: Based on existing agent_brain_server/providers/base.py pattern
+
+@runtime_checkable
+class RerankerProvider(Protocol):
+    """Protocol for reranking providers."""
+
+    async def rerank(
+        self,
+        query: str,
+        documents: list[str],
+        top_k: int = 10,
+    ) -> list[tuple[int, float]]:
+        """Rerank documents for a query.
+
+        Args:
+            query: The search query
+            documents: List of document texts to rerank
+            top_k: Number of top results to return
+
+        Returns:
+            List of (original_index, score) tuples, sorted by score descending
+        """
+        ...
+
+    @property
+    def provider_name(self) -> str:
+        """Human-readable provider name."""
+        ...
+
+    @property
+    def model_name(self) -> str:
+        """Model identifier being used."""
+        ...
+```
+
+### Pattern 2: Two-Stage Retrieval Flow
+
+**What:** Fast retrieval followed by accurate reranking
+**When to use:** When ENABLE_RERANKING=true
+**Example:**
+```python
+# Source: https://www.pinecone.io/learn/series/rag/rerankers/
+
+async def _execute_hybrid_query_with_rerank(self, request: QueryRequest) -> list[QueryResult]:
+    """Execute hybrid search with optional reranking."""
+
+    # Stage 1: Fast retrieval (existing code)
+    # Retrieve more candidates than final top_k
+    stage1_top_k = min(request.top_k * 10, 100)  # 10x or cap at 100
+    stage1_results = await self._execute_hybrid_query(request._replace(top_k=stage1_top_k))
+
+    # Stage 2: Reranking (new, optional)
+    if settings.ENABLE_RERANKING and len(stage1_results) > request.top_k:
+        try:
+            reranker = get_reranker_provider()
+            documents = [r.text for r in stage1_results]
+            reranked = await reranker.rerank(
+                query=request.query,
+                documents=documents,
+                top_k=request.top_k,
+            )
+            # Reorder results based on reranking scores
+            return [stage1_results[idx] for idx, score in reranked]
+        except Exception as e:
+            logger.warning(f"Reranking failed, using stage 1 results: {e}")
+            # Graceful fallback
+            return stage1_results[:request.top_k]
+
+    return stage1_results[:request.top_k]
+```
+
+### Pattern 3: Sentence-Transformers CrossEncoder Implementation
+
+**What:** Use sentence-transformers CrossEncoder directly
+**When to use:** Default reranker implementation (recommended)
+**Example:**
+```python
+# Source: https://www.sbert.net/docs/package_reference/cross_encoder/cross_encoder
+
+from sentence_transformers import CrossEncoder
+
+class SentenceTransformerRerankerProvider(BaseRerankerProvider):
+    """Reranker using sentence-transformers CrossEncoder."""
+
+    def __init__(self, config: "RerankerConfig") -> None:
+        self._model = CrossEncoder(config.model)
+        self._batch_size = config.params.get("batch_size", 32)
+
+    async def rerank(
+        self,
+        query: str,
+        documents: list[str],
+        top_k: int = 10,
+    ) -> list[tuple[int, float]]:
+        # CrossEncoder.rank() handles batching and sorting
+        results = self._model.rank(
+            query,
+            documents,
+            top_k=top_k,
+            return_documents=False,
+        )
+        return [(r["corpus_id"], r["score"]) for r in results]
+```
+
+### Pattern 4: Ollama Chat-Based Reranking
+
+**What:** Use Ollama Qwen3 Reranker via chat completions
+**When to use:** When user wants fully local inference without HuggingFace downloads
+**Example:**
+```python
+# Source: https://apidog.com/blog/qwen-3-embedding-reranker-ollama/
+
+import ollama
+from concurrent.futures import ThreadPoolExecutor
+
+class OllamaRerankerProvider(BaseRerankerProvider):
+    """Reranker using Ollama chat completions with Qwen3 Reranker."""
+
+    RERANK_PROMPT = '''Score the relevance of this document to the query.
+Query: {query}
+Document: {document}
+
+Output only a number from 0 to 10, where 10 is perfectly relevant.'''
+
+    async def rerank(
+        self,
+        query: str,
+        documents: list[str],
+        top_k: int = 10,
+    ) -> list[tuple[int, float]]:
+        scores = []
+        for idx, doc in enumerate(documents):
+            try:
+                response = ollama.chat(
+                    model=self._model,
+                    messages=[{
+                        "role": "user",
+                        "content": self.RERANK_PROMPT.format(query=query, document=doc)
+                    }],
+                    options={"temperature": 0.0}
+                )
+                score = float(response["message"]["content"].strip())
+                scores.append((idx, score))
+            except Exception:
+                scores.append((idx, 0.0))  # Default score on error
+
+        # Sort by score descending and take top_k
+        scores.sort(key=lambda x: x[1], reverse=True)
+        return scores[:top_k]
+```
+
+### Anti-Patterns to Avoid
+- **Processing all documents through reranker:** Always limit to top 50-100 candidates from Stage 1
+- **Synchronous reranking in request path:** Use async patterns to avoid blocking
+- **No fallback on failure:** MUST gracefully degrade to Stage 1 results
+- **Reranking when disabled:** Always check ENABLE_RERANKING before invoking reranker
+
+## Don't Hand-Roll
+
+Problems that look simple but have existing solutions:
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Cross-encoder scoring | Custom transformer inference | `sentence-transformers.CrossEncoder` | Handles batching, tokenization, model loading |
+| Document ranking | Manual sort + score | `CrossEncoder.rank()` method | Optimized, returns sorted corpus_id and scores |
+| LlamaIndex integration | Custom postprocessor | `SentenceTransformerRerank` | Native NodePostprocessor, well-tested |
+| Provider configuration | Hardcoded settings | Existing `ProviderConfig` pattern | YAML config, env vars, factory caching |
+
+**Key insight:** The `sentence-transformers` library has a mature `CrossEncoder` class with `.rank()` method specifically designed for reranking. Do not implement custom transformer inference.
+
+## Common Pitfalls
+
+### Pitfall 1: Retrieving Too Few Stage 1 Candidates
+**What goes wrong:** Reranking cannot surface relevant documents that weren't retrieved
+**Why it happens:** Setting Stage 1 top_k same as final top_k
+**How to avoid:** Retrieve 5-10x final top_k in Stage 1 (e.g., top_k=5 -> retrieve 50)
+**Warning signs:** Reranking shows minimal improvement over Stage 1 results
+
+### Pitfall 2: Exceeding 100ms Latency Budget
+**What goes wrong:** User experience degrades, reranking becomes bottleneck
+**Why it happens:** Reranking too many documents, using large models, no batching
+**How to avoid:** Cap Stage 1 at 100 docs, use lightweight models (MiniLM), batch inference
+**Warning signs:** P95 latency > 100ms for reranking step alone
+
+### Pitfall 3: Ollama Reranker Model Not Available
+**What goes wrong:** Reranking fails silently or with cryptic errors
+**Why it happens:** User hasn't pulled the Ollama model, Ollama not running
+**How to avoid:** Health check on startup, graceful fallback, clear error messages
+**Warning signs:** `OllamaConnectionError`, empty responses
+
+### Pitfall 4: Breaking Graceful Fallback
+**What goes wrong:** Entire query fails when reranking fails
+**Why it happens:** Not wrapping reranker call in try/except, propagating exceptions
+**How to avoid:** Always catch reranker exceptions, return Stage 1 results
+**Warning signs:** Query failures with ENABLE_RERANKING=true that work when false
+
+### Pitfall 5: Inconsistent Score Ranges
+**What goes wrong:** Reranker scores don't compare properly with Stage 1 scores
+**Why it happens:** Mixing cross-encoder scores (unbounded) with cosine similarity (0-1)
+**How to avoid:** Use reranker scores only for ordering, not combining with Stage 1 scores
+**Warning signs:** Confusing score values in query results
+
+## Code Examples
+
+Verified patterns from official sources:
+
+### LlamaIndex SentenceTransformerRerank Integration
+```python
+# Source: https://github.com/run-llama/llama_index/blob/main/docs/src/content/docs/framework/module_guides/querying/node_postprocessors/node_postprocessors.md
+
+from llama_index.core.postprocessor import SentenceTransformerRerank
+
+# Use fast model for production
+postprocessor = SentenceTransformerRerank(
+    model="cross-encoder/ms-marco-MiniLM-L-2-v2",  # Fast, decent accuracy
+    top_n=5,
+)
+
+# Apply to retrieved nodes
+reranked_nodes = postprocessor.postprocess_nodes(nodes)
+```
+
+### Direct CrossEncoder Usage
+```python
+# Source: https://www.sbert.net/docs/package_reference/cross_encoder/cross_encoder
+
+from sentence_transformers import CrossEncoder
+
+model = CrossEncoder("cross-encoder/ms-marco-MiniLM-L6-v2")
+
+query = "How to implement reranking?"
+documents = [doc.text for doc in stage1_results]
+
+# Rank and get top 5
+results = model.rank(query, documents, top_k=5, return_documents=False)
+# results = [{"corpus_id": 2, "score": 8.61}, {"corpus_id": 0, "score": 6.35}, ...]
+```
+
+### Configuration Pattern (Following Existing Codebase)
+```python
+# Source: Based on agent_brain_server/config/settings.py pattern
+
+class Settings(BaseSettings):
+    # ... existing settings ...
+
+    # Reranking Configuration (Feature 123)
+    ENABLE_RERANKING: bool = False  # Off by default
+    RERANKER_PROVIDER: str = "sentence-transformers"  # or "ollama"
+    RERANKER_MODEL: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+    RERANKER_TOP_K_MULTIPLIER: int = 10  # Retrieve top_k * this for Stage 1
+    RERANKER_MAX_CANDIDATES: int = 100  # Cap on Stage 1 candidates
+```
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| Single-stage retrieval | Two-stage retrieve + rerank | 2023+ | +15-20% precision improvement |
+| BERT cross-encoders | MiniLM distilled models | 2022+ | 10x faster with minimal accuracy loss |
+| API-only rerankers (Cohere) | Local cross-encoders | 2024+ | No API costs, privacy preserved |
+| Embedding similarity reranking | True cross-encoder attention | 2023+ | Better semantic understanding |
+
+**Deprecated/outdated:**
+- `bge-reranker-v2-m3` on Ollama: Uses embed API (embedding similarity), not true cross-encoder. Less accurate than sentence-transformers CrossEncoder.
+- Custom transformer inference: sentence-transformers handles this better
+
+## Open Questions
+
+Things that need validation during implementation:
+
+1. **Latency with 100 candidates**
+   - What we know: MiniLM models are fast (~2-5ms per document)
+   - What's unclear: Actual latency in Agent Brain's async context
+   - Recommendation: Benchmark during implementation, target <100ms total
+
+2. **Ollama Qwen3 Reranker Accuracy**
+   - What we know: Chat-based scoring works but may be less accurate than true cross-encoders
+   - What's unclear: Precision improvement vs sentence-transformers approach
+   - Recommendation: Implement both, let user choose via config
+
+3. **Async CrossEncoder Inference**
+   - What we know: CrossEncoder.predict() is synchronous
+   - What's unclear: Best pattern for async wrapper (threadpool vs process pool)
+   - Recommendation: Use `asyncio.to_thread()` for CPU-bound inference
+
+## Sources
+
+### Primary (HIGH confidence)
+- `/websites/sbert_net` (Context7) - CrossEncoder.rank() method, retrieve & rerank patterns
+- `/run-llama/llama_index` (Context7) - SentenceTransformerRerank NodePostprocessor usage
+- [Pinecone Rerankers Guide](https://www.pinecone.io/learn/series/rag/rerankers/) - Two-stage architecture, performance benchmarks
+
+### Secondary (MEDIUM confidence)
+- [Ollama Qwen3 Reranker Guide](https://apidog.com/blog/qwen-3-embedding-reranker-ollama/) - Ollama chat-based reranking pattern
+- [GitHub ollama/ollama#3368](https://github.com/ollama/ollama/issues/3368) - Confirmed no native rerank API in Ollama
+
+### Tertiary (LOW confidence)
+- WebSearch results on Ollama reranking models - Community uploads, varying quality
+- BGE-reranker-v2-m3 Ollama usage - Uses embed API, not ideal for cross-encoder reranking
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack: HIGH - sentence-transformers is industry standard with excellent docs
+- Architecture: HIGH - Two-stage retrieval is well-established pattern
+- Pitfalls: HIGH - Common issues are well-documented in community
+- Ollama approach: MEDIUM - Works but less tested than sentence-transformers
+
+**Research date:** 2026-02-07
+**Valid until:** 2026-03-07 (30 days - stable domain)
+
+## Recommendation Summary
+
+1. **Use `sentence-transformers` CrossEncoder** as primary implementation (not Ollama BGE models)
+2. **Add `RerankerProvider` protocol** following existing provider patterns in codebase
+3. **Integrate after RRF fusion** in `query_service.py`
+4. **Default model:** `cross-encoder/ms-marco-MiniLM-L-6-v2` (fast, good accuracy)
+5. **Optional Ollama support:** Qwen3-Reranker-0.6B via chat completions for fully local users
+6. **Stage 1 retrieval:** 10x top_k, capped at 100 candidates
+7. **Graceful fallback:** Always return Stage 1 results on any reranker failure

--- a/.planning/phases/02-pluggable-providers/02-01-PLAN.md
+++ b/.planning/phases/02-pluggable-providers/02-01-PLAN.md
@@ -1,0 +1,566 @@
+---
+phase: 02-pluggable-providers
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - agent-brain-server/agent_brain_server/storage/vector_store.py
+  - agent-brain-server/agent_brain_server/services/indexing_service.py
+  - agent-brain-server/agent_brain_server/api/main.py
+  - agent-brain-server/tests/unit/storage/test_vector_store_metadata.py
+autonomous: true
+
+must_haves:
+  truths:
+    - "ChromaDB collection stores embedding provider metadata (provider, model, dimensions)"
+    - "Startup validates that current config matches existing collection metadata"
+    - "Index operations validate dimension compatibility before processing"
+    - "ProviderMismatchError is raised on dimension or provider mismatch"
+    - "--force flag allows re-indexing with different provider"
+  artifacts:
+    - path: "agent-brain-server/agent_brain_server/storage/vector_store.py"
+      provides: "Embedding metadata storage and validation"
+      contains: "get_embedding_metadata"
+    - path: "agent-brain-server/agent_brain_server/services/indexing_service.py"
+      provides: "Pre-indexing validation"
+      contains: "validate_embedding_compatibility"
+    - path: "agent-brain-server/agent_brain_server/api/main.py"
+      provides: "Startup dimension validation"
+      contains: "check_embedding_compatibility"
+  key_links:
+    - from: "storage/vector_store.py"
+      to: "providers/exceptions.py"
+      via: "ProviderMismatchError import"
+      pattern: "from.*providers.exceptions.*import.*ProviderMismatchError"
+---
+
+<objective>
+Implement dimension mismatch prevention to ensure embedding providers match indexed data.
+
+Purpose: Prevent silent search quality degradation when users switch embedding providers without re-indexing. ChromaDB accepts any dimension vectors silently, so we must enforce validation at the application layer.
+
+Output: Metadata storage in ChromaDB collection, startup validation, index-time validation, and --force flag for intentional re-indexing.
+</objective>
+
+<execution_context>
+@/Users/richardhightower/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/richardhightower/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/phases/02-pluggable-providers/02-RESEARCH.md
+@agent-brain-server/agent_brain_server/storage/vector_store.py
+@agent-brain-server/agent_brain_server/services/indexing_service.py
+@agent-brain-server/agent_brain_server/api/main.py
+@agent-brain-server/agent_brain_server/providers/exceptions.py
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add embedding metadata model and storage methods to VectorStoreManager</name>
+  <files>agent-brain-server/agent_brain_server/storage/vector_store.py</files>
+  <action>
+1. Add import for ProviderMismatchError and dataclass for EmbeddingMetadata:
+
+```python
+from dataclasses import dataclass, asdict
+from typing import Any, Optional
+from agent_brain_server.providers.exceptions import ProviderMismatchError
+
+@dataclass
+class EmbeddingMetadata:
+    """Metadata about the embedding provider used for this collection."""
+    provider: str
+    model: str
+    dimensions: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for ChromaDB metadata."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "EmbeddingMetadata":
+        """Create from dictionary (ChromaDB metadata)."""
+        return cls(
+            provider=data.get("embedding_provider", "unknown"),
+            model=data.get("embedding_model", "unknown"),
+            dimensions=data.get("embedding_dimensions", 0),
+        )
+```
+
+2. Add methods to VectorStoreManager class after `initialize()`:
+
+```python
+async def get_embedding_metadata(self) -> Optional[EmbeddingMetadata]:
+    """Get stored embedding metadata from collection.
+
+    Returns:
+        EmbeddingMetadata if collection has metadata, None otherwise.
+    """
+    if not self.is_initialized or self._collection is None:
+        return None
+
+    async with self._lock:
+        metadata = self._collection.metadata
+        if metadata and "embedding_provider" in metadata:
+            return EmbeddingMetadata.from_dict(metadata)
+        return None
+
+async def set_embedding_metadata(
+    self,
+    provider: str,
+    model: str,
+    dimensions: int,
+) -> None:
+    """Store embedding metadata in collection.
+
+    Args:
+        provider: Embedding provider name (e.g., "openai", "ollama")
+        model: Model name (e.g., "text-embedding-3-large")
+        dimensions: Embedding vector dimensions
+    """
+    if not self.is_initialized or self._collection is None:
+        raise RuntimeError("Vector store not initialized")
+
+    async with self._lock:
+        assert self._client is not None
+        # ChromaDB requires recreating collection to update metadata
+        # Get existing metadata and merge
+        existing_meta = dict(self._collection.metadata or {})
+        existing_meta.update({
+            "embedding_provider": provider,
+            "embedding_model": model,
+            "embedding_dimensions": dimensions,
+            "hnsw:space": "cosine",
+        })
+
+        # Modify collection metadata
+        self._collection.modify(metadata=existing_meta)
+
+        logger.info(
+            f"Stored embedding metadata: {provider}/{model} "
+            f"({dimensions} dimensions)"
+        )
+
+def validate_embedding_compatibility(
+    self,
+    provider: str,
+    model: str,
+    dimensions: int,
+    stored_metadata: Optional[EmbeddingMetadata],
+) -> None:
+    """Validate current embedding config against stored metadata.
+
+    Args:
+        provider: Current provider name
+        model: Current model name
+        dimensions: Current embedding dimensions
+        stored_metadata: Previously stored metadata (or None if new index)
+
+    Raises:
+        ProviderMismatchError: If dimensions or provider/model don't match
+    """
+    if stored_metadata is None:
+        return  # New index, no validation needed
+
+    # Check dimension mismatch first (critical)
+    if stored_metadata.dimensions != dimensions:
+        raise ProviderMismatchError(
+            current_provider=provider,
+            current_model=model,
+            indexed_provider=stored_metadata.provider,
+            indexed_model=stored_metadata.model,
+        )
+
+    # Check provider/model mismatch (even same dimensions can be incompatible)
+    if (stored_metadata.provider != provider or
+        stored_metadata.model != model):
+        raise ProviderMismatchError(
+            current_provider=provider,
+            current_model=model,
+            indexed_provider=stored_metadata.provider,
+            indexed_model=stored_metadata.model,
+        )
+```
+
+3. Update `initialize()` to preserve existing metadata:
+
+In the `get_or_create_collection` call, the metadata is already being set to `{"hnsw:space": "cosine"}`. No change needed here as we'll set embedding metadata separately after first indexing.
+  </action>
+  <verify>Run `cd agent-brain-server && poetry run python -c "from agent_brain_server.storage.vector_store import EmbeddingMetadata, VectorStoreManager; m = EmbeddingMetadata('openai', 'text-embedding-3-large', 3072); print(m.to_dict())"` to verify the dataclass works.</verify>
+  <done>VectorStoreManager has get_embedding_metadata, set_embedding_metadata, and validate_embedding_compatibility methods.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add validation to IndexingService before indexing</name>
+  <files>agent-brain-server/agent_brain_server/services/indexing_service.py</files>
+  <action>
+1. Add imports at the top:
+
+```python
+from agent_brain_server.providers.exceptions import ProviderMismatchError
+from agent_brain_server.storage.vector_store import EmbeddingMetadata
+from agent_brain_server.config.provider_config import load_provider_settings
+```
+
+2. Add `force` parameter to `start_indexing` method signature:
+
+```python
+async def start_indexing(
+    self,
+    request: IndexRequest,
+    progress_callback: Optional[ProgressCallback] = None,
+    force: bool = False,
+) -> str:
+```
+
+3. Add validation before running pipeline in `start_indexing`:
+
+Inside the method, after the lock check but before starting the background task:
+
+```python
+# Validate embedding compatibility unless force=True
+if not force:
+    await self._validate_embedding_compatibility()
+```
+
+4. Add the validation method:
+
+```python
+async def _validate_embedding_compatibility(self) -> None:
+    """Validate current embedding config matches existing index.
+
+    Raises:
+        ProviderMismatchError: If provider/model/dimensions don't match
+    """
+    # Get stored metadata
+    stored_metadata = await self.vector_store.get_embedding_metadata()
+
+    if stored_metadata is None:
+        # No existing index, no validation needed
+        return
+
+    # Get current config
+    settings = load_provider_settings()
+    current_provider = settings.embedding.provider
+    current_model = settings.embedding.model
+    current_dimensions = self.embedding_generator.get_embedding_dimensions()
+
+    # Validate
+    self.vector_store.validate_embedding_compatibility(
+        provider=str(current_provider),
+        model=current_model,
+        dimensions=current_dimensions,
+        stored_metadata=stored_metadata,
+    )
+```
+
+5. Update `_run_indexing_pipeline` to store metadata after successful indexing:
+
+After the line `await self.vector_store.initialize()` in `_run_indexing_pipeline`, add:
+
+```python
+# Get current embedding config for metadata storage
+settings = load_provider_settings()
+current_provider = str(settings.embedding.provider)
+current_model = settings.embedding.model
+current_dimensions = self.embedding_generator.get_embedding_dimensions()
+```
+
+After successfully storing in vector database (after the batch loop for ChromaDB upserts), add:
+
+```python
+# Store embedding metadata for future validation
+await self.vector_store.set_embedding_metadata(
+    provider=current_provider,
+    model=current_model,
+    dimensions=current_dimensions,
+)
+```
+
+6. Update `reset()` method to note that metadata will be cleared:
+
+Add a comment in the reset method:
+```python
+# Note: Embedding metadata is stored in collection metadata,
+# so it will be cleared when collection is reset
+```
+  </action>
+  <verify>Run `cd agent-brain-server && poetry run python -c "from agent_brain_server.services.indexing_service import IndexingService; print('IndexingService imported successfully')"` to verify imports work.</verify>
+  <done>IndexingService validates embedding compatibility before indexing and stores metadata after successful indexing.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Add startup validation to FastAPI lifespan</name>
+  <files>agent-brain-server/agent_brain_server/api/main.py</files>
+  <action>
+1. Add import for ProviderMismatchError:
+
+```python
+from agent_brain_server.providers.exceptions import ProviderMismatchError
+```
+
+2. Add validation function after the imports section:
+
+```python
+async def check_embedding_compatibility(
+    vector_store: VectorStoreManager,
+) -> Optional[str]:
+    """Check if current embedding config matches existing index.
+
+    Args:
+        vector_store: Initialized vector store manager
+
+    Returns:
+        Warning message if mismatch detected, None if compatible
+    """
+    try:
+        stored_metadata = await vector_store.get_embedding_metadata()
+        if stored_metadata is None:
+            return None  # No existing index
+
+        # Get current config
+        provider_settings = load_provider_settings()
+        from agent_brain_server.providers.factory import ProviderRegistry
+
+        embedding_provider = ProviderRegistry.get_embedding_provider(
+            provider_settings.embedding
+        )
+        current_dimensions = embedding_provider.get_dimensions()
+        current_provider = str(provider_settings.embedding.provider)
+        current_model = provider_settings.embedding.model
+
+        # Check for mismatch
+        if (stored_metadata.dimensions != current_dimensions or
+            stored_metadata.provider != current_provider or
+            stored_metadata.model != current_model):
+            return (
+                f"Embedding provider mismatch: index was created with "
+                f"{stored_metadata.provider}/{stored_metadata.model} "
+                f"({stored_metadata.dimensions}d), but current config uses "
+                f"{current_provider}/{current_model} ({current_dimensions}d). "
+                f"Queries may return incorrect results. "
+                f"Re-index with --force to update."
+            )
+        return None
+    except Exception as e:
+        logger.warning(f"Failed to check embedding compatibility: {e}")
+        return None
+```
+
+3. Add validation call in lifespan() after vector store initialization:
+
+After the line `logger.info("Vector store initialized")`, add:
+
+```python
+# Check embedding compatibility (PROV-07)
+embedding_warning = await check_embedding_compatibility(vector_store)
+if embedding_warning:
+    logger.warning(f"Embedding compatibility: {embedding_warning}")
+    # Store warning for health endpoint
+    app.state.embedding_warning = embedding_warning
+else:
+    app.state.embedding_warning = None
+```
+  </action>
+  <verify>Run `cd agent-brain-server && poetry run python -c "from agent_brain_server.api.main import check_embedding_compatibility; print('Function imported successfully')"` to verify the function is importable.</verify>
+  <done>Startup checks embedding compatibility and logs warning if mismatch detected.</done>
+</task>
+
+<task type="auto">
+  <name>Task 4: Add --force flag to CLI index command</name>
+  <files>agent-brain-server/agent_brain_server/models/index.py, agent-brain-cli/agent_brain_cli/commands/index.py</files>
+  <action>
+1. First, check the IndexRequest model in `agent-brain-server/agent_brain_server/models/index.py` and add force field:
+
+```python
+class IndexRequest(BaseModel):
+    """Request to start indexing operation."""
+
+    folder_path: str
+    recursive: bool = True
+    include_code: bool = True
+    chunk_size: int = 512
+    chunk_overlap: int = 50
+    generate_summaries: bool = True
+    force: bool = Field(
+        default=False,
+        description="Force re-indexing even if provider has changed",
+    )
+```
+
+2. Update the CLI index command in `agent-brain-cli/agent_brain_cli/commands/index.py`:
+
+Add the --force option:
+
+```python
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Force re-indexing even if embedding provider has changed",
+)
+```
+
+And update the function signature and request body to include force=force.
+
+3. Update the API router if needed to pass force through to the service.
+  </action>
+  <verify>Run `cd agent-brain-cli && poetry run agent-brain index --help` to verify --force flag appears in help.</verify>
+  <done>CLI index command has --force flag that bypasses provider mismatch validation.</done>
+</task>
+
+<task type="auto">
+  <name>Task 5: Add unit tests for embedding metadata validation</name>
+  <files>agent-brain-server/tests/unit/storage/test_vector_store_metadata.py</files>
+  <action>
+Create a new test file with comprehensive tests:
+
+```python
+"""Tests for embedding metadata storage and validation."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from agent_brain_server.storage.vector_store import (
+    EmbeddingMetadata,
+    VectorStoreManager,
+)
+from agent_brain_server.providers.exceptions import ProviderMismatchError
+
+
+class TestEmbeddingMetadata:
+    """Tests for EmbeddingMetadata dataclass."""
+
+    def test_to_dict(self) -> None:
+        """Test conversion to dictionary."""
+        metadata = EmbeddingMetadata(
+            provider="openai",
+            model="text-embedding-3-large",
+            dimensions=3072,
+        )
+        result = metadata.to_dict()
+        assert result == {
+            "provider": "openai",
+            "model": "text-embedding-3-large",
+            "dimensions": 3072,
+        }
+
+    def test_from_dict(self) -> None:
+        """Test creation from dictionary."""
+        data = {
+            "embedding_provider": "ollama",
+            "embedding_model": "nomic-embed-text",
+            "embedding_dimensions": 768,
+        }
+        metadata = EmbeddingMetadata.from_dict(data)
+        assert metadata.provider == "ollama"
+        assert metadata.model == "nomic-embed-text"
+        assert metadata.dimensions == 768
+
+    def test_from_dict_missing_keys(self) -> None:
+        """Test handling of missing keys."""
+        data = {}
+        metadata = EmbeddingMetadata.from_dict(data)
+        assert metadata.provider == "unknown"
+        assert metadata.model == "unknown"
+        assert metadata.dimensions == 0
+
+
+class TestVectorStoreValidation:
+    """Tests for embedding validation methods."""
+
+    def test_validate_compatible(self) -> None:
+        """Test validation passes when metadata matches."""
+        store = VectorStoreManager()
+        stored = EmbeddingMetadata("openai", "text-embedding-3-large", 3072)
+
+        # Should not raise
+        store.validate_embedding_compatibility(
+            provider="openai",
+            model="text-embedding-3-large",
+            dimensions=3072,
+            stored_metadata=stored,
+        )
+
+    def test_validate_dimension_mismatch(self) -> None:
+        """Test validation fails on dimension mismatch."""
+        store = VectorStoreManager()
+        stored = EmbeddingMetadata("openai", "text-embedding-3-large", 3072)
+
+        with pytest.raises(ProviderMismatchError) as exc_info:
+            store.validate_embedding_compatibility(
+                provider="ollama",
+                model="nomic-embed-text",
+                dimensions=768,
+                stored_metadata=stored,
+            )
+
+        assert "Provider mismatch" in str(exc_info.value)
+        assert "openai" in str(exc_info.value)
+        assert "ollama" in str(exc_info.value)
+
+    def test_validate_provider_mismatch_same_dimensions(self) -> None:
+        """Test validation fails on provider mismatch even with same dimensions."""
+        store = VectorStoreManager()
+        # Both Cohere and some Ollama models can have 1024 dimensions
+        stored = EmbeddingMetadata("cohere", "embed-english-v3.0", 1024)
+
+        with pytest.raises(ProviderMismatchError):
+            store.validate_embedding_compatibility(
+                provider="ollama",
+                model="mxbai-embed-large",
+                dimensions=1024,
+                stored_metadata=stored,
+            )
+
+    def test_validate_no_stored_metadata(self) -> None:
+        """Test validation passes when no metadata exists (new index)."""
+        store = VectorStoreManager()
+
+        # Should not raise
+        store.validate_embedding_compatibility(
+            provider="openai",
+            model="text-embedding-3-large",
+            dimensions=3072,
+            stored_metadata=None,
+        )
+```
+  </action>
+  <verify>Run `cd agent-brain-server && poetry run pytest tests/unit/storage/test_vector_store_metadata.py -v` to run the tests.</verify>
+  <done>Unit tests cover all validation scenarios including dimension mismatch, provider mismatch, and new index cases.</done>
+</task>
+
+</tasks>
+
+<verification>
+1. Run `task before-push` from the agent-brain directory to ensure all quality checks pass
+2. Verify ProviderMismatchError is raised when dimensions don't match:
+   - Create an index with one provider
+   - Change config to different provider
+   - Attempt to index again (should fail without --force)
+3. Verify --force bypasses validation:
+   - With mismatched provider, run `agent-brain index /path --force`
+   - Should succeed and update metadata
+4. Verify startup logs warning when mismatch detected
+5. Run full test suite: `poetry run pytest`
+</verification>
+
+<success_criteria>
+- EmbeddingMetadata dataclass exists with to_dict/from_dict methods
+- VectorStoreManager stores embedding metadata in ChromaDB collection
+- VectorStoreManager.validate_embedding_compatibility raises ProviderMismatchError on mismatch
+- IndexingService validates before indexing (unless force=True)
+- IndexingService stores metadata after successful indexing
+- FastAPI startup logs warning if embedding mismatch detected
+- CLI index command has --force flag
+- Unit tests pass with >80% coverage for new code
+- `task before-push` passes
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/02-pluggable-providers/02-01-SUMMARY.md`
+</output>

--- a/.planning/phases/02-pluggable-providers/02-02-PLAN.md
+++ b/.planning/phases/02-pluggable-providers/02-02-PLAN.md
@@ -1,0 +1,646 @@
+---
+phase: 02-pluggable-providers
+plan: 02
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - agent-brain-server/agent_brain_server/config/provider_config.py
+  - agent-brain-server/agent_brain_server/api/main.py
+  - agent-brain-server/agent_brain_server/api/routers/health.py
+  - agent-brain-server/agent_brain_server/models/health.py
+  - agent-brain-cli/agent_brain_cli/commands/start.py
+  - agent-brain-server/tests/unit/config/test_provider_validation.py
+autonomous: true
+
+must_haves:
+  truths:
+    - "Validation errors have severity levels (CRITICAL, WARNING)"
+    - "CRITICAL errors cause startup failure when --strict mode is enabled"
+    - "WARNING errors are logged but don't block startup"
+    - "/health/providers endpoint shows provider status with health checks"
+    - "CLI start command supports --strict flag"
+  artifacts:
+    - path: "agent-brain-server/agent_brain_server/config/provider_config.py"
+      provides: "ValidationError class with severity"
+      contains: "class ValidationError"
+    - path: "agent-brain-server/agent_brain_server/api/routers/health.py"
+      provides: "/providers endpoint"
+      contains: "def providers_status"
+    - path: "agent-brain-cli/agent_brain_cli/commands/start.py"
+      provides: "--strict flag"
+      contains: "--strict"
+  key_links:
+    - from: "api/main.py"
+      to: "config/provider_config.py"
+      via: "ValidationError import"
+      pattern: "from.*provider_config.*import.*ValidationError"
+---
+
+<objective>
+Implement strict startup validation with severity levels and provider health endpoint.
+
+Purpose: Allow users to catch configuration errors early with fail-fast behavior (--strict mode) while maintaining backward compatibility with current warning-only behavior.
+
+Output: Validation severity levels, --strict CLI flag, and /health/providers endpoint for debugging.
+</objective>
+
+<execution_context>
+@/Users/richardhightower/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/richardhightower/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/phases/02-pluggable-providers/02-RESEARCH.md
+@agent-brain-server/agent_brain_server/config/provider_config.py
+@agent-brain-server/agent_brain_server/api/main.py
+@agent-brain-server/agent_brain_server/api/routers/health.py
+@agent-brain-cli/agent_brain_cli/commands/start.py
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add ValidationError class with severity levels</name>
+  <files>agent-brain-server/agent_brain_server/config/provider_config.py</files>
+  <action>
+1. Add enum and dataclass imports at the top:
+
+```python
+from dataclasses import dataclass
+from enum import Enum
+```
+
+2. Add severity enum and ValidationError class after the imports, before EmbeddingConfig:
+
+```python
+class ValidationSeverity(str, Enum):
+    """Severity level for validation errors."""
+
+    CRITICAL = "critical"  # Blocks startup in strict mode
+    WARNING = "warning"    # Logged but doesn't block startup
+
+
+@dataclass
+class ValidationError:
+    """A validation error with severity and details."""
+
+    message: str
+    severity: ValidationSeverity
+    provider_type: str  # "embedding", "summarization", "reranker"
+    field: str = ""     # Optional field name
+
+    def __str__(self) -> str:
+        prefix = "[CRITICAL]" if self.severity == ValidationSeverity.CRITICAL else "[WARNING]"
+        return f"{prefix} {self.provider_type}: {self.message}"
+```
+
+3. Update `validate_provider_config` to return ValidationError objects instead of strings:
+
+```python
+def validate_provider_config(settings: ProviderSettings) -> list[ValidationError]:
+    """Validate provider configuration and return list of errors.
+
+    Checks:
+    - API keys are available for providers that need them (CRITICAL)
+    - Provider health checks pass (WARNING)
+
+    Args:
+        settings: Provider settings to validate
+
+    Returns:
+        List of ValidationError objects (empty if valid)
+    """
+    errors: list[ValidationError] = []
+
+    # Validate embedding provider
+    if settings.embedding.provider != EmbeddingProviderType.OLLAMA:
+        api_key = settings.embedding.get_api_key()
+        if not api_key:
+            env_var = settings.embedding.api_key_env or "OPENAI_API_KEY"
+            errors.append(ValidationError(
+                message=(
+                    f"Missing API key for {settings.embedding.provider} embeddings. "
+                    f"Set {env_var} environment variable."
+                ),
+                severity=ValidationSeverity.CRITICAL,
+                provider_type="embedding",
+                field="api_key",
+            ))
+
+    # Validate summarization provider
+    if settings.summarization.provider != SummarizationProviderType.OLLAMA:
+        api_key = settings.summarization.get_api_key()
+        if not api_key:
+            env_var = settings.summarization.api_key_env or "ANTHROPIC_API_KEY"
+            errors.append(ValidationError(
+                message=(
+                    f"Missing API key for {settings.summarization.provider} summarization. "
+                    f"Set {env_var} environment variable."
+                ),
+                severity=ValidationSeverity.CRITICAL,
+                provider_type="summarization",
+                field="api_key",
+            ))
+
+    return errors
+
+
+def has_critical_errors(errors: list[ValidationError]) -> bool:
+    """Check if any validation errors are critical.
+
+    Args:
+        errors: List of validation errors
+
+    Returns:
+        True if any error has CRITICAL severity
+    """
+    return any(e.severity == ValidationSeverity.CRITICAL for e in errors)
+```
+
+4. Add export for new classes in the module's imports if using __all__:
+
+```python
+# If there's an __all__ list, add:
+# "ValidationSeverity", "ValidationError", "has_critical_errors"
+```
+  </action>
+  <verify>Run `cd agent-brain-server && poetry run python -c "from agent_brain_server.config.provider_config import ValidationError, ValidationSeverity, has_critical_errors; e = ValidationError('test', ValidationSeverity.CRITICAL, 'embedding'); print(str(e))"` to verify the classes work.</verify>
+  <done>ValidationError class with severity levels exists and validate_provider_config returns structured errors.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add provider health endpoint to health router</name>
+  <files>agent-brain-server/agent_brain_server/api/routers/health.py, agent-brain-server/agent_brain_server/models/health.py</files>
+  <action>
+1. First, add the response model to `agent-brain-server/agent_brain_server/models/health.py`:
+
+```python
+from pydantic import BaseModel, Field
+from typing import Optional
+from datetime import datetime
+
+
+class ProviderHealth(BaseModel):
+    """Health status for a single provider."""
+
+    provider_type: str = Field(description="Type: embedding, summarization, reranker")
+    provider_name: str = Field(description="Provider name (e.g., openai, ollama)")
+    model: str = Field(description="Model being used")
+    status: str = Field(description="Status: healthy, degraded, unavailable")
+    message: Optional[str] = Field(default=None, description="Status message")
+    dimensions: Optional[int] = Field(
+        default=None, description="Embedding dimensions (for embedding providers)"
+    )
+
+
+class ProvidersStatus(BaseModel):
+    """Status of all configured providers."""
+
+    config_source: Optional[str] = Field(
+        default=None, description="Path to config file if loaded"
+    )
+    strict_mode: bool = Field(
+        default=False, description="Whether strict validation is enabled"
+    )
+    validation_errors: list[str] = Field(
+        default_factory=list, description="Validation error messages"
+    )
+    providers: list[ProviderHealth] = Field(
+        default_factory=list, description="Status of each provider"
+    )
+    timestamp: datetime = Field(description="Status check timestamp")
+```
+
+2. Update `agent-brain-server/agent_brain_server/api/routers/health.py`:
+
+Add imports:
+
+```python
+from agent_brain_server.models.health import ProviderHealth, ProvidersStatus
+from agent_brain_server.config.provider_config import (
+    load_provider_settings,
+    validate_provider_config,
+    _find_config_file,
+)
+from agent_brain_server.providers.factory import ProviderRegistry
+```
+
+Add the new endpoint:
+
+```python
+@router.get(
+    "/providers",
+    response_model=ProvidersStatus,
+    summary="Provider Status",
+    description="Returns status of all configured providers with health checks.",
+)
+async def providers_status(request: Request) -> ProvidersStatus:
+    """Get detailed status of all configured providers.
+
+    Returns:
+        ProvidersStatus with configuration source, validation errors,
+        and health status of each provider.
+    """
+    # Get config source
+    config_file = _find_config_file()
+    config_source = str(config_file) if config_file else None
+
+    # Get strict mode from app state
+    strict_mode = getattr(request.app.state, "strict_mode", False)
+
+    # Load settings and validate
+    settings = load_provider_settings()
+    validation_errors = validate_provider_config(settings)
+    error_messages = [str(e) for e in validation_errors]
+
+    providers: list[ProviderHealth] = []
+
+    # Check embedding provider
+    try:
+        embedding_provider = ProviderRegistry.get_embedding_provider(settings.embedding)
+        embedding_status = "healthy"
+        embedding_message = None
+        embedding_dimensions = embedding_provider.get_dimensions()
+    except Exception as e:
+        embedding_status = "unavailable"
+        embedding_message = str(e)
+        embedding_dimensions = None
+
+    providers.append(ProviderHealth(
+        provider_type="embedding",
+        provider_name=str(settings.embedding.provider),
+        model=settings.embedding.model,
+        status=embedding_status,
+        message=embedding_message,
+        dimensions=embedding_dimensions,
+    ))
+
+    # Check summarization provider
+    try:
+        summarization_provider = ProviderRegistry.get_summarization_provider(
+            settings.summarization
+        )
+        summarization_status = "healthy"
+        summarization_message = None
+    except Exception as e:
+        summarization_status = "unavailable"
+        summarization_message = str(e)
+
+    providers.append(ProviderHealth(
+        provider_type="summarization",
+        provider_name=str(settings.summarization.provider),
+        model=settings.summarization.model,
+        status=summarization_status,
+        message=summarization_message,
+    ))
+
+    # Check reranker provider if reranking is enabled
+    from agent_brain_server.config import settings as app_settings
+    if app_settings.ENABLE_RERANKING:
+        try:
+            reranker_provider = ProviderRegistry.get_reranker_provider(
+                settings.reranker
+            )
+            reranker_status = "healthy"
+            reranker_message = None
+        except Exception as e:
+            reranker_status = "unavailable"
+            reranker_message = str(e)
+
+        providers.append(ProviderHealth(
+            provider_type="reranker",
+            provider_name=str(settings.reranker.provider),
+            model=settings.reranker.model,
+            status=reranker_status,
+            message=reranker_message,
+        ))
+
+    return ProvidersStatus(
+        config_source=config_source,
+        strict_mode=strict_mode,
+        validation_errors=error_messages,
+        providers=providers,
+        timestamp=datetime.now(timezone.utc),
+    )
+```
+  </action>
+  <verify>Run `cd agent-brain-server && poetry run python -c "from agent_brain_server.api.routers.health import providers_status; print('Endpoint imported successfully')"` to verify the endpoint is importable.</verify>
+  <done>/health/providers endpoint exists and returns provider status with health checks.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Add strict mode to FastAPI lifespan</name>
+  <files>agent-brain-server/agent_brain_server/api/main.py</files>
+  <action>
+1. Add imports:
+
+```python
+from agent_brain_server.config.provider_config import (
+    clear_settings_cache,
+    load_provider_settings,
+    validate_provider_config,
+    has_critical_errors,
+    ValidationSeverity,
+)
+```
+
+2. Add strict mode environment variable to settings.py (if not exists):
+
+In `agent-brain-server/agent_brain_server/config/settings.py`, add:
+
+```python
+# Strict Mode Configuration
+AGENT_BRAIN_STRICT_MODE: bool = False  # Fail on critical validation errors
+```
+
+3. Update the validation section in lifespan():
+
+Replace the existing validation block:
+
+```python
+# Load and validate provider configuration
+# Clear cache first to ensure we pick up env vars set by CLI
+clear_settings_cache()
+try:
+    provider_settings = load_provider_settings()
+    validation_errors = validate_provider_config(provider_settings)
+
+    if validation_errors:
+        for error in validation_errors:
+            logger.warning(f"Provider config warning: {error}")
+        # Log but don't fail - providers may work if keys are set later
+        # or if using Ollama which doesn't need keys
+```
+
+With:
+
+```python
+# Load and validate provider configuration
+# Clear cache first to ensure we pick up env vars set by CLI
+clear_settings_cache()
+strict_mode = settings.AGENT_BRAIN_STRICT_MODE
+
+try:
+    provider_settings = load_provider_settings()
+    validation_errors = validate_provider_config(provider_settings)
+
+    if validation_errors:
+        for error in validation_errors:
+            if error.severity == ValidationSeverity.CRITICAL:
+                logger.error(f"Provider config error: {error}")
+            else:
+                logger.warning(f"Provider config warning: {error}")
+
+        # In strict mode, fail on critical errors
+        if strict_mode and has_critical_errors(validation_errors):
+            critical_msgs = [
+                str(e) for e in validation_errors
+                if e.severity == ValidationSeverity.CRITICAL
+            ]
+            raise RuntimeError(
+                f"Critical provider configuration errors (strict mode): "
+                f"{'; '.join(critical_msgs)}"
+            )
+```
+
+4. Store strict mode on app.state for the health endpoint:
+
+After the provider validation section, add:
+
+```python
+app.state.strict_mode = strict_mode
+```
+  </action>
+  <verify>Run `cd agent-brain-server && AGENT_BRAIN_STRICT_MODE=true poetry run python -c "from agent_brain_server.config import settings; print(f'Strict mode: {settings.AGENT_BRAIN_STRICT_MODE}')"` to verify the setting is read.</verify>
+  <done>FastAPI lifespan fails on critical errors when strict mode is enabled.</done>
+</task>
+
+<task type="auto">
+  <name>Task 4: Add --strict flag to CLI start command</name>
+  <files>agent-brain-cli/agent_brain_cli/commands/start.py</files>
+  <action>
+1. Add the --strict option to the start command decorator:
+
+```python
+@click.option(
+    "--strict",
+    is_flag=True,
+    help="Enable strict mode: fail on critical provider configuration errors",
+)
+```
+
+2. Update the function signature:
+
+```python
+def start_command(
+    path: Optional[str],
+    host: Optional[str],
+    port: Optional[int],
+    foreground: bool,
+    timeout: int,
+    json_output: bool,
+    strict: bool,
+) -> None:
+```
+
+3. Add strict mode to environment variables before server launch:
+
+In the section where environment variables are set (before `server_cmd`), add:
+
+```python
+# Set environment variables for server
+env = os.environ.copy()
+env["AGENT_BRAIN_PROJECT_ROOT"] = str(project_root)
+env["AGENT_BRAIN_STATE_DIR"] = str(state_dir)
+if strict:
+    env["AGENT_BRAIN_STRICT_MODE"] = "true"
+```
+
+4. Update the CLI help text to mention strict mode:
+
+```python
+"""Start an Agent Brain server for this project.
+
+Spawns a new server instance bound to the project. If a server is
+already running for this project, reports its URL instead.
+
+\b
+Examples:
+  agent-brain start                    # Start server for current project
+  agent-brain start --port 8080        # Start on specific port
+  agent-brain start --strict           # Fail on missing API keys
+  agent-brain start --foreground       # Run in foreground
+  agent-brain start --path /my/project # Start for specific project
+"""
+```
+  </action>
+  <verify>Run `cd agent-brain-cli && poetry run agent-brain start --help` to verify --strict flag appears in help output.</verify>
+  <done>CLI start command has --strict flag that sets AGENT_BRAIN_STRICT_MODE=true.</done>
+</task>
+
+<task type="auto">
+  <name>Task 5: Add unit tests for validation severity</name>
+  <files>agent-brain-server/tests/unit/config/test_provider_validation.py</files>
+  <action>
+Create a new test file:
+
+```python
+"""Tests for provider configuration validation with severity levels."""
+
+import os
+import pytest
+from unittest.mock import patch
+
+from agent_brain_server.config.provider_config import (
+    EmbeddingConfig,
+    SummarizationConfig,
+    ProviderSettings,
+    ValidationError,
+    ValidationSeverity,
+    validate_provider_config,
+    has_critical_errors,
+)
+from agent_brain_server.providers.base import (
+    EmbeddingProviderType,
+    SummarizationProviderType,
+)
+
+
+class TestValidationError:
+    """Tests for ValidationError class."""
+
+    def test_critical_error_string(self) -> None:
+        """Test CRITICAL error string representation."""
+        error = ValidationError(
+            message="Missing API key",
+            severity=ValidationSeverity.CRITICAL,
+            provider_type="embedding",
+            field="api_key",
+        )
+        result = str(error)
+        assert "[CRITICAL]" in result
+        assert "embedding" in result
+        assert "Missing API key" in result
+
+    def test_warning_error_string(self) -> None:
+        """Test WARNING error string representation."""
+        error = ValidationError(
+            message="Provider may be unavailable",
+            severity=ValidationSeverity.WARNING,
+            provider_type="summarization",
+        )
+        result = str(error)
+        assert "[WARNING]" in result
+        assert "summarization" in result
+
+
+class TestValidateProviderConfig:
+    """Tests for validate_provider_config function."""
+
+    def test_valid_config_with_env_keys(self) -> None:
+        """Test validation passes when env vars are set."""
+        with patch.dict(os.environ, {
+            "OPENAI_API_KEY": "sk-test-key",
+            "ANTHROPIC_API_KEY": "sk-ant-test",
+        }):
+            settings = ProviderSettings()
+            errors = validate_provider_config(settings)
+            assert len(errors) == 0
+
+    def test_missing_embedding_key_is_critical(self) -> None:
+        """Test missing embedding API key is CRITICAL severity."""
+        with patch.dict(os.environ, {
+            "ANTHROPIC_API_KEY": "sk-ant-test",
+        }, clear=True):
+            # Clear OPENAI_API_KEY
+            os.environ.pop("OPENAI_API_KEY", None)
+
+            settings = ProviderSettings(
+                embedding=EmbeddingConfig(
+                    provider=EmbeddingProviderType.OPENAI,
+                    api_key=None,
+                    api_key_env="OPENAI_API_KEY",
+                ),
+            )
+            errors = validate_provider_config(settings)
+
+            embedding_errors = [e for e in errors if e.provider_type == "embedding"]
+            assert len(embedding_errors) == 1
+            assert embedding_errors[0].severity == ValidationSeverity.CRITICAL
+
+    def test_ollama_no_key_required(self) -> None:
+        """Test Ollama provider doesn't require API key."""
+        settings = ProviderSettings(
+            embedding=EmbeddingConfig(
+                provider=EmbeddingProviderType.OLLAMA,
+                model="nomic-embed-text",
+            ),
+            summarization=SummarizationConfig(
+                provider=SummarizationProviderType.OLLAMA,
+                model="llama3.2",
+            ),
+        )
+        errors = validate_provider_config(settings)
+        # Should have no CRITICAL errors for missing keys
+        critical = [e for e in errors if e.severity == ValidationSeverity.CRITICAL]
+        assert len(critical) == 0
+
+
+class TestHasCriticalErrors:
+    """Tests for has_critical_errors function."""
+
+    def test_returns_true_with_critical(self) -> None:
+        """Test returns True when critical error present."""
+        errors = [
+            ValidationError("warn", ValidationSeverity.WARNING, "test"),
+            ValidationError("crit", ValidationSeverity.CRITICAL, "test"),
+        ]
+        assert has_critical_errors(errors) is True
+
+    def test_returns_false_with_only_warnings(self) -> None:
+        """Test returns False when only warnings present."""
+        errors = [
+            ValidationError("warn1", ValidationSeverity.WARNING, "test"),
+            ValidationError("warn2", ValidationSeverity.WARNING, "test"),
+        ]
+        assert has_critical_errors(errors) is False
+
+    def test_returns_false_with_empty_list(self) -> None:
+        """Test returns False with empty list."""
+        assert has_critical_errors([]) is False
+```
+  </action>
+  <verify>Run `cd agent-brain-server && poetry run pytest tests/unit/config/test_provider_validation.py -v` to run the tests.</verify>
+  <done>Unit tests cover validation severity levels and has_critical_errors function.</done>
+</task>
+
+</tasks>
+
+<verification>
+1. Run `task before-push` from the agent-brain directory to ensure all quality checks pass
+2. Test strict mode behavior:
+   - Start server without API keys: `agent-brain start` (should warn but start)
+   - Start with strict mode: `agent-brain start --strict` (should fail without API keys)
+3. Test /health/providers endpoint:
+   - `curl http://localhost:8000/health/providers` should return provider status
+4. Verify validation error messages include severity level
+5. Run full test suite: `poetry run pytest`
+</verification>
+
+<success_criteria>
+- ValidationError class exists with severity (CRITICAL/WARNING)
+- validate_provider_config returns ValidationError objects
+- has_critical_errors function works correctly
+- FastAPI lifespan fails on critical errors in strict mode
+- CLI start has --strict flag that enables strict mode
+- /health/providers endpoint returns provider status
+- Unit tests pass with >80% coverage for new code
+- `task before-push` passes
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/02-pluggable-providers/02-02-SUMMARY.md`
+</output>

--- a/.planning/phases/02-pluggable-providers/02-03-PLAN.md
+++ b/.planning/phases/02-pluggable-providers/02-03-PLAN.md
@@ -1,0 +1,639 @@
+---
+phase: 02-pluggable-providers
+plan: 03
+type: execute
+wave: 2
+depends_on: ["02-01"]
+files_modified:
+  - e2e/integration/test_provider_switching.py
+  - agent-brain-cli/agent_brain_cli/commands/config.py
+  - agent-brain-cli/agent_brain_cli/cli.py
+  - e2e/fixtures/config_openai.yaml
+  - e2e/fixtures/config_ollama.yaml
+autonomous: true
+
+must_haves:
+  truths:
+    - "E2E test proves provider switching works by changing config file"
+    - "Test verifies different embedding dimensions after provider switch"
+    - "agent-brain config show CLI command displays active configuration"
+    - "Test uses mocked providers to avoid actual API calls"
+  artifacts:
+    - path: "e2e/integration/test_provider_switching.py"
+      provides: "E2E test for provider switching"
+      contains: "test_provider_switch"
+    - path: "agent-brain-cli/agent_brain_cli/commands/config.py"
+      provides: "config show command"
+      contains: "def show"
+  key_links:
+    - from: "agent_brain_cli/cli.py"
+      to: "commands/config.py"
+      via: "config command group import"
+      pattern: "from.*commands.config.*import"
+---
+
+<objective>
+Create E2E test proving provider switching works and add CLI command for configuration debugging.
+
+Purpose: Verify that changing config.yaml and restarting server uses the new provider (PROV-03 verification). Provide `agent-brain config show` for users to debug which config is active.
+
+Output: E2E test for provider switching, test fixtures for different providers, and CLI config show command.
+</objective>
+
+<execution_context>
+@/Users/richardhightower/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/richardhightower/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/phases/02-pluggable-providers/02-RESEARCH.md
+@.planning/phases/02-pluggable-providers/02-01-PLAN.md
+@agent-brain-server/agent_brain_server/config/provider_config.py
+@agent-brain-cli/agent_brain_cli/cli.py
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create test fixtures for different provider configurations</name>
+  <files>e2e/fixtures/config_openai.yaml, e2e/fixtures/config_ollama.yaml</files>
+  <action>
+1. Create the e2e/fixtures directory if it doesn't exist:
+
+```bash
+mkdir -p e2e/fixtures
+```
+
+2. Create `e2e/fixtures/config_openai.yaml`:
+
+```yaml
+# OpenAI provider configuration for E2E testing
+embedding:
+  provider: openai
+  model: text-embedding-3-large
+  api_key_env: OPENAI_API_KEY
+
+summarization:
+  provider: anthropic
+  model: claude-haiku-4-5-20251001
+  api_key_env: ANTHROPIC_API_KEY
+```
+
+3. Create `e2e/fixtures/config_ollama.yaml`:
+
+```yaml
+# Ollama provider configuration for E2E testing (fully offline)
+embedding:
+  provider: ollama
+  model: nomic-embed-text
+  base_url: http://localhost:11434/v1
+
+summarization:
+  provider: ollama
+  model: llama3.2
+  base_url: http://localhost:11434/v1
+```
+
+4. Create `e2e/fixtures/config_cohere.yaml` for dimension testing:
+
+```yaml
+# Cohere provider configuration (different dimensions than OpenAI)
+embedding:
+  provider: cohere
+  model: embed-english-v3.0
+  api_key_env: COHERE_API_KEY
+
+summarization:
+  provider: anthropic
+  model: claude-haiku-4-5-20251001
+  api_key_env: ANTHROPIC_API_KEY
+```
+  </action>
+  <verify>Run `ls -la e2e/fixtures/` to verify fixture files exist.</verify>
+  <done>Test fixture YAML files created for OpenAI, Ollama, and Cohere configurations.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Create E2E test for provider switching</name>
+  <files>e2e/integration/test_provider_switching.py</files>
+  <action>
+Create the test file:
+
+```python
+"""E2E tests for provider switching (PROV-03 verification).
+
+These tests verify that changing config.yaml and restarting the server
+results in using the new provider configuration.
+"""
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any, Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent_brain_server.config.provider_config import (
+    clear_settings_cache,
+    load_provider_settings,
+    _find_config_file,
+)
+from agent_brain_server.providers.base import EmbeddingProviderType
+
+
+# Path to fixture files
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
+
+
+@pytest.fixture
+def temp_project_dir() -> Generator[Path, None, None]:
+    """Create a temporary project directory with .claude/agent-brain structure."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        project_dir = Path(tmpdir)
+        config_dir = project_dir / ".claude" / "agent-brain"
+        config_dir.mkdir(parents=True)
+        yield project_dir
+
+
+@pytest.fixture(autouse=True)
+def clear_config_cache() -> Generator[None, None, None]:
+    """Clear the provider settings cache before and after each test."""
+    clear_settings_cache()
+    yield
+    clear_settings_cache()
+
+
+class TestConfigFileDiscovery:
+    """Tests for configuration file discovery."""
+
+    def test_finds_config_in_project_dir(self, temp_project_dir: Path) -> None:
+        """Test that config is found in .claude/agent-brain/config.yaml."""
+        # Copy OpenAI config to project directory
+        config_path = temp_project_dir / ".claude" / "agent-brain" / "config.yaml"
+        shutil.copy(FIXTURES_DIR / "config_openai.yaml", config_path)
+
+        # Set CWD to project directory
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(temp_project_dir)
+            found = _find_config_file()
+            assert found is not None
+            assert found == config_path
+        finally:
+            os.chdir(original_cwd)
+
+    def test_env_var_override(self, temp_project_dir: Path) -> None:
+        """Test AGENT_BRAIN_CONFIG env var overrides file search."""
+        config_path = temp_project_dir / "custom_config.yaml"
+        shutil.copy(FIXTURES_DIR / "config_ollama.yaml", config_path)
+
+        with patch.dict(os.environ, {"AGENT_BRAIN_CONFIG": str(config_path)}):
+            clear_settings_cache()
+            found = _find_config_file()
+            assert found == config_path
+
+
+class TestProviderSwitching:
+    """Tests for provider switching behavior (PROV-03)."""
+
+    def test_switch_from_openai_to_ollama(self, temp_project_dir: Path) -> None:
+        """Test switching from OpenAI to Ollama provider."""
+        config_path = temp_project_dir / ".claude" / "agent-brain" / "config.yaml"
+
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(temp_project_dir)
+
+            # Start with OpenAI config
+            shutil.copy(FIXTURES_DIR / "config_openai.yaml", config_path)
+            clear_settings_cache()
+
+            settings1 = load_provider_settings()
+            assert settings1.embedding.provider == EmbeddingProviderType.OPENAI
+            assert settings1.embedding.model == "text-embedding-3-large"
+
+            # Switch to Ollama config
+            shutil.copy(FIXTURES_DIR / "config_ollama.yaml", config_path)
+            clear_settings_cache()
+
+            settings2 = load_provider_settings()
+            assert settings2.embedding.provider == EmbeddingProviderType.OLLAMA
+            assert settings2.embedding.model == "nomic-embed-text"
+
+        finally:
+            os.chdir(original_cwd)
+
+    def test_dimension_mismatch_detection(self, temp_project_dir: Path) -> None:
+        """Test that dimension mismatch is detected after provider switch."""
+        from agent_brain_server.storage.vector_store import (
+            EmbeddingMetadata,
+            VectorStoreManager,
+        )
+        from agent_brain_server.providers.exceptions import ProviderMismatchError
+
+        store = VectorStoreManager()
+
+        # Simulate existing OpenAI index (3072 dimensions)
+        stored_metadata = EmbeddingMetadata(
+            provider="openai",
+            model="text-embedding-3-large",
+            dimensions=3072,
+        )
+
+        # Try to use Ollama (768 dimensions) - should raise
+        with pytest.raises(ProviderMismatchError) as exc_info:
+            store.validate_embedding_compatibility(
+                provider="ollama",
+                model="nomic-embed-text",
+                dimensions=768,
+                stored_metadata=stored_metadata,
+            )
+
+        error = exc_info.value
+        assert "openai" in str(error)
+        assert "ollama" in str(error)
+        assert "text-embedding-3-large" in str(error)
+
+
+class TestProviderInstantiation:
+    """Tests for provider instantiation from config."""
+
+    def test_openai_provider_created(self, temp_project_dir: Path) -> None:
+        """Test OpenAI provider is created from config."""
+        config_path = temp_project_dir / ".claude" / "agent-brain" / "config.yaml"
+        shutil.copy(FIXTURES_DIR / "config_openai.yaml", config_path)
+
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(temp_project_dir)
+            clear_settings_cache()
+
+            # Mock the API key
+            with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test-key"}):
+                settings = load_provider_settings()
+                from agent_brain_server.providers.factory import ProviderRegistry
+
+                # This should create OpenAI provider (mocked)
+                with patch(
+                    "agent_brain_server.providers.embedding.openai.openai"
+                ) as mock_openai:
+                    provider = ProviderRegistry.get_embedding_provider(settings.embedding)
+                    assert provider.provider_name == "openai"
+                    assert provider.get_dimensions() == 3072
+
+        finally:
+            os.chdir(original_cwd)
+
+    def test_ollama_provider_no_api_key_needed(self, temp_project_dir: Path) -> None:
+        """Test Ollama provider doesn't require API key."""
+        config_path = temp_project_dir / ".claude" / "agent-brain" / "config.yaml"
+        shutil.copy(FIXTURES_DIR / "config_ollama.yaml", config_path)
+
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(temp_project_dir)
+            clear_settings_cache()
+
+            settings = load_provider_settings()
+
+            # Ollama config should not need API key
+            assert settings.embedding.get_api_key() is None
+            assert settings.summarization.get_api_key() is None
+
+        finally:
+            os.chdir(original_cwd)
+
+
+class TestConfigShowCommand:
+    """Tests for agent-brain config show CLI command."""
+
+    def test_config_show_displays_active_config(
+        self, temp_project_dir: Path
+    ) -> None:
+        """Test config show command displays the active configuration."""
+        from click.testing import CliRunner
+        from agent_brain_cli.commands.config import show_config
+
+        config_path = temp_project_dir / ".claude" / "agent-brain" / "config.yaml"
+        shutil.copy(FIXTURES_DIR / "config_openai.yaml", config_path)
+
+        runner = CliRunner()
+
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(temp_project_dir)
+            clear_settings_cache()
+
+            with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}):
+                result = runner.invoke(show_config)
+                assert result.exit_code == 0
+                assert "openai" in result.output.lower()
+                assert "text-embedding-3-large" in result.output
+
+        finally:
+            os.chdir(original_cwd)
+```
+  </action>
+  <verify>Run `cd agent-brain-server && poetry run pytest e2e/integration/test_provider_switching.py -v --tb=short` to run the tests (some may fail if providers not mocked correctly; adjust as needed).</verify>
+  <done>E2E test file created with tests for provider switching, dimension mismatch detection, and config show command.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Create config CLI command module</name>
+  <files>agent-brain-cli/agent_brain_cli/commands/config.py</files>
+  <action>
+Create the config command module:
+
+```python
+"""Config commands for viewing and managing Agent Brain configuration."""
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+import click
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+console = Console()
+
+
+def _find_config_file() -> Optional[Path]:
+    """Find the configuration file in standard locations.
+
+    Search order:
+    1. AGENT_BRAIN_CONFIG environment variable
+    2. State directory config.yaml (if AGENT_BRAIN_STATE_DIR set)
+    3. Current directory config.yaml
+    4. Walk up from CWD looking for .claude/agent-brain/config.yaml
+    5. User home ~/.agent-brain/config.yaml
+    6. XDG config ~/.config/agent-brain/config.yaml
+
+    Returns:
+        Path to config file or None if not found
+    """
+    # 1. Environment variable override
+    env_config = os.getenv("AGENT_BRAIN_CONFIG")
+    if env_config:
+        path = Path(env_config)
+        if path.exists():
+            return path
+
+    # 2. State directory
+    state_dir = os.getenv("AGENT_BRAIN_STATE_DIR") or os.getenv("DOC_SERVE_STATE_DIR")
+    if state_dir:
+        state_config = Path(state_dir) / "config.yaml"
+        if state_config.exists():
+            return state_config
+
+    # 3. Current directory
+    cwd_config = Path.cwd() / "config.yaml"
+    if cwd_config.exists():
+        return cwd_config
+
+    # 4. Walk up from CWD
+    current = Path.cwd()
+    root = Path(current.anchor)
+    while current != root:
+        claude_config = current / ".claude" / "agent-brain" / "config.yaml"
+        if claude_config.exists():
+            return claude_config
+        current = current.parent
+
+    # 5. User home
+    home_config = Path.home() / ".agent-brain" / "config.yaml"
+    if home_config.exists():
+        return home_config
+
+    # 6. XDG config
+    xdg_config = Path.home() / ".config" / "agent-brain" / "config.yaml"
+    if xdg_config.exists():
+        return xdg_config
+
+    return None
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    """Load YAML configuration file."""
+    import yaml
+
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+
+@click.group("config")
+def config_group() -> None:
+    """View and manage Agent Brain configuration.
+
+    \b
+    Commands:
+      show   - Display active configuration
+      path   - Show config file location
+    """
+    pass
+
+
+@config_group.command("show")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+def show_config(json_output: bool) -> None:
+    """Display the active provider configuration.
+
+    Shows which config file is being used and the current provider settings
+    for embedding, summarization, and reranking.
+
+    \b
+    Examples:
+      agent-brain config show           # Rich formatted output
+      agent-brain config show --json    # JSON output for scripting
+    """
+    config_path = _find_config_file()
+
+    if json_output:
+        output: dict[str, Any] = {
+            "config_file": str(config_path) if config_path else None,
+            "config_source": "file" if config_path else "defaults",
+        }
+
+        if config_path:
+            config = _load_yaml(config_path)
+            output["embedding"] = config.get("embedding", {})
+            output["summarization"] = config.get("summarization", {})
+            output["reranker"] = config.get("reranker", {})
+        else:
+            output["embedding"] = {
+                "provider": "openai",
+                "model": "text-embedding-3-large",
+            }
+            output["summarization"] = {
+                "provider": "anthropic",
+                "model": "claude-haiku-4-5-20251001",
+            }
+
+        click.echo(json.dumps(output, indent=2))
+        return
+
+    # Rich formatted output
+    if config_path:
+        console.print(f"\n[bold]Config file:[/] {config_path}\n")
+        config = _load_yaml(config_path)
+    else:
+        console.print(
+            "\n[yellow]No config file found, using defaults[/]\n"
+        )
+        config = {}
+
+    # Embedding provider
+    embedding = config.get("embedding", {})
+    embed_table = Table(title="Embedding Provider", show_header=False)
+    embed_table.add_column("Setting", style="cyan")
+    embed_table.add_column("Value")
+    embed_table.add_row("Provider", embedding.get("provider", "openai"))
+    embed_table.add_row("Model", embedding.get("model", "text-embedding-3-large"))
+    embed_table.add_row("API Key Env", embedding.get("api_key_env", "OPENAI_API_KEY"))
+    if embedding.get("base_url"):
+        embed_table.add_row("Base URL", embedding["base_url"])
+    console.print(embed_table)
+
+    # Summarization provider
+    summarization = config.get("summarization", {})
+    summ_table = Table(title="Summarization Provider", show_header=False)
+    summ_table.add_column("Setting", style="cyan")
+    summ_table.add_column("Value")
+    summ_table.add_row("Provider", summarization.get("provider", "anthropic"))
+    summ_table.add_row("Model", summarization.get("model", "claude-haiku-4-5-20251001"))
+    summ_table.add_row(
+        "API Key Env", summarization.get("api_key_env", "ANTHROPIC_API_KEY")
+    )
+    if summarization.get("base_url"):
+        summ_table.add_row("Base URL", summarization["base_url"])
+    console.print(summ_table)
+
+    # Reranker (if configured)
+    reranker = config.get("reranker", {})
+    if reranker:
+        rerank_table = Table(title="Reranker Provider", show_header=False)
+        rerank_table.add_column("Setting", style="cyan")
+        rerank_table.add_column("Value")
+        rerank_table.add_row(
+            "Provider", reranker.get("provider", "sentence-transformers")
+        )
+        rerank_table.add_row(
+            "Model", reranker.get("model", "cross-encoder/ms-marco-MiniLM-L-6-v2")
+        )
+        if reranker.get("base_url"):
+            rerank_table.add_row("Base URL", reranker["base_url"])
+        console.print(rerank_table)
+
+    console.print()
+
+
+@config_group.command("path")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+def config_path(json_output: bool) -> None:
+    """Show the path to the active config file.
+
+    \b
+    Examples:
+      agent-brain config path           # Print config file path
+      agent-brain config path --json    # JSON output
+    """
+    config_path = _find_config_file()
+
+    if json_output:
+        click.echo(
+            json.dumps({
+                "config_file": str(config_path) if config_path else None,
+                "exists": config_path.exists() if config_path else False,
+            })
+        )
+        return
+
+    if config_path:
+        console.print(f"[green]{config_path}[/]")
+    else:
+        console.print("[yellow]No config file found[/]")
+```
+  </action>
+  <verify>Run `cd agent-brain-cli && poetry run python -c "from agent_brain_cli.commands.config import config_group; print('Config command imported successfully')"` to verify import works.</verify>
+  <done>Config CLI command module created with show and path subcommands.</done>
+</task>
+
+<task type="auto">
+  <name>Task 4: Register config command in CLI main module</name>
+  <files>agent-brain-cli/agent_brain_cli/cli.py</files>
+  <action>
+1. Add import for the config command group:
+
+```python
+from agent_brain_cli.commands.config import config_group
+```
+
+2. Register the command group with the main CLI:
+
+```python
+# In the CLI setup section, after other command registrations:
+cli.add_command(config_group, name="config")
+```
+
+This makes `agent-brain config show` and `agent-brain config path` available.
+  </action>
+  <verify>Run `cd agent-brain-cli && poetry run agent-brain config --help` to verify the command group is registered.</verify>
+  <done>Config command group registered in main CLI.</done>
+</task>
+
+<task type="auto">
+  <name>Task 5: Add PyYAML dependency to CLI if not present</name>
+  <files>agent-brain-cli/pyproject.toml</files>
+  <action>
+Check if PyYAML is already a dependency. If not, add it:
+
+```bash
+cd agent-brain-cli && poetry add pyyaml
+```
+
+Or manually add to pyproject.toml under [tool.poetry.dependencies]:
+
+```toml
+pyyaml = "^6.0"
+```
+  </action>
+  <verify>Run `cd agent-brain-cli && poetry show pyyaml` to verify PyYAML is installed.</verify>
+  <done>PyYAML dependency available in CLI package.</done>
+</task>
+
+</tasks>
+
+<verification>
+1. Run `task before-push` from the agent-brain directory to ensure all quality checks pass
+2. Test config commands:
+   - `agent-brain config show` - should display active configuration
+   - `agent-brain config path` - should show config file path
+   - `agent-brain config show --json` - should output JSON
+3. Run E2E tests:
+   - `cd agent-brain-server && poetry run pytest e2e/integration/test_provider_switching.py -v`
+4. Verify provider switching works:
+   - Create config with OpenAI, note embedding dimensions
+   - Change to Ollama config
+   - Verify config show reflects the change
+5. Run full test suite: `poetry run pytest`
+</verification>
+
+<success_criteria>
+- E2E test file exists with tests for provider switching
+- Test fixtures exist for OpenAI, Ollama, and Cohere configurations
+- agent-brain config show displays active configuration
+- agent-brain config path shows config file location
+- Tests verify dimension mismatch detection works
+- All tests pass
+- `task before-push` passes
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/02-pluggable-providers/02-03-SUMMARY.md`
+</output>

--- a/.planning/phases/02-pluggable-providers/02-04-PLAN.md
+++ b/.planning/phases/02-pluggable-providers/02-04-PLAN.md
@@ -1,0 +1,615 @@
+---
+phase: 02-pluggable-providers
+plan: 04
+type: execute
+wave: 2
+depends_on: ["02-02"]
+files_modified:
+  - e2e/integration/test_ollama_offline.py
+  - e2e/fixtures/config_ollama_only.yaml
+autonomous: true
+
+must_haves:
+  truths:
+    - "E2E test runs with Ollama-only configuration"
+    - "Test verifies no external API calls are made"
+    - "Test gracefully handles Ollama not running"
+    - "Test documents fully offline operation capability"
+  artifacts:
+    - path: "e2e/integration/test_ollama_offline.py"
+      provides: "E2E test for Ollama offline mode"
+      contains: "test_ollama_offline"
+    - path: "e2e/fixtures/config_ollama_only.yaml"
+      provides: "Ollama-only configuration"
+      contains: "provider: ollama"
+  key_links: []
+---
+
+<objective>
+Create E2E test verifying fully offline operation with Ollama-only configuration.
+
+Purpose: Prove that Agent Brain can operate without any external API calls when using Ollama for both embeddings and summarization (PROV-04 verification).
+
+Output: E2E test for Ollama offline mode with proper graceful degradation when Ollama is unavailable.
+</objective>
+
+<execution_context>
+@/Users/richardhightower/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/richardhightower/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/phases/02-pluggable-providers/02-RESEARCH.md
+@.planning/phases/02-pluggable-providers/02-02-PLAN.md
+@agent-brain-server/agent_brain_server/providers/embedding/ollama.py
+@agent-brain-server/agent_brain_server/providers/summarization/ollama.py
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create Ollama-only configuration fixture</name>
+  <files>e2e/fixtures/config_ollama_only.yaml</files>
+  <action>
+Create the configuration file:
+
+```yaml
+# Ollama-only configuration for fully offline operation
+# No external API calls are made with this configuration
+
+embedding:
+  provider: ollama
+  model: nomic-embed-text
+  base_url: http://localhost:11434/v1
+  params:
+    # Ollama embedding batch size (reduce for memory-constrained systems)
+    batch_size: 64
+
+summarization:
+  provider: ollama
+  model: llama3.2
+  base_url: http://localhost:11434/v1
+  params:
+    # Summarization parameters
+    max_tokens: 500
+    temperature: 0.3
+
+# Reranker can also use Ollama for fully offline operation
+reranker:
+  provider: ollama
+  model: llama3.2
+  base_url: http://localhost:11434
+```
+
+This configuration ensures:
+- No OpenAI API calls (embedding uses Ollama)
+- No Anthropic API calls (summarization uses Ollama)
+- Fully local operation
+  </action>
+  <verify>Run `cat e2e/fixtures/config_ollama_only.yaml` to verify the file exists with correct content.</verify>
+  <done>Ollama-only configuration fixture created.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Create E2E test for Ollama offline mode</name>
+  <files>e2e/integration/test_ollama_offline.py</files>
+  <action>
+Create the test file:
+
+```python
+"""E2E tests for Ollama offline mode (PROV-04 verification).
+
+These tests verify that Agent Brain can operate fully offline using
+Ollama for both embeddings and summarization, without making any
+external API calls.
+"""
+
+import os
+import shutil
+import socket
+import tempfile
+from pathlib import Path
+from typing import Any, Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent_brain_server.config.provider_config import (
+    clear_settings_cache,
+    load_provider_settings,
+    validate_provider_config,
+)
+from agent_brain_server.providers.base import (
+    EmbeddingProviderType,
+    SummarizationProviderType,
+)
+from agent_brain_server.providers.exceptions import OllamaConnectionError
+
+
+# Path to fixture files
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
+
+
+def is_ollama_running(host: str = "localhost", port: int = 11434) -> bool:
+    """Check if Ollama is running on the specified host:port."""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.settimeout(1.0)
+            s.connect((host, port))
+            return True
+    except (socket.error, socket.timeout):
+        return False
+
+
+@pytest.fixture
+def temp_project_dir() -> Generator[Path, None, None]:
+    """Create a temporary project directory with .claude/agent-brain structure."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        project_dir = Path(tmpdir)
+        config_dir = project_dir / ".claude" / "agent-brain"
+        config_dir.mkdir(parents=True)
+        yield project_dir
+
+
+@pytest.fixture(autouse=True)
+def clear_config_cache() -> Generator[None, None, None]:
+    """Clear the provider settings cache before and after each test."""
+    clear_settings_cache()
+    yield
+    clear_settings_cache()
+
+
+class TestOllamaConfiguration:
+    """Tests for Ollama-only configuration."""
+
+    def test_ollama_config_loads_correctly(self, temp_project_dir: Path) -> None:
+        """Test Ollama-only config loads with correct provider types."""
+        config_path = temp_project_dir / ".claude" / "agent-brain" / "config.yaml"
+        shutil.copy(FIXTURES_DIR / "config_ollama_only.yaml", config_path)
+
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(temp_project_dir)
+            clear_settings_cache()
+
+            settings = load_provider_settings()
+
+            # Verify embedding provider is Ollama
+            assert settings.embedding.provider == EmbeddingProviderType.OLLAMA
+            assert settings.embedding.model == "nomic-embed-text"
+            assert "localhost:11434" in (settings.embedding.get_base_url() or "")
+
+            # Verify summarization provider is Ollama
+            assert settings.summarization.provider == SummarizationProviderType.OLLAMA
+            assert settings.summarization.model == "llama3.2"
+
+        finally:
+            os.chdir(original_cwd)
+
+    def test_ollama_no_api_keys_required(self, temp_project_dir: Path) -> None:
+        """Test Ollama config doesn't require any API keys."""
+        config_path = temp_project_dir / ".claude" / "agent-brain" / "config.yaml"
+        shutil.copy(FIXTURES_DIR / "config_ollama_only.yaml", config_path)
+
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(temp_project_dir)
+            clear_settings_cache()
+
+            settings = load_provider_settings()
+
+            # Verify no API keys are needed
+            assert settings.embedding.get_api_key() is None
+            assert settings.summarization.get_api_key() is None
+
+            # Verify validation passes (no critical errors)
+            errors = validate_provider_config(settings)
+            critical = [e for e in errors if e.severity.value == "critical"]
+            assert len(critical) == 0, f"Unexpected critical errors: {critical}"
+
+        finally:
+            os.chdir(original_cwd)
+
+
+class TestNoExternalApiCalls:
+    """Tests verifying no external API calls are made with Ollama config."""
+
+    def test_no_openai_calls(self, temp_project_dir: Path) -> None:
+        """Test that no OpenAI API calls are made."""
+        config_path = temp_project_dir / ".claude" / "agent-brain" / "config.yaml"
+        shutil.copy(FIXTURES_DIR / "config_ollama_only.yaml", config_path)
+
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(temp_project_dir)
+            clear_settings_cache()
+
+            # Mock httpx to track outgoing requests
+            with patch("httpx.AsyncClient.post") as mock_post:
+                with patch("httpx.AsyncClient.get") as mock_get:
+                    settings = load_provider_settings()
+
+                    # Create embedding provider (mocked Ollama)
+                    with patch(
+                        "agent_brain_server.providers.embedding.ollama.httpx"
+                    ) as mock_httpx:
+                        mock_client = MagicMock()
+                        mock_httpx.AsyncClient.return_value.__aenter__.return_value = (
+                            mock_client
+                        )
+
+                        from agent_brain_server.providers.factory import ProviderRegistry
+
+                        provider = ProviderRegistry.get_embedding_provider(
+                            settings.embedding
+                        )
+
+                        # Check that provider is Ollama
+                        assert provider.provider_name == "ollama"
+
+                        # Verify no calls to api.openai.com
+                        for call in mock_post.call_args_list:
+                            url = str(call[0][0]) if call[0] else ""
+                            assert "openai.com" not in url
+                            assert "anthropic.com" not in url
+
+        finally:
+            os.chdir(original_cwd)
+
+    def test_no_anthropic_calls(self, temp_project_dir: Path) -> None:
+        """Test that no Anthropic API calls are made."""
+        config_path = temp_project_dir / ".claude" / "agent-brain" / "config.yaml"
+        shutil.copy(FIXTURES_DIR / "config_ollama_only.yaml", config_path)
+
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(temp_project_dir)
+            clear_settings_cache()
+
+            settings = load_provider_settings()
+
+            # Mock the anthropic client to ensure it's never called
+            with patch("anthropic.AsyncAnthropic") as mock_anthropic:
+                from agent_brain_server.providers.factory import ProviderRegistry
+
+                provider = ProviderRegistry.get_summarization_provider(
+                    settings.summarization
+                )
+
+                # Check that provider is Ollama
+                assert provider.provider_name == "ollama"
+
+                # Anthropic client should not be instantiated
+                mock_anthropic.assert_not_called()
+
+        finally:
+            os.chdir(original_cwd)
+
+
+class TestOllamaGracefulDegradation:
+    """Tests for graceful degradation when Ollama is unavailable."""
+
+    def test_connection_error_when_ollama_down(self, temp_project_dir: Path) -> None:
+        """Test appropriate error when Ollama is not running."""
+        config_path = temp_project_dir / ".claude" / "agent-brain" / "config.yaml"
+        shutil.copy(FIXTURES_DIR / "config_ollama_only.yaml", config_path)
+
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(temp_project_dir)
+            clear_settings_cache()
+
+            settings = load_provider_settings()
+
+            # Mock Ollama being unavailable
+            with patch(
+                "agent_brain_server.providers.embedding.ollama.httpx.AsyncClient"
+            ) as mock_client:
+                import httpx
+
+                mock_instance = MagicMock()
+                mock_client.return_value.__aenter__.return_value = mock_instance
+                mock_instance.post.side_effect = httpx.ConnectError(
+                    "Connection refused"
+                )
+
+                from agent_brain_server.providers.factory import ProviderRegistry
+
+                provider = ProviderRegistry.get_embedding_provider(settings.embedding)
+
+                # Attempt to embed should raise OllamaConnectionError
+                with pytest.raises(OllamaConnectionError) as exc_info:
+                    import asyncio
+
+                    asyncio.get_event_loop().run_until_complete(
+                        provider.embed_text("test")
+                    )
+
+                assert "Cannot connect to Ollama" in str(exc_info.value)
+                assert "localhost:11434" in str(exc_info.value)
+
+        finally:
+            os.chdir(original_cwd)
+
+    def test_health_check_reports_ollama_status(self, temp_project_dir: Path) -> None:
+        """Test that health check accurately reports Ollama provider status."""
+        config_path = temp_project_dir / ".claude" / "agent-brain" / "config.yaml"
+        shutil.copy(FIXTURES_DIR / "config_ollama_only.yaml", config_path)
+
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(temp_project_dir)
+            clear_settings_cache()
+
+            settings = load_provider_settings()
+
+            # Check if Ollama is actually running
+            ollama_running = is_ollama_running()
+
+            from agent_brain_server.providers.factory import ProviderRegistry
+
+            try:
+                provider = ProviderRegistry.get_embedding_provider(settings.embedding)
+                provider_created = True
+            except Exception:
+                provider_created = False
+
+            # Provider should be created regardless of Ollama status
+            # (actual connection happens on first embed call)
+            if provider_created:
+                assert provider.provider_name == "ollama"
+
+        finally:
+            os.chdir(original_cwd)
+
+
+@pytest.mark.skipif(
+    not is_ollama_running(),
+    reason="Ollama not running - skipping live integration test",
+)
+class TestOllamaLiveIntegration:
+    """Live integration tests that require Ollama to be running.
+
+    These tests are skipped if Ollama is not available.
+    Run with: pytest -m "not skip" to include when Ollama is running.
+    """
+
+    def test_ollama_embedding_returns_vector(self, temp_project_dir: Path) -> None:
+        """Test that Ollama returns actual embeddings when running."""
+        config_path = temp_project_dir / ".claude" / "agent-brain" / "config.yaml"
+        shutil.copy(FIXTURES_DIR / "config_ollama_only.yaml", config_path)
+
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(temp_project_dir)
+            clear_settings_cache()
+
+            settings = load_provider_settings()
+
+            from agent_brain_server.providers.factory import ProviderRegistry
+
+            provider = ProviderRegistry.get_embedding_provider(settings.embedding)
+
+            # Actually call Ollama
+            import asyncio
+
+            embedding = asyncio.get_event_loop().run_until_complete(
+                provider.embed_text("Hello, world!")
+            )
+
+            # Verify we got a vector
+            assert isinstance(embedding, list)
+            assert len(embedding) > 0
+            assert all(isinstance(x, float) for x in embedding)
+
+            # nomic-embed-text produces 768-dimensional vectors
+            assert len(embedding) == 768
+
+        finally:
+            os.chdir(original_cwd)
+
+    def test_ollama_summarization_returns_text(self, temp_project_dir: Path) -> None:
+        """Test that Ollama returns actual summaries when running."""
+        config_path = temp_project_dir / ".claude" / "agent-brain" / "config.yaml"
+        shutil.copy(FIXTURES_DIR / "config_ollama_only.yaml", config_path)
+
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(temp_project_dir)
+            clear_settings_cache()
+
+            settings = load_provider_settings()
+
+            from agent_brain_server.providers.factory import ProviderRegistry
+
+            provider = ProviderRegistry.get_summarization_provider(
+                settings.summarization
+            )
+
+            # Actually call Ollama
+            import asyncio
+
+            code = '''
+            def hello():
+                """Say hello to the world."""
+                print("Hello, world!")
+            '''
+
+            summary = asyncio.get_event_loop().run_until_complete(
+                provider.summarize(code)
+            )
+
+            # Verify we got text back
+            assert isinstance(summary, str)
+            assert len(summary) > 10
+
+        finally:
+            os.chdir(original_cwd)
+
+
+class TestOfflineDocumentation:
+    """Tests that document offline operation capabilities."""
+
+    def test_offline_config_documented(self) -> None:
+        """Verify offline configuration fixture is properly documented."""
+        config_path = FIXTURES_DIR / "config_ollama_only.yaml"
+        content = config_path.read_text()
+
+        # Verify documentation is present
+        assert "fully offline" in content.lower() or "offline" in content.lower()
+        assert "no external api" in content.lower() or "no api calls" in content.lower()
+
+    def test_all_providers_support_ollama(self) -> None:
+        """Verify all provider types support Ollama backend."""
+        from agent_brain_server.providers.base import (
+            EmbeddingProviderType,
+            SummarizationProviderType,
+            RerankerProviderType,
+        )
+
+        # All provider types should have OLLAMA option
+        assert EmbeddingProviderType.OLLAMA.value == "ollama"
+        assert SummarizationProviderType.OLLAMA.value == "ollama"
+        assert RerankerProviderType.OLLAMA.value == "ollama"
+```
+  </action>
+  <verify>Run `cd agent-brain-server && poetry run pytest e2e/integration/test_ollama_offline.py -v --tb=short` to run the tests.</verify>
+  <done>E2E test file created for Ollama offline mode verification.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Add pytest marker for Ollama tests</name>
+  <files>agent-brain-server/pytest.ini or agent-brain-server/pyproject.toml</files>
+  <action>
+Add pytest marker configuration for Ollama tests. In `pyproject.toml` under `[tool.pytest.ini_options]`:
+
+```toml
+[tool.pytest.ini_options]
+markers = [
+    "ollama: marks tests that require Ollama to be running",
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
+```
+
+Or in `pytest.ini`:
+
+```ini
+[pytest]
+markers =
+    ollama: marks tests that require Ollama to be running
+    slow: marks tests as slow
+```
+
+This allows running:
+- `pytest -m "not ollama"` to skip Ollama tests when Ollama is down
+- `pytest -m ollama` to run only Ollama tests
+  </action>
+  <verify>Run `cd agent-brain-server && poetry run pytest --markers | grep ollama` to verify the marker is registered.</verify>
+  <done>Pytest marker configured for Ollama-dependent tests.</done>
+</task>
+
+<task type="auto">
+  <name>Task 4: Update PROV-04 documentation</name>
+  <files>e2e/integration/test_ollama_offline.py</files>
+  <action>
+Add comprehensive docstring at the top of the test file documenting PROV-04:
+
+```python
+"""E2E tests for Ollama offline mode (PROV-04 verification).
+
+PROV-04 Requirement: Fully offline operation with Ollama
+=========================================================
+
+Agent Brain must be able to operate fully offline when configured with
+Ollama for both embeddings and summarization. This means:
+
+1. No external API calls to OpenAI, Anthropic, Cohere, or other cloud services
+2. No API keys required for operation
+3. Graceful error handling when Ollama is unavailable
+4. Clear documentation of offline configuration
+
+Test Categories
+---------------
+
+1. Configuration Tests (TestOllamaConfiguration)
+   - Verify Ollama-only config loads correctly
+   - Verify no API keys are required
+
+2. No External API Tests (TestNoExternalApiCalls)
+   - Verify no OpenAI calls are made
+   - Verify no Anthropic calls are made
+
+3. Graceful Degradation Tests (TestOllamaGracefulDegradation)
+   - Verify appropriate errors when Ollama is down
+   - Verify health check reports Ollama status
+
+4. Live Integration Tests (TestOllamaLiveIntegration)
+   - Test actual embedding generation (requires Ollama running)
+   - Test actual summarization (requires Ollama running)
+
+Running Tests
+-------------
+
+With Ollama running:
+    pytest e2e/integration/test_ollama_offline.py -v
+
+Without Ollama (skips live tests):
+    pytest e2e/integration/test_ollama_offline.py -v
+
+Only live tests:
+    pytest e2e/integration/test_ollama_offline.py -v -k "Live"
+
+Configuration
+-------------
+
+Use e2e/fixtures/config_ollama_only.yaml for fully offline operation.
+
+Requirements:
+- Ollama installed: https://ollama.ai
+- Models pulled: ollama pull nomic-embed-text && ollama pull llama3.2
+- Ollama running: ollama serve
+"""
+```
+
+This docstring is already included in the test file from Task 2, but ensure it's complete.
+  </action>
+  <verify>Run `head -50 e2e/integration/test_ollama_offline.py` to verify documentation is present.</verify>
+  <done>PROV-04 documentation added to test file.</done>
+</task>
+
+</tasks>
+
+<verification>
+1. Run `task before-push` from the agent-brain directory to ensure all quality checks pass
+2. Test with Ollama running:
+   - Start Ollama: `ollama serve`
+   - Run tests: `pytest e2e/integration/test_ollama_offline.py -v`
+   - Verify live tests pass
+3. Test without Ollama:
+   - Stop Ollama
+   - Run tests: `pytest e2e/integration/test_ollama_offline.py -v`
+   - Verify live tests are skipped
+   - Verify graceful degradation tests pass
+4. Verify no external API calls:
+   - Check mock assertions in test output
+   - Verify no calls to openai.com or anthropic.com
+5. Run full test suite: `poetry run pytest`
+</verification>
+
+<success_criteria>
+- config_ollama_only.yaml fixture exists with full offline config
+- E2E test file exists with comprehensive Ollama tests
+- Tests verify no external API calls are made
+- Tests handle Ollama unavailability gracefully
+- Live integration tests are properly skipped when Ollama is down
+- pytest marker configured for Ollama tests
+- Documentation clearly explains PROV-04 requirements
+- All tests pass
+- `task before-push` passes
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/02-pluggable-providers/02-04-SUMMARY.md`
+</output>

--- a/.planning/phases/02-pluggable-providers/02-RESEARCH.md
+++ b/.planning/phases/02-pluggable-providers/02-RESEARCH.md
@@ -1,0 +1,237 @@
+# Phase 2: Pluggable Providers - Research Findings
+
+**Date:** 2026-02-08
+**Status:** Research Complete
+
+## Executive Summary
+
+The provider infrastructure is **substantially implemented** but has critical gaps in validation, testing, and documentation. The core architecture (factory, config, providers) works. The main gaps are:
+
+1. **PROV-07 is NOT implemented** - No dimension mismatch detection
+2. **PROV-03 is PARTIALLY done** - Config switching works but lacks E2E verification
+3. **PROV-06 is PARTIAL** - Startup validation exists but doesn't fail on critical errors
+4. Integration tests for provider combinations are missing
+
+---
+
+## Requirements Status Table
+
+| Requirement | Status | Evidence | Gap |
+|-------------|--------|----------|-----|
+| **PROV-01** | DONE | `provider_config.py` EmbeddingConfig, YAML loading, OpenAI/Ollama/Cohere registered | None |
+| **PROV-02** | DONE | `provider_config.py` SummarizationConfig, Anthropic/OpenAI/Gemini/Grok/Ollama registered | None |
+| **PROV-03** | PARTIAL | Config file switching implemented; tested in `test_config.py` | No E2E test proving runtime switching works |
+| **PROV-04** | DONE | Ollama providers exist; `get_api_key()` returns None for Ollama; `health_check()` implemented | No offline mode E2E test |
+| **PROV-05** | DONE | `api_key_env` field, `get_api_key()` reads from `os.getenv()`, never stores keys in YAML | None |
+| **PROV-06** | PARTIAL | `validate_provider_config()` called in `lifespan()`, logs warnings | Does NOT fail on critical errors - only warns |
+| **PROV-07** | MISSING | `ProviderMismatchError` defined but **never raised**; no dimension check on index | Need dimension validation during indexing |
+
+---
+
+## Detailed Gap Analysis
+
+### PROV-03: Config-Only Switching (PARTIAL)
+
+**What Works:**
+- `_find_config_file()` searches standard locations
+- `load_provider_settings()` parses YAML to Pydantic models
+- `ProviderRegistry.get_embedding_provider()` instantiates based on config
+- Unit tests verify config parsing
+
+**Gap:**
+- No E2E test proving: "change config.yaml -> restart server -> different provider used"
+- No CLI command to show active provider configuration
+
+**Recommendation:** Add integration test for provider switching
+
+### PROV-06: Startup Validation (PARTIAL)
+
+**What Works:**
+```python
+# In api/main.py lifespan():
+validation_errors = validate_provider_config(provider_settings)
+if validation_errors:
+    for error in validation_errors:
+        logger.warning(f"Provider config warning: {error}")
+    # Log but don't fail - providers may work if keys are set later
+```
+
+**Gap:**
+- Validation only **warns** - server starts even with missing API keys
+- No distinction between critical (OpenAI without key) vs recoverable errors
+- Comment suggests this is intentional: "providers may work if keys are set later"
+
+**Risk:**
+- User runs server, starts indexing, gets cryptic error later
+- Better to fail fast on startup
+
+**Recommendation:**
+1. Add `--strict` flag to fail on validation errors
+2. Add health endpoint `/health/providers` showing provider status
+3. Distinguish between "configured but untested" vs "critical missing"
+
+### PROV-07: Dimension Mismatch (MISSING)
+
+**What Exists:**
+- Each provider implements `get_dimensions()` with correct values:
+  - OpenAI: 3072 (text-embedding-3-large), 1536 (small/ada-002)
+  - Ollama: 768 (nomic-embed-text), 1024 (mxbai-embed-large)
+  - Cohere: 1024 (v3.0), 384 (light-v3.0)
+- `ProviderMismatchError` exception defined in `providers/exceptions.py`
+- Exception is **never raised** anywhere in code
+
+**Gap:**
+- ChromaDB collection has no metadata about which provider/model created it
+- No check on indexing: "Does new embedding dimension match existing?"
+- No check on query: "Is query embedding same dimension as index?"
+
+**What Could Go Wrong:**
+1. User indexes with OpenAI (3072d), changes to Ollama (768d)
+2. Query embedding is 768d, stored embeddings are 3072d
+3. ChromaDB may silently fail or return garbage results
+
+**Recommendation:**
+1. Store embedding config metadata in collection on creation
+2. Validate on startup: if collection exists, check dimensions match
+3. Validate on indexing: reject if dimension mismatch
+4. Add `--force` flag to allow re-indexing with different provider
+
+---
+
+## Key Files That Need Modification
+
+### For PROV-06 Enhancement (Strict Validation)
+
+| File | Change |
+|------|--------|
+| `agent_brain_server/api/main.py` | Add strict mode, fail on critical validation errors |
+| `agent_brain_server/config/provider_config.py` | Add severity levels to validation errors |
+| `agent_brain_cli/commands/*.py` | Add `--strict` flag to start command |
+
+### For PROV-07 (Dimension Mismatch)
+
+| File | Change |
+|------|--------|
+| `agent_brain_server/storage/vector_store.py` | Store/check embedding metadata in collection |
+| `agent_brain_server/services/indexing_service.py` | Validate dimensions before indexing |
+| `agent_brain_server/services/query_service.py` | Validate query embedding dimensions |
+| `agent_brain_server/api/main.py` | Dimension validation in startup |
+
+### For PROV-03 Testing
+
+| File | Change |
+|------|--------|
+| `e2e/integration/test_provider_switching.py` | NEW - E2E test for provider switching |
+| `e2e/fixtures/` | Add config.yaml variants for different providers |
+
+---
+
+## Risks and Pitfalls
+
+### 1. ChromaDB Dimension Handling
+ChromaDB does NOT enforce dimensions - it will silently accept mismatched vectors. This can lead to:
+- Corrupted similarity scores
+- Silent search quality degradation
+- Difficult-to-debug issues
+
+**Mitigation:** Explicit dimension validation before any vector operation.
+
+### 2. Ollama Connection at Startup
+If Ollama is configured but not running, `health_check()` fails. Current behavior:
+- Logs warning
+- Server continues
+- First indexing operation fails with `OllamaConnectionError`
+
+**Recommendation:** Add optional startup health check for local providers.
+
+### 3. Mixed Provider Index
+If a user indexed with OpenAI, then switches to Cohere (both 1024d for some models), embeddings are semantically incompatible even if dimensions match.
+
+**Recommendation:** Track provider name + model, not just dimensions.
+
+### 4. Config File Discovery Race
+Multiple config search paths could lead to unexpected behavior if user has both project and home configs.
+
+**Currently:** First match wins. Logged at DEBUG level.
+**Recommendation:** Add `agent-brain config show` command to display active config source.
+
+---
+
+## Test Coverage Analysis
+
+### Existing Tests
+
+| Test File | Coverage |
+|-----------|----------|
+| `tests/unit/providers/test_config.py` | YAML loading, validation, defaults |
+| `tests/unit/providers/test_factory.py` | Registry, caching, error handling |
+| `tests/unit/providers/test_openai_embedding.py` | Dimensions, batch embedding, errors |
+| `tests/unit/providers/test_ollama_embedding.py` | Dimensions, connection errors |
+| `tests/unit/providers/test_anthropic_summarization.py` | Summarization flow |
+
+### Missing Tests
+
+| Gap | Priority |
+|-----|----------|
+| E2E test for provider switching | HIGH |
+| E2E test for Ollama offline mode | HIGH |
+| Integration test for dimension mismatch prevention | HIGH |
+| E2E test for Cohere provider | MEDIUM |
+| E2E test for Gemini/Grok providers | LOW |
+
+---
+
+## Recommendations for Plans Needed
+
+### Plan 1: Dimension Mismatch Prevention (PROV-07)
+**Priority:** HIGH
+**Effort:** 3-4 hours
+
+Implement:
+1. Store embedding metadata in ChromaDB collection metadata
+2. Validate on startup if collection exists
+3. Validate on index operations
+4. Add `--force` flag to bypass and re-index
+
+### Plan 2: Strict Startup Validation (PROV-06 Enhancement)
+**Priority:** MEDIUM
+**Effort:** 2 hours
+
+Implement:
+1. Add validation severity levels (ERROR vs WARNING)
+2. Add `--strict` flag to CLI start command
+3. Add `/health/providers` endpoint
+
+### Plan 3: Provider Switching E2E Test (PROV-03 Verification)
+**Priority:** MEDIUM
+**Effort:** 2 hours
+
+Implement:
+1. E2E test that changes config and verifies behavior
+2. CLI command `agent-brain config show` for debugging
+
+### Plan 4: Ollama Offline E2E Test (PROV-04 Verification)
+**Priority:** LOW
+**Effort:** 1 hour
+
+Implement:
+1. E2E test running with Ollama-only config
+2. Verify no external API calls made
+
+---
+
+## Summary
+
+| Item | Count |
+|------|-------|
+| Requirements Done | 4 (PROV-01, PROV-02, PROV-04, PROV-05) |
+| Requirements Partial | 2 (PROV-03, PROV-06) |
+| Requirements Missing | 1 (PROV-07) |
+| Plans Recommended | 4 |
+| Estimated Total Effort | 8-9 hours |
+
+The provider infrastructure is solid. The main work is adding dimension validation (PROV-07) and improving startup validation robustness (PROV-06). Testing gaps should be addressed in Phase 4 (Provider Integration Testing) rather than here.
+
+---
+
+*Research completed: 2026-02-08*

--- a/agent-brain-server/.planning/phases/01-two-stage-reranking/01-05-SUMMARY.md
+++ b/agent-brain-server/.planning/phases/01-two-stage-reranking/01-05-SUMMARY.md
@@ -1,0 +1,111 @@
+# Wave 3 Summary: QueryService Integration
+
+## Status: COMPLETE
+
+## Overview
+
+Wave 3 integrated two-stage reranking into the QueryService, completing the core feature implementation for Feature 123 (Two-Stage Reranking).
+
+## Changes Made
+
+### 1. QueryResult Model Updates (`models/query.py`)
+
+Added new fields to QueryResult for reranking metadata:
+
+```python
+# Reranking fields (Feature 123)
+rerank_score: float | None = Field(
+    default=None, description="Score from reranking stage (if enabled)"
+)
+original_rank: int | None = Field(
+    default=None, description="Position before reranking (1-indexed)"
+)
+```
+
+### 2. QueryService Updates (`services/query_service.py`)
+
+#### New Imports
+
+```python
+from agent_brain_server.config.provider_config import load_provider_settings
+from agent_brain_server.providers import ProviderRegistry
+import agent_brain_server.providers.reranker  # noqa: F401  # Triggers registration
+```
+
+#### New `_rerank_results` Method
+
+Added async method that:
+- Gets reranker provider from configuration via `load_provider_settings()` and `ProviderRegistry`
+- Checks `is_available()` before proceeding
+- Calls `reranker.rerank(query, documents, top_k)`
+- Updates results with `rerank_score` and `original_rank` (1-indexed)
+- Updates primary `score` to `rerank_score`
+- Gracefully falls back to stage 1 results on ANY failure
+- Logs reranking time and success/failure
+
+#### Updated `execute_query` Method
+
+Modified to support two-stage retrieval:
+- Uses `getattr()` with defaults to handle mocked settings in tests
+- When `ENABLE_RERANKING=True`:
+  - Calculates `stage1_top_k = min(top_k * multiplier, max_candidates)`
+  - Creates modified request with expanded `top_k` for Stage 1
+  - After retrieval, applies `_rerank_results()` if results > requested `top_k`
+- When `ENABLE_RERANKING=False` (default):
+  - Standard retrieval with no changes
+- Updated logging to indicate "(reranked)" when applicable
+
+### 3. Bug Fix for Test Compatibility
+
+Fixed TypeError when settings are mocked in tests:
+- Changed `settings.ENABLE_RERANKING` to `getattr(settings, "ENABLE_RERANKING", False)`
+- Added type check: `if not isinstance(enable_reranking, bool): enable_reranking = False`
+- This prevents `MagicMock` objects from reaching `min()` comparisons
+
+## Configuration
+
+Reranking uses these settings from `config/settings.py`:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `ENABLE_RERANKING` | `False` | Master switch (off by default) |
+| `RERANKER_TOP_K_MULTIPLIER` | `10` | Stage 1 retrieves `top_k * multiplier` |
+| `RERANKER_MAX_CANDIDATES` | `100` | Cap on Stage 1 candidates |
+
+## Verification
+
+```bash
+# QueryResult has new fields
+cd agent-brain-server && .venv/bin/python -c "
+from agent_brain_server.models.query import QueryResult
+r = QueryResult(text='test', source='test.py', score=0.9, chunk_id='c1')
+print(r.rerank_score, r.original_rank)
+"
+# Output: None None
+
+# QueryService has _rerank_results method
+cd agent-brain-server && .venv/bin/python -c "
+from agent_brain_server.services.query_service import QueryService
+print(hasattr(QueryService, '_rerank_results'))
+"
+# Output: True
+```
+
+## Tests
+
+All 383 tests pass, including:
+- Existing query mode tests (vector, bm25, hybrid, graph, multi)
+- RRF fusion tests with mocked settings
+- Graph query integration tests
+
+## Files Modified
+
+1. `agent_brain_server/models/query.py` - Added rerank_score and original_rank fields
+2. `agent_brain_server/services/query_service.py` - Added imports, _rerank_results method, and execute_query integration
+
+## Next Steps
+
+Wave 4 should add tests for the reranking functionality:
+- Unit tests for `_rerank_results()` method
+- Integration tests with reranking enabled
+- Tests for graceful fallback on reranker failure

--- a/agent-brain-server/agent_brain_server/config/settings.py
+++ b/agent-brain-server/agent_brain_server/config/settings.py
@@ -74,7 +74,7 @@ class Settings(BaseSettings):
     RERANKER_MODEL: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"
     RERANKER_TOP_K_MULTIPLIER: int = 10  # Retrieve top_k * this for Stage 1
     RERANKER_MAX_CANDIDATES: int = 100  # Cap on Stage 1 candidates
-    RERANKER_BATCH_SIZE: int = 32  # Batch size for reranking inference
+    # Note: CrossEncoder.rank() handles batching internally, no batch_size config needed
 
     model_config = SettingsConfigDict(
         env_file=[

--- a/agent-brain-server/agent_brain_server/config/settings.py
+++ b/agent-brain-server/agent_brain_server/config/settings.py
@@ -68,6 +68,14 @@ class Settings(BaseSettings):
     AGENT_BRAIN_MAX_RETRIES: int = 3  # Max retries for failed jobs
     AGENT_BRAIN_CHECKPOINT_INTERVAL: int = 50  # Progress checkpoint every N files
 
+    # Reranking Configuration (Feature 123)
+    ENABLE_RERANKING: bool = False  # Off by default
+    RERANKER_PROVIDER: str = "sentence-transformers"  # or "ollama"
+    RERANKER_MODEL: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+    RERANKER_TOP_K_MULTIPLIER: int = 10  # Retrieve top_k * this for Stage 1
+    RERANKER_MAX_CANDIDATES: int = 100  # Cap on Stage 1 candidates
+    RERANKER_BATCH_SIZE: int = 32  # Batch size for reranking inference
+
     model_config = SettingsConfigDict(
         env_file=[
             ".env",  # Current directory

--- a/agent-brain-server/agent_brain_server/indexing/graph_index.py
+++ b/agent-brain-server/agent_brain_server/indexing/graph_index.py
@@ -572,9 +572,11 @@ class GraphIndexManager:
                 "graph_index.clear: skipped",
                 extra={
                     "enabled": settings.ENABLE_GRAPH_INDEX,
-                    "initialized": self.graph_store.is_initialized
-                    if settings.ENABLE_GRAPH_INDEX
-                    else False,
+                    "initialized": (
+                        self.graph_store.is_initialized
+                        if settings.ENABLE_GRAPH_INDEX
+                        else False
+                    ),
                 },
             )
 

--- a/agent-brain-server/agent_brain_server/models/query.py
+++ b/agent-brain-server/agent_brain_server/models/query.py
@@ -1,7 +1,7 @@
 """Query request and response models."""
 
 from enum import Enum
-from typing import Any, Optional
+from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -69,7 +69,7 @@ class QueryRequest(BaseModel):
 
     @field_validator("languages")
     @classmethod
-    def validate_languages(cls, v: Optional[list[str]]) -> Optional[list[str]]:
+    def validate_languages(cls, v: list[str] | None) -> list[str] | None:
         """Validate that provided languages are supported."""
         if v is None:
             return v
@@ -142,6 +142,14 @@ class QueryResult(BaseModel):
     )
     relationship_path: list[str] | None = Field(
         default=None, description="Relationship paths in the graph"
+    )
+
+    # Reranking fields (Feature 123)
+    rerank_score: float | None = Field(
+        default=None, description="Score from reranking stage (if enabled)"
+    )
+    original_rank: int | None = Field(
+        default=None, description="Position before reranking (1-indexed)"
     )
 
     # Additional metadata

--- a/agent-brain-server/agent_brain_server/providers/base.py
+++ b/agent-brain-server/agent_brain_server/providers/base.py
@@ -27,6 +27,13 @@ class SummarizationProviderType(str, Enum):
     OLLAMA = "ollama"
 
 
+class RerankerProviderType(str, Enum):
+    """Supported reranking providers."""
+
+    SENTENCE_TRANSFORMERS = "sentence-transformers"
+    OLLAMA = "ollama"
+
+
 @runtime_checkable
 class EmbeddingProvider(Protocol):
     """Protocol for embedding providers.

--- a/agent-brain-server/agent_brain_server/providers/factory.py
+++ b/agent-brain-server/agent_brain_server/providers/factory.py
@@ -8,12 +8,14 @@ from agent_brain_server.providers.exceptions import ProviderNotFoundError
 if TYPE_CHECKING:
     from agent_brain_server.config.provider_config import (
         EmbeddingConfig,
+        RerankerConfig,
         SummarizationConfig,
     )
     from agent_brain_server.providers.base import (
         EmbeddingProvider,
         SummarizationProvider,
     )
+    from agent_brain_server.providers.reranker.base import RerankerProvider
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +29,7 @@ class ProviderRegistry:
 
     _embedding_providers: dict[str, type[Any]] = {}
     _summarization_providers: dict[str, type[Any]] = {}
+    _reranker_providers: dict[str, type[Any]] = {}
     _instances: dict[str, Any] = {}
 
     @classmethod
@@ -141,6 +144,60 @@ class ProviderRegistry:
         return cast(SummarizationProvider, cls._instances[cache_key])
 
     @classmethod
+    def register_reranker_provider(
+        cls,
+        provider_type: str,
+        provider_class: type["RerankerProvider"],
+    ) -> None:
+        """Register a reranking provider class.
+
+        Args:
+            provider_type: Provider identifier (e.g., 'sentence-transformers', 'ollama')
+            provider_class: Provider class implementing RerankerProvider protocol
+        """
+        cls._reranker_providers[provider_type] = provider_class
+        logger.debug(f"Registered reranker provider: {provider_type}")
+
+    @classmethod
+    def get_reranker_provider(cls, config: "RerankerConfig") -> "RerankerProvider":
+        """Get or create reranker provider instance.
+
+        Args:
+            config: Reranker provider configuration
+
+        Returns:
+            Configured RerankerProvider instance
+
+        Raises:
+            ProviderNotFoundError: If provider type is not registered
+        """
+        # Get provider type as string value
+        provider_type = (
+            config.provider.value
+            if hasattr(config.provider, "value")
+            else str(config.provider)
+        )
+        cache_key = f"rerank:{provider_type}:{config.model}"
+
+        if cache_key not in cls._instances:
+            provider_class = cls._reranker_providers.get(provider_type)
+            if not provider_class:
+                available = list(cls._reranker_providers.keys())
+                raise ProviderNotFoundError(
+                    f"Unknown reranker provider: {provider_type}. "
+                    f"Available: {', '.join(available) if available else 'none'}",
+                    provider_type,
+                )
+            cls._instances[cache_key] = provider_class(config)
+            logger.info(
+                f"Created {provider_type} reranker provider with model {config.model}"
+            )
+
+        from agent_brain_server.providers.reranker.base import RerankerProvider
+
+        return cast(RerankerProvider, cls._instances[cache_key])
+
+    @classmethod
     def clear_cache(cls) -> None:
         """Clear provider instance cache (for testing)."""
         cls._instances.clear()
@@ -155,3 +212,8 @@ class ProviderRegistry:
     def get_available_summarization_providers(cls) -> list[str]:
         """Get list of registered summarization provider types."""
         return list(cls._summarization_providers.keys())
+
+    @classmethod
+    def get_available_reranker_providers(cls) -> list[str]:
+        """Get list of registered reranker provider types."""
+        return list(cls._reranker_providers.keys())

--- a/agent-brain-server/agent_brain_server/providers/reranker/__init__.py
+++ b/agent-brain-server/agent_brain_server/providers/reranker/__init__.py
@@ -1,0 +1,11 @@
+"""Reranking providers package."""
+
+from agent_brain_server.providers.reranker.base import (
+    BaseRerankerProvider,
+    RerankerProvider,
+)
+
+__all__ = [
+    "BaseRerankerProvider",
+    "RerankerProvider",
+]

--- a/agent-brain-server/agent_brain_server/providers/reranker/__init__.py
+++ b/agent-brain-server/agent_brain_server/providers/reranker/__init__.py
@@ -4,8 +4,14 @@ from agent_brain_server.providers.reranker.base import (
     BaseRerankerProvider,
     RerankerProvider,
 )
+from agent_brain_server.providers.reranker.ollama import OllamaRerankerProvider
+from agent_brain_server.providers.reranker.sentence_transformers import (
+    SentenceTransformerRerankerProvider,
+)
 
 __all__ = [
     "BaseRerankerProvider",
     "RerankerProvider",
+    "OllamaRerankerProvider",
+    "SentenceTransformerRerankerProvider",
 ]

--- a/agent-brain-server/agent_brain_server/providers/reranker/base.py
+++ b/agent-brain-server/agent_brain_server/providers/reranker/base.py
@@ -1,0 +1,101 @@
+"""Base protocol and class for reranking providers."""
+
+import logging
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from agent_brain_server.config.provider_config import RerankerConfig
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class RerankerProvider(Protocol):
+    """Protocol for reranking providers.
+
+    All reranking providers must implement this interface to be usable
+    by the Agent Brain query system for two-stage retrieval.
+    """
+
+    async def rerank(
+        self,
+        query: str,
+        documents: list[str],
+        top_k: int = 10,
+    ) -> list[tuple[int, float]]:
+        """Rerank documents for a query.
+
+        Args:
+            query: The search query.
+            documents: List of document texts to rerank.
+            top_k: Number of top results to return.
+
+        Returns:
+            List of (original_index, score) tuples, sorted by score descending.
+            The original_index refers to the position in the input documents list.
+
+        Raises:
+            ProviderError: If reranking fails.
+        """
+        ...
+
+    @property
+    def provider_name(self) -> str:
+        """Human-readable provider name for logging."""
+        ...
+
+    @property
+    def model_name(self) -> str:
+        """Model identifier being used."""
+        ...
+
+    def is_available(self) -> bool:
+        """Check if the provider is available and ready.
+
+        Returns:
+            True if provider can perform reranking, False otherwise.
+        """
+        ...
+
+
+class BaseRerankerProvider(ABC):
+    """Base class for reranking providers with common functionality."""
+
+    def __init__(self, config: "RerankerConfig") -> None:
+        """Initialize the reranker provider.
+
+        Args:
+            config: Reranker configuration.
+        """
+        self._model = config.model
+        self._batch_size = config.params.get("batch_size", 32)
+        self._config = config
+        logger.info(
+            f"Initialized {self.provider_name} reranker with model {self._model}"
+        )
+
+    @property
+    def model_name(self) -> str:
+        """Model identifier being used."""
+        return self._model
+
+    @abstractmethod
+    async def rerank(
+        self,
+        query: str,
+        documents: list[str],
+        top_k: int = 10,
+    ) -> list[tuple[int, float]]:
+        """Provider-specific reranking implementation."""
+        ...
+
+    @property
+    @abstractmethod
+    def provider_name(self) -> str:
+        """Human-readable provider name for logging."""
+        ...
+
+    def is_available(self) -> bool:
+        """Default implementation - override if availability check needed."""
+        return True

--- a/agent-brain-server/agent_brain_server/providers/reranker/base.py
+++ b/agent-brain-server/agent_brain_server/providers/reranker/base.py
@@ -69,11 +69,21 @@ class BaseRerankerProvider(ABC):
             config: Reranker configuration.
         """
         self._model = config.model
-        self._batch_size = config.params.get("batch_size", 32)
         self._config = config
         logger.info(
             f"Initialized {self.provider_name} reranker with model {self._model}"
         )
+
+    def warm_up(self) -> bool:
+        """Pre-load resources at startup to avoid first-query latency.
+
+        Override in subclasses that need startup initialization.
+        Default implementation returns True (no warm-up needed).
+
+        Returns:
+            True if warm-up successful, False otherwise.
+        """
+        return True
 
     @property
     def model_name(self) -> str:

--- a/agent-brain-server/agent_brain_server/providers/reranker/ollama.py
+++ b/agent-brain-server/agent_brain_server/providers/reranker/ollama.py
@@ -216,7 +216,7 @@ class OllamaRerankerProvider(BaseRerankerProvider):
         # Check circuit breaker - if open, signal caller to use fallback
         if not self._check_circuit():
             logger.warning(
-                "Ollama circuit breaker open - skipping rerank and using stage 1 results"
+                "Ollama circuit breaker open - skipping rerank, using stage 1"
             )
             # Raise to trigger fallback in caller
             raise RuntimeError("Ollama circuit breaker open - reranking unavailable")

--- a/agent-brain-server/agent_brain_server/providers/reranker/ollama.py
+++ b/agent-brain-server/agent_brain_server/providers/reranker/ollama.py
@@ -215,8 +215,10 @@ class OllamaRerankerProvider(BaseRerankerProvider):
 
         # Check circuit breaker - if open, signal caller to use fallback
         if not self._check_circuit():
-            logger.debug("Ollama circuit open, signaling fallback")
-            # Return empty to signal failure - caller will use stage 1 results
+            logger.warning(
+                "Ollama circuit breaker open - skipping rerank and using stage 1 results"
+            )
+            # Raise to trigger fallback in caller
             raise RuntimeError("Ollama circuit breaker open - reranking unavailable")
 
         # Create scoring tasks with semaphore for rate limiting

--- a/agent-brain-server/agent_brain_server/providers/reranker/ollama.py
+++ b/agent-brain-server/agent_brain_server/providers/reranker/ollama.py
@@ -1,0 +1,210 @@
+"""Ollama-based reranking provider using chat completions."""
+
+import asyncio
+import logging
+import re
+from typing import TYPE_CHECKING
+
+import httpx
+
+from agent_brain_server.providers.factory import ProviderRegistry
+from agent_brain_server.providers.reranker.base import BaseRerankerProvider
+
+if TYPE_CHECKING:
+    from agent_brain_server.config.provider_config import RerankerConfig
+
+logger = logging.getLogger(__name__)
+
+
+class OllamaRerankerProvider(BaseRerankerProvider):
+    """Reranker using Ollama chat completions for relevance scoring.
+
+    Uses prompt-based scoring to rank documents by relevance to the query.
+    This approach works with any Ollama model but is slower than CrossEncoder.
+
+    Recommended models:
+    - qwen3:0.6b-reranker (if available)
+    - llama3.2:1b (general purpose, good for scoring)
+    - gemma2:2b (good instruction following)
+
+    Note: This is slower than sentence-transformers but fully local without
+    needing to download HuggingFace models.
+    """
+
+    RERANK_PROMPT = (
+        "You are a relevance scoring system. "
+        "Score how relevant the document is to the query.\n\n"
+        "Query: {query}\n\n"
+        "Document: {document}\n\n"
+        "Instructions:\n"
+        "- Output ONLY a single number from 0 to 10\n"
+        "- 10 = perfectly relevant, directly answers the query\n"
+        "- 5 = somewhat relevant, related topic\n"
+        "- 0 = completely irrelevant\n"
+        "- Do not output any other text, just the number\n\n"
+        "Score:"
+    )
+
+    def __init__(self, config: "RerankerConfig") -> None:
+        """Initialize the Ollama reranker.
+
+        Args:
+            config: Reranker configuration.
+        """
+        super().__init__(config)
+        self._base_url = config.get_base_url() or "http://localhost:11434"
+        self._timeout = config.params.get("timeout", 30.0)
+        self._max_concurrent = config.params.get("max_concurrent", 5)
+        self._client: httpx.AsyncClient | None = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        """Get or create HTTP client."""
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                base_url=self._base_url,
+                timeout=httpx.Timeout(self._timeout),
+            )
+        return self._client
+
+    async def _score_document(
+        self,
+        query: str,
+        document: str,
+        doc_index: int,
+    ) -> tuple[int, float]:
+        """Score a single document for relevance.
+
+        Args:
+            query: The search query.
+            document: Document text to score.
+            doc_index: Original index in the document list.
+
+        Returns:
+            Tuple of (doc_index, score).
+        """
+        # Truncate document to avoid context overflow
+        max_doc_len = 2000
+        doc_text = document[:max_doc_len] if len(document) > max_doc_len else document
+
+        prompt = self.RERANK_PROMPT.format(query=query, document=doc_text)
+
+        try:
+            client = self._get_client()
+            response = await client.post(
+                "/api/chat",
+                json={
+                    "model": self._model,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "stream": False,
+                    "options": {"temperature": 0.0},
+                },
+            )
+            response.raise_for_status()
+            result = response.json()
+
+            # Parse score from response
+            content = result.get("message", {}).get("content", "").strip()
+            score = self._parse_score(content)
+            return (doc_index, score)
+
+        except httpx.HTTPError as e:
+            logger.warning(f"Ollama request failed for doc {doc_index}: {e}")
+            return (doc_index, 0.0)
+        except Exception as e:
+            logger.warning(f"Error scoring doc {doc_index}: {e}")
+            return (doc_index, 0.0)
+
+    def _parse_score(self, content: str) -> float:
+        """Parse numeric score from model output.
+
+        Args:
+            content: Raw model response.
+
+        Returns:
+            Parsed score (0-10), or 0.0 on failure.
+        """
+        try:
+            # Try to extract first number from response
+            match = re.search(r"(\d+(?:\.\d+)?)", content)
+            if match:
+                score = float(match.group(1))
+                # Clamp to 0-10 range
+                return min(max(score, 0.0), 10.0)
+            return 0.0
+        except (ValueError, AttributeError):
+            return 0.0
+
+    async def rerank(
+        self,
+        query: str,
+        documents: list[str],
+        top_k: int = 10,
+    ) -> list[tuple[int, float]]:
+        """Rerank documents using Ollama chat completions.
+
+        Scores each document concurrently with rate limiting.
+
+        Args:
+            query: The search query.
+            documents: List of document texts to rerank.
+            top_k: Number of top results to return.
+
+        Returns:
+            List of (original_index, score) tuples, sorted by score descending.
+        """
+        if not documents:
+            return []
+
+        # Create scoring tasks with semaphore for rate limiting
+        semaphore = asyncio.Semaphore(self._max_concurrent)
+
+        async def score_with_limit(idx: int, doc: str) -> tuple[int, float]:
+            async with semaphore:
+                return await self._score_document(query, doc, idx)
+
+        # Score all documents concurrently
+        tasks = [score_with_limit(i, doc) for i, doc in enumerate(documents)]
+        scores = await asyncio.gather(*tasks)
+
+        # Sort by score descending and take top_k
+        sorted_scores = sorted(scores, key=lambda x: x[1], reverse=True)
+
+        logger.debug(
+            f"Ollama reranked {len(documents)} documents, returning top {top_k}"
+        )
+
+        return sorted_scores[:top_k]
+
+    @property
+    def provider_name(self) -> str:
+        """Human-readable provider name."""
+        return "Ollama"
+
+    def is_available(self) -> bool:
+        """Check if Ollama is running and model is available.
+
+        Returns:
+            True if Ollama responds to health check, False otherwise.
+        """
+        try:
+            import httpx as sync_httpx
+
+            with sync_httpx.Client(base_url=self._base_url, timeout=5.0) as client:
+                response = client.get("/api/tags")
+                return response.status_code == 200
+        except Exception as e:
+            logger.debug(f"Ollama not available: {e}")
+            return False
+
+    async def close(self) -> None:
+        """Close the HTTP client."""
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+
+
+# Register provider on import
+ProviderRegistry.register_reranker_provider(
+    "ollama",
+    OllamaRerankerProvider,
+)

--- a/agent-brain-server/agent_brain_server/providers/reranker/sentence_transformers.py
+++ b/agent-brain-server/agent_brain_server/providers/reranker/sentence_transformers.py
@@ -1,0 +1,145 @@
+"""SentenceTransformer CrossEncoder reranking provider."""
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from sentence_transformers import CrossEncoder
+
+from agent_brain_server.providers.factory import ProviderRegistry
+from agent_brain_server.providers.reranker.base import BaseRerankerProvider
+
+if TYPE_CHECKING:
+    from agent_brain_server.config.provider_config import RerankerConfig
+
+logger = logging.getLogger(__name__)
+
+
+class SentenceTransformerRerankerProvider(BaseRerankerProvider):
+    """Reranker using sentence-transformers CrossEncoder.
+
+    Uses pre-trained cross-encoder models for accurate document reranking.
+    The CrossEncoder scores query-document pairs directly, providing
+    more accurate relevance scores than bi-encoder similarity.
+
+    Default model: cross-encoder/ms-marco-MiniLM-L-6-v2 (fast, good accuracy)
+    Alternative: cross-encoder/ms-marco-MiniLM-L-12-v2 (slower, better accuracy)
+    """
+
+    def __init__(self, config: "RerankerConfig") -> None:
+        """Initialize the CrossEncoder reranker.
+
+        Args:
+            config: Reranker configuration.
+        """
+        super().__init__(config)
+        self._cross_encoder: CrossEncoder | None = None
+        self._model_loaded = False
+
+    def _ensure_model_loaded(self) -> CrossEncoder:
+        """Lazy-load the CrossEncoder model.
+
+        Returns:
+            Loaded CrossEncoder instance.
+        """
+        if self._cross_encoder is None:
+            logger.info(f"Loading CrossEncoder model: {self._model}")
+            self._cross_encoder = CrossEncoder(self._model)
+            self._model_loaded = True
+            logger.info(f"CrossEncoder model loaded: {self._model}")
+        return self._cross_encoder
+
+    async def rerank(
+        self,
+        query: str,
+        documents: list[str],
+        top_k: int = 10,
+    ) -> list[tuple[int, float]]:
+        """Rerank documents using CrossEncoder.
+
+        Uses CrossEncoder.rank() for efficient batch scoring and sorting.
+        Runs in thread pool to avoid blocking the async event loop.
+
+        Args:
+            query: The search query.
+            documents: List of document texts to rerank.
+            top_k: Number of top results to return.
+
+        Returns:
+            List of (original_index, score) tuples, sorted by score descending.
+        """
+        if not documents:
+            return []
+
+        # Limit top_k to document count
+        effective_top_k = min(top_k, len(documents))
+
+        # Run CrossEncoder in thread pool (CPU-bound operation)
+        results = await asyncio.to_thread(
+            self._rerank_sync,
+            query,
+            documents,
+            effective_top_k,
+        )
+
+        logger.debug(
+            f"Reranked {len(documents)} documents, returning top {effective_top_k}"
+        )
+
+        return results
+
+    def _rerank_sync(
+        self,
+        query: str,
+        documents: list[str],
+        top_k: int,
+    ) -> list[tuple[int, float]]:
+        """Synchronous reranking implementation.
+
+        Args:
+            query: The search query.
+            documents: List of document texts.
+            top_k: Number of results to return.
+
+        Returns:
+            List of (corpus_id, score) tuples.
+        """
+        model = self._ensure_model_loaded()
+
+        # CrossEncoder.rank() returns sorted results with corpus_id and score
+        # return_documents=False for efficiency (we don't need the text back)
+        ranked = model.rank(
+            query,
+            documents,
+            top_k=top_k,
+            return_documents=False,
+        )
+
+        # Convert to (index, score) tuples
+        # corpus_id is always int from CrossEncoder.rank()
+        return [(int(r["corpus_id"]), float(r["score"])) for r in ranked]
+
+    @property
+    def provider_name(self) -> str:
+        """Human-readable provider name."""
+        return "SentenceTransformers"
+
+    def is_available(self) -> bool:
+        """Check if CrossEncoder can be loaded.
+
+        Returns:
+            True if model can be loaded, False otherwise.
+        """
+        try:
+            self._ensure_model_loaded()
+            return True
+        except Exception as e:
+            logger.warning(f"CrossEncoder not available: {e}")
+            return False
+
+
+# Register provider on import
+ProviderRegistry.register_reranker_provider(
+    "sentence-transformers",
+    SentenceTransformerRerankerProvider,
+)

--- a/agent-brain-server/agent_brain_server/services/query_service.py
+++ b/agent-brain-server/agent_brain_server/services/query_service.py
@@ -719,6 +719,13 @@ class QueryService:
                 top_k=top_k,
             )
 
+            # If reranker returned nothing, fall back gracefully
+            if not reranked:
+                logger.warning(
+                    "Reranker returned no results, falling back to stage 1 results"
+                )
+                return results[:top_k]
+
             # Build reranked results with updated scores and metadata
             reranked_results: list[QueryResult] = []
             for original_index, rerank_score in reranked:

--- a/agent-brain-server/agent_brain_server/services/query_service.py
+++ b/agent-brain-server/agent_brain_server/services/query_service.py
@@ -2,12 +2,15 @@
 
 import logging
 import time
-from typing import Any, Optional
+from typing import Any
 
 from llama_index.core.retrievers import BaseRetriever
 from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode
 
+# Import reranker module to trigger provider registration
+import agent_brain_server.providers.reranker  # noqa: F401
 from agent_brain_server.config import settings
+from agent_brain_server.config.provider_config import load_provider_settings
 from agent_brain_server.indexing import EmbeddingGenerator, get_embedding_generator
 from agent_brain_server.indexing.bm25_index import BM25IndexManager, get_bm25_manager
 from agent_brain_server.indexing.graph_index import (
@@ -20,6 +23,7 @@ from agent_brain_server.models import (
     QueryResponse,
     QueryResult,
 )
+from agent_brain_server.providers import ProviderRegistry
 from agent_brain_server.storage import VectorStoreManager, get_vector_store
 
 logger = logging.getLogger(__name__)
@@ -71,10 +75,10 @@ class QueryService:
 
     def __init__(
         self,
-        vector_store: Optional[VectorStoreManager] = None,
-        embedding_generator: Optional[EmbeddingGenerator] = None,
-        bm25_manager: Optional[BM25IndexManager] = None,
-        graph_index_manager: Optional[GraphIndexManager] = None,
+        vector_store: VectorStoreManager | None = None,
+        embedding_generator: EmbeddingGenerator | None = None,
+        bm25_manager: BM25IndexManager | None = None,
+        graph_index_manager: GraphIndexManager | None = None,
     ):
         """
         Initialize the query service.
@@ -103,6 +107,10 @@ class QueryService:
         """
         Execute a search query based on the requested mode.
 
+        Supports optional two-stage reranking when ENABLE_RERANKING=True.
+        Stage 1: Broad retrieval with expanded top_k
+        Stage 2: Cross-encoder reranking for precision
+
         Args:
             request: QueryRequest with query text and parameters.
 
@@ -119,26 +127,78 @@ class QueryService:
 
         start_time = time.time()
 
-        if request.mode == QueryMode.BM25:
-            results = await self._execute_bm25_query(request)
-        elif request.mode == QueryMode.VECTOR:
-            results = await self._execute_vector_query(request)
-        elif request.mode == QueryMode.GRAPH:
-            results = await self._execute_graph_query(request)
-        elif request.mode == QueryMode.MULTI:
-            results = await self._execute_multi_query(request)
+        # Determine if reranking is enabled
+        # Use getattr with default False to handle mocked settings in tests
+        enable_reranking = getattr(settings, "ENABLE_RERANKING", False)
+        if not isinstance(enable_reranking, bool):
+            enable_reranking = False
+        original_top_k = request.top_k
+
+        # Stage 1: Adjust top_k for reranking if enabled
+        if enable_reranking:
+            # Calculate stage 1 candidates: top_k * multiplier, capped at max_candidates
+            multiplier = getattr(settings, "RERANKER_TOP_K_MULTIPLIER", 10)
+            max_candidates = getattr(settings, "RERANKER_MAX_CANDIDATES", 100)
+            stage1_top_k = min(
+                request.top_k * multiplier,
+                max_candidates,
+            )
+            logger.debug(
+                f"Reranking enabled: Stage 1 retrieving {stage1_top_k} candidates "
+                f"for final top_k={original_top_k}"
+            )
+            # Create modified request with expanded top_k for Stage 1
+            stage1_request = QueryRequest(
+                query=request.query,
+                top_k=stage1_top_k,
+                similarity_threshold=request.similarity_threshold,
+                mode=request.mode,
+                alpha=request.alpha,
+                source_types=request.source_types,
+                languages=request.languages,
+                file_paths=request.file_paths,
+            )
+        else:
+            stage1_request = request
+
+        # Execute Stage 1 retrieval
+        if stage1_request.mode == QueryMode.BM25:
+            results = await self._execute_bm25_query(stage1_request)
+        elif stage1_request.mode == QueryMode.VECTOR:
+            results = await self._execute_vector_query(stage1_request)
+        elif stage1_request.mode == QueryMode.GRAPH:
+            results = await self._execute_graph_query(stage1_request)
+        elif stage1_request.mode == QueryMode.MULTI:
+            results = await self._execute_multi_query(stage1_request)
         else:  # HYBRID
-            results = await self._execute_hybrid_query(request)
+            results = await self._execute_hybrid_query(stage1_request)
 
         # Apply content filters if specified
         if any([request.source_types, request.languages, request.file_paths]):
             results = self._filter_results(results, request)
+
+        # Stage 2: Apply reranking if enabled and we have more results than requested
+        if enable_reranking and len(results) > original_top_k:
+            results = await self._rerank_results(
+                results=results,
+                query=request.query,
+                top_k=original_top_k,
+            )
+        elif enable_reranking:
+            # Not enough results to warrant reranking, just truncate
+            logger.debug(
+                f"Skipping reranking: only {len(results)} results, "
+                f"need more than {original_top_k}"
+            )
+            results = results[:original_top_k]
+        # else: reranking disabled, results already at correct size
 
         query_time_ms = (time.time() - start_time) * 1000
 
         logger.debug(
             f"Query ({request.mode}) '{request.query[:50]}...' returned "
             f"{len(results)} results in {query_time_ms:.2f}ms"
+            f"{' (reranked)' if enable_reranking else ''}"
         )
 
         return QueryResponse(
@@ -609,9 +669,99 @@ class QueryService:
         else:
             return {"$and": conditions}
 
+    async def _rerank_results(
+        self,
+        results: list[QueryResult],
+        query: str,
+        top_k: int,
+    ) -> list[QueryResult]:
+        """Rerank results using a cross-encoder model.
+
+        Two-stage retrieval: Stage 1 returns broad candidates, Stage 2 reranks
+        using a more accurate cross-encoder model.
+
+        Args:
+            results: List of QueryResult from Stage 1 retrieval.
+            query: The original query text.
+            top_k: Number of final results to return.
+
+        Returns:
+            Reranked list of QueryResult with updated scores and reranking metadata.
+            Falls back to original results (truncated to top_k) on any failure.
+        """
+        if not results:
+            return results
+
+        start_time = time.time()
+
+        try:
+            # Get reranker configuration
+            provider_settings = load_provider_settings()
+            reranker = ProviderRegistry.get_reranker_provider(
+                provider_settings.reranker
+            )
+
+            # Check if reranker is available
+            if not reranker.is_available():
+                logger.warning(
+                    f"Reranker {reranker.provider_name} not available, "
+                    "falling back to stage 1 results"
+                )
+                return results[:top_k]
+
+            # Extract document texts for reranking
+            documents = [r.text for r in results]
+
+            # Perform reranking
+            reranked = await reranker.rerank(
+                query=query,
+                documents=documents,
+                top_k=top_k,
+            )
+
+            # Build reranked results with updated scores and metadata
+            reranked_results: list[QueryResult] = []
+            for original_index, rerank_score in reranked:
+                result = results[original_index]
+                # Create new result with reranking metadata
+                reranked_result = QueryResult(
+                    text=result.text,
+                    source=result.source,
+                    score=rerank_score,  # Update main score to rerank score
+                    vector_score=result.vector_score,
+                    bm25_score=result.bm25_score,
+                    chunk_id=result.chunk_id,
+                    source_type=result.source_type,
+                    language=result.language,
+                    graph_score=result.graph_score,
+                    related_entities=result.related_entities,
+                    relationship_path=result.relationship_path,
+                    rerank_score=rerank_score,
+                    original_rank=original_index + 1,  # 1-indexed
+                    metadata=result.metadata,
+                )
+                reranked_results.append(reranked_result)
+
+            rerank_time_ms = (time.time() - start_time) * 1000
+            logger.info(
+                f"Reranked {len(results)} -> {len(reranked_results)} results "
+                f"in {rerank_time_ms:.2f}ms using {reranker.provider_name}"
+            )
+
+            return reranked_results
+
+        except Exception as e:
+            rerank_time_ms = (time.time() - start_time) * 1000
+            logger.warning(
+                f"Reranking failed after {rerank_time_ms:.2f}ms: {e}, "
+                "falling back to stage 1 results"
+            )
+            # Graceful fallback: return stage 1 results truncated to top_k
+            return results[:top_k]
+
 
 # Singleton instance
-_query_service: Optional[QueryService] = None
+_query_service: QueryService | None = None
 
 
 def get_query_service() -> QueryService:

--- a/agent-brain-server/agent_brain_server/storage/graph_store.py
+++ b/agent-brain-server/agent_brain_server/storage/graph_store.py
@@ -83,9 +83,7 @@ class GraphStoreManager:
         This is a no-op when ENABLE_GRAPH_INDEX is False.
         """
         if not settings.ENABLE_GRAPH_INDEX:
-            logger.debug(
-                "graph_store.initialize: skipped (ENABLE_GRAPH_INDEX=false)"
-            )
+            logger.debug("graph_store.initialize: skipped (ENABLE_GRAPH_INDEX=false)")
             return
 
         if self._initialized:

--- a/agent-brain-server/pyproject.toml
+++ b/agent-brain-server/pyproject.toml
@@ -46,6 +46,9 @@ pyyaml = "^6.0.0"
 cohere = "^5.0.0"
 google-generativeai = "^0.8.0"
 
+# Reranking dependencies (Feature 01 - Two-Stage Reranking)
+sentence-transformers = "^3.4.0"
+
 # Optional GraphRAG dependencies (Feature 113)
 langextract = {version = "^1.0.0", optional = true}
 llama-index-graph-stores-kuzu = {version = "^0.9.0", optional = true}

--- a/agent-brain-server/tests/contract/test_query_modes.py
+++ b/agent-brain-server/tests/contract/test_query_modes.py
@@ -169,12 +169,12 @@ class TestRerankingContract:
 
         settings = Settings()
         # All reranking settings should be present
+        # Note: RERANKER_BATCH_SIZE removed (CrossEncoder handles batching)
         assert hasattr(settings, "ENABLE_RERANKING")
         assert hasattr(settings, "RERANKER_PROVIDER")
         assert hasattr(settings, "RERANKER_MODEL")
         assert hasattr(settings, "RERANKER_TOP_K_MULTIPLIER")
         assert hasattr(settings, "RERANKER_MAX_CANDIDATES")
-        assert hasattr(settings, "RERANKER_BATCH_SIZE")
 
     def test_query_result_has_rerank_fields(self) -> None:
         """QueryResult model includes reranking fields."""

--- a/agent-brain-server/tests/contract/test_query_modes.py
+++ b/agent-brain-server/tests/contract/test_query_modes.py
@@ -1,15 +1,16 @@
-"""Contract tests for QueryMode enum values.
+"""Contract tests for QueryMode enum values and QueryResult model.
 
 These tests ensure API stability by verifying that QueryMode enum values
 remain consistent across releases. Changing these values would be a
 breaking change for API consumers.
 
 Feature 113: GraphRAG Integration
+Feature 123: Two-Stage Reranking
 """
 
 import pytest
 
-from agent_brain_server.models.query import QueryMode
+from agent_brain_server.models.query import QueryMode, QueryResult
 
 
 class TestQueryModeContract:
@@ -86,9 +87,7 @@ class TestQueryModeContract:
             ("MULTI", "multi"),
         ],
     )
-    def test_query_mode_name_value_pairs(
-        self, mode_name: str, mode_value: str
-    ) -> None:
+    def test_query_mode_name_value_pairs(self, mode_name: str, mode_value: str) -> None:
         """Verify all query mode name-value pairs are correct."""
         mode = getattr(QueryMode, mode_name)
         assert mode.value == mode_value
@@ -149,3 +148,177 @@ class TestQueryModeGraphRAGContract:
 
         with pytest.raises(ValueError):
             QueryMode("GRAPH")  # Case sensitive - must be lowercase
+
+
+class TestRerankingContract:
+    """Contract tests for two-stage reranking feature (Feature 123).
+
+    These tests verify the API contract for reranking fields and settings.
+    """
+
+    def test_reranking_disabled_by_default(self) -> None:
+        """ENABLE_RERANKING is false by default for backward compatibility."""
+        from agent_brain_server.config.settings import Settings
+
+        settings = Settings()
+        assert settings.ENABLE_RERANKING is False
+
+    def test_reranker_settings_exist(self) -> None:
+        """All reranker settings are defined in Settings."""
+        from agent_brain_server.config.settings import Settings
+
+        settings = Settings()
+        # All reranking settings should be present
+        assert hasattr(settings, "ENABLE_RERANKING")
+        assert hasattr(settings, "RERANKER_PROVIDER")
+        assert hasattr(settings, "RERANKER_MODEL")
+        assert hasattr(settings, "RERANKER_TOP_K_MULTIPLIER")
+        assert hasattr(settings, "RERANKER_MAX_CANDIDATES")
+        assert hasattr(settings, "RERANKER_BATCH_SIZE")
+
+    def test_query_result_has_rerank_fields(self) -> None:
+        """QueryResult model includes reranking fields."""
+        result = QueryResult(
+            text="test content",
+            source="test.py",
+            score=0.9,
+            chunk_id="c1",
+            rerank_score=0.85,
+            original_rank=3,
+        )
+        assert result.rerank_score == 0.85
+        assert result.original_rank == 3
+
+    def test_rerank_fields_optional(self) -> None:
+        """Reranking fields are optional (None by default)."""
+        result = QueryResult(
+            text="test",
+            source="test.py",
+            score=0.9,
+            chunk_id="c1",
+        )
+        assert result.rerank_score is None
+        assert result.original_rank is None
+
+    def test_rerank_score_field_type(self) -> None:
+        """rerank_score field accepts float values."""
+        result = QueryResult(
+            text="test",
+            source="test.py",
+            score=0.9,
+            chunk_id="c1",
+            rerank_score=0.123456,
+        )
+        assert isinstance(result.rerank_score, float)
+        assert result.rerank_score == 0.123456
+
+    def test_original_rank_field_type(self) -> None:
+        """original_rank field accepts integer values (1-indexed)."""
+        result = QueryResult(
+            text="test",
+            source="test.py",
+            score=0.9,
+            chunk_id="c1",
+            original_rank=1,
+        )
+        assert isinstance(result.original_rank, int)
+        assert result.original_rank == 1
+
+    def test_rerank_score_can_be_higher_than_original(self) -> None:
+        """rerank_score can differ from original score."""
+        result = QueryResult(
+            text="test",
+            source="test.py",
+            score=0.5,  # Original score
+            chunk_id="c1",
+            rerank_score=0.95,  # Higher rerank score
+            original_rank=10,  # Was ranked 10th, now might be higher
+        )
+        assert result.rerank_score > result.score
+
+    def test_query_result_serialization_includes_rerank_fields(self) -> None:
+        """QueryResult serialization includes reranking fields."""
+        result = QueryResult(
+            text="test",
+            source="test.py",
+            score=0.9,
+            chunk_id="c1",
+            rerank_score=0.85,
+            original_rank=5,
+        )
+        data = result.model_dump()
+        assert "rerank_score" in data
+        assert "original_rank" in data
+        assert data["rerank_score"] == 0.85
+        assert data["original_rank"] == 5
+
+    def test_query_result_serialization_null_rerank_fields(self) -> None:
+        """QueryResult serialization handles null reranking fields."""
+        result = QueryResult(
+            text="test",
+            source="test.py",
+            score=0.9,
+            chunk_id="c1",
+        )
+        data = result.model_dump()
+        assert "rerank_score" in data
+        assert "original_rank" in data
+        assert data["rerank_score"] is None
+        assert data["original_rank"] is None
+
+
+class TestRerankerProviderContract:
+    """Contract tests for reranker provider types."""
+
+    def test_reranker_provider_types_exist(self) -> None:
+        """RerankerProviderType enum has required values."""
+        from agent_brain_server.providers.base import RerankerProviderType
+
+        assert hasattr(RerankerProviderType, "SENTENCE_TRANSFORMERS")
+        assert hasattr(RerankerProviderType, "OLLAMA")
+
+    def test_reranker_provider_values(self) -> None:
+        """RerankerProviderType values match expected strings."""
+        from agent_brain_server.providers.base import RerankerProviderType
+
+        assert (
+            RerankerProviderType.SENTENCE_TRANSFORMERS.value == "sentence-transformers"
+        )
+        assert RerankerProviderType.OLLAMA.value == "ollama"
+
+    def test_reranker_config_exists(self) -> None:
+        """RerankerConfig model exists and is importable."""
+        from agent_brain_server.config.provider_config import RerankerConfig
+
+        config = RerankerConfig()
+        assert config.provider is not None
+        assert config.model is not None
+
+    def test_reranker_config_default_values(self) -> None:
+        """RerankerConfig has sensible defaults."""
+        from agent_brain_server.config.provider_config import RerankerConfig
+        from agent_brain_server.providers.base import RerankerProviderType
+
+        config = RerankerConfig()
+        # Default provider should be sentence-transformers
+        assert config.provider == RerankerProviderType.SENTENCE_TRANSFORMERS
+        # Default model should be the fast MiniLM model
+        assert "MiniLM" in config.model
+
+    def test_provider_registry_has_reranker_methods(self) -> None:
+        """ProviderRegistry has reranker-related methods."""
+        from agent_brain_server.providers.factory import ProviderRegistry
+
+        assert hasattr(ProviderRegistry, "register_reranker_provider")
+        assert hasattr(ProviderRegistry, "get_reranker_provider")
+        assert hasattr(ProviderRegistry, "get_available_reranker_providers")
+
+    def test_reranker_providers_are_registered(self) -> None:
+        """Both reranker providers are registered on import."""
+        # Import reranker module to trigger registration
+        import agent_brain_server.providers.reranker  # noqa: F401
+        from agent_brain_server.providers.factory import ProviderRegistry
+
+        available = ProviderRegistry.get_available_reranker_providers()
+        assert "sentence-transformers" in available
+        assert "ollama" in available

--- a/agent-brain-server/tests/unit/providers/test_reranker_providers.py
+++ b/agent-brain-server/tests/unit/providers/test_reranker_providers.py
@@ -1,0 +1,547 @@
+"""Unit tests for reranker providers.
+
+Tests cover:
+- RerankerProvider protocol implementation
+- SentenceTransformerRerankerProvider functionality
+- OllamaRerankerProvider functionality
+- Provider registration and caching
+- Graceful error handling and degradation
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent_brain_server.config.provider_config import RerankerConfig
+from agent_brain_server.providers.base import RerankerProviderType
+from agent_brain_server.providers.factory import ProviderRegistry
+from agent_brain_server.providers.reranker import (
+    BaseRerankerProvider,
+    OllamaRerankerProvider,
+    RerankerProvider,
+    SentenceTransformerRerankerProvider,
+)
+
+
+class TestRerankerProtocol:
+    """Test RerankerProvider protocol implementation."""
+
+    def test_sentence_transformer_implements_protocol(self) -> None:
+        """SentenceTransformerRerankerProvider implements RerankerProvider."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.SENTENCE_TRANSFORMERS,
+            model="cross-encoder/ms-marco-MiniLM-L-6-v2",
+        )
+        provider = SentenceTransformerRerankerProvider(config)
+        assert isinstance(provider, RerankerProvider)
+
+    def test_ollama_implements_protocol(self) -> None:
+        """OllamaRerankerProvider implements RerankerProvider."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.OLLAMA,
+            model="llama3.2:1b",
+        )
+        provider = OllamaRerankerProvider(config)
+        assert isinstance(provider, RerankerProvider)
+
+    def test_base_reranker_is_abstract(self) -> None:
+        """BaseRerankerProvider cannot be instantiated directly."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.SENTENCE_TRANSFORMERS,
+            model="test-model",
+        )
+        with pytest.raises(TypeError, match="abstract"):
+            BaseRerankerProvider(config)  # type: ignore[abstract]
+
+
+class TestProviderRegistry:
+    """Test provider registration and caching."""
+
+    def setup_method(self) -> None:
+        """Clear cache before each test."""
+        ProviderRegistry.clear_cache()
+
+    def test_sentence_transformers_registered(self) -> None:
+        """SentenceTransformers provider is registered."""
+        available = ProviderRegistry.get_available_reranker_providers()
+        assert "sentence-transformers" in available
+
+    def test_ollama_registered(self) -> None:
+        """Ollama provider is registered."""
+        available = ProviderRegistry.get_available_reranker_providers()
+        assert "ollama" in available
+
+    def test_get_reranker_provider_sentence_transformers(self) -> None:
+        """Can get sentence-transformers reranker provider from registry."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.SENTENCE_TRANSFORMERS,
+            model="cross-encoder/ms-marco-MiniLM-L-6-v2",
+        )
+        provider = ProviderRegistry.get_reranker_provider(config)
+        assert provider.provider_name == "SentenceTransformers"
+
+    def test_get_reranker_provider_ollama(self) -> None:
+        """Can get ollama reranker provider from registry."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.OLLAMA,
+            model="llama3.2:1b",
+        )
+        provider = ProviderRegistry.get_reranker_provider(config)
+        assert provider.provider_name == "Ollama"
+
+    def test_provider_caching(self) -> None:
+        """Provider instances are cached by type and model."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.SENTENCE_TRANSFORMERS,
+            model="cross-encoder/ms-marco-MiniLM-L-6-v2",
+        )
+        provider1 = ProviderRegistry.get_reranker_provider(config)
+        provider2 = ProviderRegistry.get_reranker_provider(config)
+        assert provider1 is provider2
+
+    def test_different_models_get_different_instances(self) -> None:
+        """Different models create different provider instances."""
+        config1 = RerankerConfig(
+            provider=RerankerProviderType.SENTENCE_TRANSFORMERS,
+            model="cross-encoder/ms-marco-MiniLM-L-6-v2",
+        )
+        config2 = RerankerConfig(
+            provider=RerankerProviderType.SENTENCE_TRANSFORMERS,
+            model="cross-encoder/ms-marco-MiniLM-L-12-v2",
+        )
+        provider1 = ProviderRegistry.get_reranker_provider(config1)
+        provider2 = ProviderRegistry.get_reranker_provider(config2)
+        assert provider1 is not provider2
+        assert provider1.model_name == "cross-encoder/ms-marco-MiniLM-L-6-v2"
+        assert provider2.model_name == "cross-encoder/ms-marco-MiniLM-L-12-v2"
+
+    def test_unregistered_provider_raises_error(self) -> None:
+        """Getting unregistered provider raises ProviderNotFoundError."""
+        from agent_brain_server.providers.exceptions import ProviderNotFoundError
+
+        # Temporarily remove all reranker providers
+        original = ProviderRegistry._reranker_providers.copy()
+        ProviderRegistry._reranker_providers.clear()
+        try:
+            config = RerankerConfig(
+                provider=RerankerProviderType.SENTENCE_TRANSFORMERS,
+                model="test-model",
+            )
+            with pytest.raises(ProviderNotFoundError):
+                ProviderRegistry.get_reranker_provider(config)
+        finally:
+            ProviderRegistry._reranker_providers.update(original)
+
+
+class TestSentenceTransformerReranker:
+    """Test SentenceTransformerRerankerProvider."""
+
+    @pytest.fixture
+    def provider(self) -> SentenceTransformerRerankerProvider:
+        """Create provider instance."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.SENTENCE_TRANSFORMERS,
+            model="cross-encoder/ms-marco-MiniLM-L-6-v2",
+        )
+        return SentenceTransformerRerankerProvider(config)
+
+    def test_provider_name(self, provider: SentenceTransformerRerankerProvider) -> None:
+        """Provider returns correct name."""
+        assert provider.provider_name == "SentenceTransformers"
+
+    def test_model_name(self, provider: SentenceTransformerRerankerProvider) -> None:
+        """Provider returns correct model."""
+        assert provider.model_name == "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+    def test_default_is_available(
+        self, provider: SentenceTransformerRerankerProvider
+    ) -> None:
+        """Provider reports is_available correctly (depends on model loading)."""
+        # The actual model loading may or may not work in test environment
+        # Just verify the method exists and returns a bool
+        result = provider.is_available()
+        assert isinstance(result, bool)
+
+    @pytest.mark.asyncio
+    async def test_rerank_empty_documents(
+        self, provider: SentenceTransformerRerankerProvider
+    ) -> None:
+        """Reranking empty list returns empty list."""
+        result = await provider.rerank("query", [], top_k=5)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_rerank_returns_tuples(
+        self, provider: SentenceTransformerRerankerProvider
+    ) -> None:
+        """Rerank returns list of (index, score) tuples in correct order."""
+        # Mock the CrossEncoder to avoid loading real model
+        mock_encoder = MagicMock()
+        mock_encoder.rank.return_value = [
+            {"corpus_id": 1, "score": 0.9},
+            {"corpus_id": 0, "score": 0.7},
+            {"corpus_id": 2, "score": 0.5},
+        ]
+
+        with patch.object(provider, "_ensure_model_loaded", return_value=mock_encoder):
+            result = await provider.rerank(
+                "test query",
+                ["doc0", "doc1", "doc2"],
+                top_k=3,
+            )
+
+            assert len(result) == 3
+            assert result[0] == (1, 0.9)
+            assert result[1] == (0, 0.7)
+            assert result[2] == (2, 0.5)
+
+    @pytest.mark.asyncio
+    async def test_rerank_respects_top_k(
+        self, provider: SentenceTransformerRerankerProvider
+    ) -> None:
+        """Rerank limits results to top_k."""
+        mock_encoder = MagicMock()
+        mock_encoder.rank.return_value = [
+            {"corpus_id": 0, "score": 0.9},
+            {"corpus_id": 1, "score": 0.8},
+        ]
+
+        with patch.object(provider, "_ensure_model_loaded", return_value=mock_encoder):
+            await provider.rerank(
+                "test query",
+                ["doc0", "doc1", "doc2", "doc3", "doc4"],
+                top_k=2,
+            )
+
+            # CrossEncoder.rank is called with top_k
+            mock_encoder.rank.assert_called_once()
+            call_kwargs = mock_encoder.rank.call_args
+            assert call_kwargs[1]["top_k"] == 2
+
+    @pytest.mark.asyncio
+    async def test_rerank_top_k_exceeds_documents(
+        self, provider: SentenceTransformerRerankerProvider
+    ) -> None:
+        """Rerank handles top_k larger than document count."""
+        mock_encoder = MagicMock()
+        mock_encoder.rank.return_value = [
+            {"corpus_id": 0, "score": 0.9},
+            {"corpus_id": 1, "score": 0.8},
+        ]
+
+        with patch.object(provider, "_ensure_model_loaded", return_value=mock_encoder):
+            await provider.rerank(
+                "test query",
+                ["doc0", "doc1"],  # Only 2 docs
+                top_k=10,  # Request 10
+            )
+
+            # effective_top_k should be min(10, 2) = 2
+            call_kwargs = mock_encoder.rank.call_args
+            assert call_kwargs[1]["top_k"] == 2
+
+
+class TestOllamaReranker:
+    """Test OllamaRerankerProvider."""
+
+    @pytest.fixture
+    def provider(self) -> OllamaRerankerProvider:
+        """Create provider instance."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.OLLAMA,
+            model="llama3.2:1b",
+        )
+        return OllamaRerankerProvider(config)
+
+    def test_provider_name(self, provider: OllamaRerankerProvider) -> None:
+        """Provider returns correct name."""
+        assert provider.provider_name == "Ollama"
+
+    def test_model_name(self, provider: OllamaRerankerProvider) -> None:
+        """Provider returns correct model."""
+        assert provider.model_name == "llama3.2:1b"
+
+    def test_default_base_url(self, provider: OllamaRerankerProvider) -> None:
+        """Provider uses default Ollama base URL."""
+        assert provider._base_url == "http://localhost:11434"
+
+    def test_custom_base_url(self) -> None:
+        """Provider respects custom base URL."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.OLLAMA,
+            model="llama3.2:1b",
+            base_url="http://custom:11434",
+        )
+        provider = OllamaRerankerProvider(config)
+        assert provider._base_url == "http://custom:11434"
+
+    def test_parse_score_valid_integer(self, provider: OllamaRerankerProvider) -> None:
+        """Parse score handles integer correctly."""
+        assert provider._parse_score("8") == 8.0
+
+    def test_parse_score_valid_float(self, provider: OllamaRerankerProvider) -> None:
+        """Parse score handles float correctly."""
+        assert provider._parse_score("7.5") == 7.5
+
+    def test_parse_score_with_text(self, provider: OllamaRerankerProvider) -> None:
+        """Parse score extracts number from surrounding text."""
+        assert provider._parse_score("The relevance score is 9") == 9.0
+        assert provider._parse_score("Score: 8.5 out of 10") == 8.5
+
+    def test_parse_score_invalid_returns_zero(
+        self, provider: OllamaRerankerProvider
+    ) -> None:
+        """Parse score returns 0 for text without numbers."""
+        assert provider._parse_score("no number here") == 0.0
+        assert provider._parse_score("") == 0.0
+
+    def test_parse_score_clamps_to_max(self, provider: OllamaRerankerProvider) -> None:
+        """Parse score clamps values above 10 to max of 10."""
+        assert provider._parse_score("15") == 10.0
+        assert provider._parse_score("100") == 10.0
+
+    def test_parse_score_clamps_to_min(self, provider: OllamaRerankerProvider) -> None:
+        """Parse score clamps negative values to 0."""
+        # Regex won't capture negative numbers, so -5 becomes 5
+        # But the clamp should handle edge cases
+        assert provider._parse_score("0") == 0.0
+
+    @pytest.mark.asyncio
+    async def test_rerank_empty_documents(
+        self, provider: OllamaRerankerProvider
+    ) -> None:
+        """Reranking empty list returns empty list."""
+        result = await provider.rerank("query", [], top_k=5)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_rerank_with_mock_response(
+        self, provider: OllamaRerankerProvider
+    ) -> None:
+        """Rerank works with mocked HTTP response."""
+        # Create mock response
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"message": {"content": "8"}}
+        mock_response.raise_for_status = MagicMock()
+
+        # Create mock client
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch.object(provider, "_get_client", return_value=mock_client):
+            result = await provider.rerank(
+                "test query",
+                ["doc1", "doc2"],
+                top_k=2,
+            )
+
+            # Both docs should have scores
+            assert len(result) == 2
+            # Scores should be parsed correctly (both get score 8)
+            scores = [r[1] for r in result]
+            assert all(s == 8.0 for s in scores)
+
+    @pytest.mark.asyncio
+    async def test_rerank_sorts_by_score_descending(
+        self, provider: OllamaRerankerProvider
+    ) -> None:
+        """Rerank sorts results by score in descending order."""
+        # Mock different scores for different documents
+        call_count = 0
+
+        async def mock_post(*args, **kwargs):
+            nonlocal call_count
+            scores = ["5", "9", "7"]  # doc0=5, doc1=9, doc2=7
+            response = MagicMock()
+            response.status_code = 200
+            response.json.return_value = {"message": {"content": scores[call_count]}}
+            response.raise_for_status = MagicMock()
+            call_count += 1
+            return response
+
+        mock_client = AsyncMock()
+        mock_client.post = mock_post
+
+        with patch.object(provider, "_get_client", return_value=mock_client):
+            result = await provider.rerank(
+                "test query",
+                ["doc0", "doc1", "doc2"],
+                top_k=3,
+            )
+
+            # Should be sorted by score descending
+            assert len(result) == 3
+            # doc1 (score 9) should be first
+            assert result[0] == (1, 9.0)
+            # doc2 (score 7) should be second
+            assert result[1] == (2, 7.0)
+            # doc0 (score 5) should be third
+            assert result[2] == (0, 5.0)
+
+    @pytest.mark.asyncio
+    async def test_rerank_respects_top_k(
+        self, provider: OllamaRerankerProvider
+    ) -> None:
+        """Rerank returns only top_k results."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"message": {"content": "8"}}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch.object(provider, "_get_client", return_value=mock_client):
+            result = await provider.rerank(
+                "test query",
+                ["doc0", "doc1", "doc2", "doc3", "doc4"],
+                top_k=2,
+            )
+
+            # Should return only 2 results
+            assert len(result) == 2
+
+
+class TestGracefulDegradation:
+    """Test graceful degradation scenarios."""
+
+    @pytest.mark.asyncio
+    async def test_ollama_handles_connection_error(self) -> None:
+        """Ollama provider handles connection errors gracefully."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.OLLAMA,
+            model="llama3.2:1b",
+        )
+        provider = OllamaRerankerProvider(config)
+
+        # Mock connection failure
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=Exception("Connection refused"))
+
+        with patch.object(provider, "_get_client", return_value=mock_client):
+            result = await provider.rerank(
+                "test query",
+                ["doc1", "doc2"],
+                top_k=2,
+            )
+
+            # Should return results with 0.0 scores (fallback)
+            assert len(result) == 2
+            assert all(r[1] == 0.0 for r in result)
+
+    @pytest.mark.asyncio
+    async def test_ollama_handles_http_error(self) -> None:
+        """Ollama provider handles HTTP errors gracefully."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.OLLAMA,
+            model="llama3.2:1b",
+        )
+        provider = OllamaRerankerProvider(config)
+
+        import httpx
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "Server error",
+                request=MagicMock(),
+                response=MagicMock(status_code=500),
+            )
+        )
+
+        with patch.object(provider, "_get_client", return_value=mock_client):
+            result = await provider.rerank(
+                "test query",
+                ["doc1", "doc2"],
+                top_k=2,
+            )
+
+            # Should return results with 0.0 scores
+            assert len(result) == 2
+            assert all(r[1] == 0.0 for r in result)
+
+    @pytest.mark.asyncio
+    async def test_ollama_handles_malformed_response(self) -> None:
+        """Ollama provider handles malformed responses gracefully."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.OLLAMA,
+            model="llama3.2:1b",
+        )
+        provider = OllamaRerankerProvider(config)
+
+        # Mock response with malformed JSON structure
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {}  # Missing 'message' key
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch.object(provider, "_get_client", return_value=mock_client):
+            result = await provider.rerank(
+                "test query",
+                ["doc1", "doc2"],
+                top_k=2,
+            )
+
+            # Should return results with 0.0 scores (parsed from empty)
+            assert len(result) == 2
+            assert all(r[1] == 0.0 for r in result)
+
+    def test_ollama_is_available_returns_false_on_connection_error(self) -> None:
+        """Ollama is_available returns False when server unreachable."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.OLLAMA,
+            model="llama3.2:1b",
+            base_url="http://nonexistent:11434",
+        )
+        provider = OllamaRerankerProvider(config)
+
+        # is_available should return False, not raise
+        result = provider.is_available()
+        assert result is False
+
+
+class TestRerankerConfigParams:
+    """Test configuration parameter handling."""
+
+    def test_batch_size_from_params(self) -> None:
+        """Batch size is read from params."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.SENTENCE_TRANSFORMERS,
+            model="test-model",
+            params={"batch_size": 64},
+        )
+        provider = SentenceTransformerRerankerProvider(config)
+        assert provider._batch_size == 64
+
+    def test_default_batch_size(self) -> None:
+        """Default batch size is used when not specified."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.SENTENCE_TRANSFORMERS,
+            model="test-model",
+        )
+        provider = SentenceTransformerRerankerProvider(config)
+        assert provider._batch_size == 32  # Default value
+
+    def test_ollama_timeout_from_params(self) -> None:
+        """Ollama timeout is read from params."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.OLLAMA,
+            model="test-model",
+            params={"timeout": 60.0},
+        )
+        provider = OllamaRerankerProvider(config)
+        assert provider._timeout == 60.0
+
+    def test_ollama_max_concurrent_from_params(self) -> None:
+        """Ollama max_concurrent is read from params."""
+        config = RerankerConfig(
+            provider=RerankerProviderType.OLLAMA,
+            model="test-model",
+            params={"max_concurrent": 10},
+        )
+        provider = OllamaRerankerProvider(config)
+        assert provider._max_concurrent == 10

--- a/agent-brain-server/tests/unit/services/__init__.py
+++ b/agent-brain-server/tests/unit/services/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for services."""

--- a/agent-brain-server/tests/unit/services/test_query_service_reranking.py
+++ b/agent-brain-server/tests/unit/services/test_query_service_reranking.py
@@ -1,0 +1,453 @@
+"""Tests for query service reranking integration.
+
+Tests cover:
+- _rerank_results method behavior
+- Graceful fallback on reranker errors
+- Reranking disabled behavior
+- Score and metadata propagation
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent_brain_server.models import QueryMode, QueryRequest, QueryResult
+from agent_brain_server.services.query_service import QueryService
+
+
+class TestRerankerResultsMethod:
+    """Test _rerank_results method in isolation."""
+
+    @pytest.fixture
+    def mock_dependencies(self):
+        """Create mocked dependencies for QueryService."""
+        mock_vector_store = MagicMock()
+        mock_vector_store.is_initialized = True
+        mock_vector_store.get_count = AsyncMock(return_value=100)
+
+        mock_embedding_gen = MagicMock()
+        mock_embedding_gen.embed_query = AsyncMock(return_value=[0.1] * 768)
+
+        mock_bm25 = MagicMock()
+        mock_bm25.is_initialized = True
+
+        mock_graph = MagicMock()
+
+        return {
+            "vector_store": mock_vector_store,
+            "embedding_generator": mock_embedding_gen,
+            "bm25_manager": mock_bm25,
+            "graph_index_manager": mock_graph,
+        }
+
+    @pytest.fixture
+    def query_service(self, mock_dependencies):
+        """Create QueryService with mocked dependencies."""
+        return QueryService(
+            vector_store=mock_dependencies["vector_store"],
+            embedding_generator=mock_dependencies["embedding_generator"],
+            bm25_manager=mock_dependencies["bm25_manager"],
+            graph_index_manager=mock_dependencies["graph_index_manager"],
+        )
+
+    @pytest.fixture
+    def sample_results(self) -> list[QueryResult]:
+        """Create sample query results for reranking tests."""
+        return [
+            QueryResult(
+                text=f"Document {i} content with various information.",
+                source=f"doc{i}.txt",
+                score=1.0 - (i * 0.1),  # Decreasing scores: 1.0, 0.9, 0.8, ...
+                vector_score=1.0 - (i * 0.1),
+                chunk_id=f"chunk_{i}",
+            )
+            for i in range(10)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_rerank_results_empty_input(self, query_service) -> None:
+        """_rerank_results handles empty input gracefully."""
+        result = await query_service._rerank_results([], "test query", top_k=5)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_rerank_results_success(self, query_service, sample_results) -> None:
+        """_rerank_results applies reranking correctly."""
+        # Mock the reranker provider
+        mock_reranker = MagicMock()
+        mock_reranker.is_available.return_value = True
+        mock_reranker.provider_name = "MockReranker"
+        # Return reordered results: doc5 (best), doc2, doc0
+        mock_reranker.rerank = AsyncMock(return_value=[(5, 0.95), (2, 0.85), (0, 0.75)])
+
+        mock_settings = MagicMock()
+        mock_settings.reranker = MagicMock()
+
+        with (
+            patch(
+                "agent_brain_server.services.query_service.load_provider_settings",
+                return_value=mock_settings,
+            ),
+            patch(
+                "agent_brain_server.services.query_service.ProviderRegistry"
+            ) as mock_registry,
+        ):
+            mock_registry.get_reranker_provider.return_value = mock_reranker
+
+            result = await query_service._rerank_results(
+                sample_results, "test query", top_k=3
+            )
+
+            # Verify correct number of results
+            assert len(result) == 3
+
+            # Check documents are reordered correctly
+            assert result[0].text == "Document 5 content with various information."
+            assert result[1].text == "Document 2 content with various information."
+            assert result[2].text == "Document 0 content with various information."
+
+            # Check rerank scores are set
+            assert result[0].rerank_score == 0.95
+            assert result[1].rerank_score == 0.85
+            assert result[2].rerank_score == 0.75
+
+            # Check original ranks are set (1-indexed)
+            assert result[0].original_rank == 6  # doc5 was at index 5 -> rank 6
+            assert result[1].original_rank == 3  # doc2 was at index 2 -> rank 3
+            assert result[2].original_rank == 1  # doc0 was at index 0 -> rank 1
+
+    @pytest.mark.asyncio
+    async def test_rerank_results_preserves_original_scores(
+        self, query_service, sample_results
+    ) -> None:
+        """_rerank_results preserves vector_score and bm25_score from originals."""
+        # Add BM25 scores to some results
+        sample_results[0].bm25_score = 0.8
+        sample_results[2].bm25_score = 0.6
+
+        mock_reranker = MagicMock()
+        mock_reranker.is_available.return_value = True
+        mock_reranker.provider_name = "MockReranker"
+        mock_reranker.rerank = AsyncMock(return_value=[(0, 0.9), (2, 0.8)])
+
+        mock_settings = MagicMock()
+        mock_settings.reranker = MagicMock()
+
+        with (
+            patch(
+                "agent_brain_server.services.query_service.load_provider_settings",
+                return_value=mock_settings,
+            ),
+            patch(
+                "agent_brain_server.services.query_service.ProviderRegistry"
+            ) as mock_registry,
+        ):
+            mock_registry.get_reranker_provider.return_value = mock_reranker
+
+            result = await query_service._rerank_results(
+                sample_results, "test query", top_k=2
+            )
+
+            # Original scores should be preserved
+            assert result[0].vector_score == 1.0  # doc0's original vector score
+            assert result[0].bm25_score == 0.8  # doc0's original bm25 score
+            assert result[1].bm25_score == 0.6  # doc2's original bm25 score
+
+    @pytest.mark.asyncio
+    async def test_rerank_results_fallback_on_provider_error(
+        self, query_service, sample_results
+    ) -> None:
+        """_rerank_results falls back to stage 1 on provider error."""
+        mock_settings = MagicMock()
+        mock_settings.reranker = MagicMock()
+
+        with (
+            patch(
+                "agent_brain_server.services.query_service.load_provider_settings",
+                return_value=mock_settings,
+            ),
+            patch(
+                "agent_brain_server.services.query_service.ProviderRegistry"
+            ) as mock_registry,
+        ):
+            mock_registry.get_reranker_provider.side_effect = Exception(
+                "Provider not found"
+            )
+
+            result = await query_service._rerank_results(
+                sample_results, "test query", top_k=3
+            )
+
+            # Should return first 3 results unchanged (original order)
+            assert len(result) == 3
+            assert result[0].text == "Document 0 content with various information."
+            assert result[1].text == "Document 1 content with various information."
+            assert result[2].text == "Document 2 content with various information."
+
+    @pytest.mark.asyncio
+    async def test_rerank_results_fallback_on_rerank_failure(
+        self, query_service, sample_results
+    ) -> None:
+        """_rerank_results falls back when rerank() raises exception."""
+        mock_reranker = MagicMock()
+        mock_reranker.is_available.return_value = True
+        mock_reranker.provider_name = "MockReranker"
+        mock_reranker.rerank = AsyncMock(side_effect=Exception("Reranking failed"))
+
+        mock_settings = MagicMock()
+        mock_settings.reranker = MagicMock()
+
+        with (
+            patch(
+                "agent_brain_server.services.query_service.load_provider_settings",
+                return_value=mock_settings,
+            ),
+            patch(
+                "agent_brain_server.services.query_service.ProviderRegistry"
+            ) as mock_registry,
+        ):
+            mock_registry.get_reranker_provider.return_value = mock_reranker
+
+            result = await query_service._rerank_results(
+                sample_results, "test query", top_k=3
+            )
+
+            # Should return first 3 results unchanged
+            assert len(result) == 3
+            assert result[0].text == "Document 0 content with various information."
+
+    @pytest.mark.asyncio
+    async def test_rerank_results_provider_unavailable(
+        self, query_service, sample_results
+    ) -> None:
+        """_rerank_results falls back when provider reports unavailable."""
+        mock_reranker = MagicMock()
+        mock_reranker.is_available.return_value = False
+        mock_reranker.provider_name = "MockReranker"
+
+        mock_settings = MagicMock()
+        mock_settings.reranker = MagicMock()
+
+        with (
+            patch(
+                "agent_brain_server.services.query_service.load_provider_settings",
+                return_value=mock_settings,
+            ),
+            patch(
+                "agent_brain_server.services.query_service.ProviderRegistry"
+            ) as mock_registry,
+        ):
+            mock_registry.get_reranker_provider.return_value = mock_reranker
+
+            result = await query_service._rerank_results(
+                sample_results, "test query", top_k=3
+            )
+
+            # Should return first 3 results unchanged
+            assert len(result) == 3
+            assert result[0].text == "Document 0 content with various information."
+
+
+class TestExecuteQueryWithReranking:
+    """Test execute_query behavior with reranking settings."""
+
+    def test_reranking_disabled_by_default(self) -> None:
+        """Reranking is disabled by default in settings."""
+        from agent_brain_server.config.settings import Settings
+
+        settings = Settings()
+        assert settings.ENABLE_RERANKING is False
+
+    def test_default_reranker_settings(self) -> None:
+        """Default reranker settings are sensible."""
+        from agent_brain_server.config.settings import Settings
+
+        settings = Settings()
+        assert settings.RERANKER_PROVIDER == "sentence-transformers"
+        assert settings.RERANKER_MODEL == "cross-encoder/ms-marco-MiniLM-L-6-v2"
+        assert settings.RERANKER_TOP_K_MULTIPLIER == 10
+        assert settings.RERANKER_MAX_CANDIDATES == 100
+
+    def test_stage1_topk_calculation_basic(self) -> None:
+        """Stage 1 top_k is multiplied correctly."""
+        # With top_k=5 and multiplier=10, stage1 should be 50
+        top_k = 5
+        multiplier = 10
+        max_candidates = 100
+        expected_stage1 = min(top_k * multiplier, max_candidates)
+        assert expected_stage1 == 50
+
+    def test_stage1_topk_calculation_capped(self) -> None:
+        """Stage 1 top_k is capped at max_candidates."""
+        # With top_k=15 and multiplier=10, stage1 should be capped at 100
+        top_k = 15
+        multiplier = 10
+        max_candidates = 100
+        expected_stage1 = min(top_k * multiplier, max_candidates)
+        assert expected_stage1 == 100
+
+    @pytest.mark.asyncio
+    async def test_execute_query_calls_rerank_when_enabled(self) -> None:
+        """execute_query calls _rerank_results when reranking is enabled."""
+        from agent_brain_server.config.settings import Settings
+
+        # Create mock services
+        mock_vector_store = MagicMock()
+        mock_vector_store.is_initialized = True
+        mock_vector_store.get_count = AsyncMock(return_value=100)
+        mock_vector_store.similarity_search = AsyncMock(
+            return_value=[
+                MagicMock(
+                    text=f"doc{i}",
+                    chunk_id=f"chunk_{i}",
+                    score=1.0 - i * 0.1,
+                    metadata={"source": f"doc{i}.txt"},
+                )
+                for i in range(50)
+            ]
+        )
+
+        mock_embedding_gen = MagicMock()
+        mock_embedding_gen.embed_query = AsyncMock(return_value=[0.1] * 768)
+
+        mock_bm25 = MagicMock()
+        mock_bm25.is_initialized = True
+        mock_bm25.search_with_filters = AsyncMock(return_value=[])
+
+        mock_graph = MagicMock()
+
+        query_service = QueryService(
+            vector_store=mock_vector_store,
+            embedding_generator=mock_embedding_gen,
+            bm25_manager=mock_bm25,
+            graph_index_manager=mock_graph,
+        )
+
+        # Mock settings with reranking enabled
+        mock_settings = Settings(
+            ENABLE_RERANKING=True,
+            RERANKER_TOP_K_MULTIPLIER=10,
+            RERANKER_MAX_CANDIDATES=100,
+        )
+
+        # Mock _rerank_results to track if it's called
+        with (
+            patch.object(
+                query_service, "_rerank_results", new_callable=AsyncMock
+            ) as mock_rerank,
+            patch("agent_brain_server.services.query_service.settings", mock_settings),
+        ):
+            mock_rerank.return_value = [
+                QueryResult(
+                    text="reranked doc",
+                    source="reranked.txt",
+                    score=0.9,
+                    chunk_id="chunk_reranked",
+                )
+            ]
+
+            request = QueryRequest(query="test query", top_k=5, mode=QueryMode.HYBRID)
+            await query_service.execute_query(request)
+
+            # _rerank_results should have been called
+            mock_rerank.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_execute_query_skips_rerank_when_disabled(self) -> None:
+        """execute_query does not call _rerank_results when disabled."""
+        # Create mock services
+        mock_vector_store = MagicMock()
+        mock_vector_store.is_initialized = True
+        mock_vector_store.get_count = AsyncMock(return_value=10)
+        mock_vector_store.similarity_search = AsyncMock(
+            return_value=[
+                MagicMock(
+                    text=f"doc{i}",
+                    chunk_id=f"chunk_{i}",
+                    score=0.9,
+                    metadata={"source": f"doc{i}.txt"},
+                )
+                for i in range(5)
+            ]
+        )
+
+        mock_embedding_gen = MagicMock()
+        mock_embedding_gen.embed_query = AsyncMock(return_value=[0.1] * 768)
+
+        mock_bm25 = MagicMock()
+        mock_bm25.is_initialized = True
+        mock_bm25.search_with_filters = AsyncMock(return_value=[])
+
+        mock_graph = MagicMock()
+
+        query_service = QueryService(
+            vector_store=mock_vector_store,
+            embedding_generator=mock_embedding_gen,
+            bm25_manager=mock_bm25,
+            graph_index_manager=mock_graph,
+        )
+
+        # Mock _rerank_results to track if it's called
+        with patch.object(
+            query_service, "_rerank_results", new_callable=AsyncMock
+        ) as mock_rerank:
+            request = QueryRequest(query="test query", top_k=5, mode=QueryMode.HYBRID)
+            await query_service.execute_query(request)
+
+            # _rerank_results should NOT be called (reranking disabled)
+            mock_rerank.assert_not_called()
+
+
+class TestQueryResultRerankingFields:
+    """Test QueryResult model reranking fields."""
+
+    def test_rerank_score_field_exists(self) -> None:
+        """QueryResult has rerank_score field."""
+        result = QueryResult(
+            text="test",
+            source="test.py",
+            score=0.9,
+            chunk_id="c1",
+            rerank_score=0.85,
+        )
+        assert result.rerank_score == 0.85
+
+    def test_original_rank_field_exists(self) -> None:
+        """QueryResult has original_rank field."""
+        result = QueryResult(
+            text="test",
+            source="test.py",
+            score=0.9,
+            chunk_id="c1",
+            original_rank=3,
+        )
+        assert result.original_rank == 3
+
+    def test_rerank_fields_are_optional(self) -> None:
+        """Reranking fields are optional (None by default)."""
+        result = QueryResult(
+            text="test",
+            source="test.py",
+            score=0.9,
+            chunk_id="c1",
+        )
+        assert result.rerank_score is None
+        assert result.original_rank is None
+
+    def test_all_fields_can_be_set(self) -> None:
+        """All reranking fields can be set together."""
+        result = QueryResult(
+            text="test",
+            source="test.py",
+            score=0.9,
+            vector_score=0.88,
+            bm25_score=0.82,
+            chunk_id="c1",
+            rerank_score=0.95,
+            original_rank=5,
+        )
+        assert result.score == 0.9
+        assert result.vector_score == 0.88
+        assert result.bm25_score == 0.82
+        assert result.rerank_score == 0.95
+        assert result.original_rank == 5

--- a/docs/plans/2026-strategic-recommendations-integration.md
+++ b/docs/plans/2026-strategic-recommendations-integration.md
@@ -1,0 +1,373 @@
+# Agent Brain 2026 Strategic Recommendations Integration Plan
+
+## Overview
+
+This plan integrates the comprehensive 2026 strategic recommendations document into Agent Brain's existing roadmap and planning structure. **The immediate next phase is implementing two-stage reranking.**
+
+## Current State Summary
+
+### Completed Features (Just Shipped)
+- **Feature 113**: GraphRAG Integration with triplet extraction (LLM + AST-based)
+- **Feature 114**: Agent Brain Plugin for Claude Code
+- **Feature 115**: Server-side job queue with JSONL persistence
+
+### Existing Roadmap (from `docs/roadmaps/product-roadmap.md`)
+| Phase | Feature | Status |
+|-------|---------|--------|
+| 5 | Pluggable Providers (103) | NEXT |
+| 6 | PostgreSQL/AlloyDB Backend (104) | Future |
+| 7 | AWS Bedrock Provider (105) | Future |
+| 8 | Vertex AI Provider (106) | Future |
+
+---
+
+## Next Phase: Two-Stage Reranking (Feature 123)
+
+**Priority**: IMMEDIATE - This is the next feature to implement.
+
+**Why Reranking**:
+- Mentioned by both user and Armando Padilla as high-value addition
+- 2026 research shows +3-4% accuracy improvement with sub-100ms latency
+- Builds on existing multi-mode retrieval without breaking changes
+
+---
+
+## Feature 123: Two-Stage Reranking (NEXT PHASE)
+
+### Architecture
+
+```
+Stage 1: Fast Retrieval (BM25 + Vector + Graph, top_k=100)
+    ↓
+RRF Fusion → ~50 candidates
+    ↓
+Stage 2: Cohere/Jina Reranking (optional, top_k=10)
+    ↓
+Final Results
+```
+
+### Recommended Starting Point: Ollama-Based Reranking
+
+**Why Ollama First**:
+1. Already integrated for embeddings and summarization
+2. Runs locally - no API keys required
+3. Works for clients that prohibit public cloud providers
+4. Models like `bge-reranker-v2-m3` or `rerank-lite` available
+5. Consistent with project's local-first philosophy
+
+**Ollama Reranker Models**:
+- `bge-reranker-v2-m3` - Multilingual, good quality
+- `bge-reranker-large` - Higher quality, more resources
+- `jina-reranker-v2-base` - Alternative option
+
+### Configuration
+
+```python
+# settings.py - New settings
+ENABLE_RERANKING: bool = False          # Master switch (off by default)
+RERANKER_PROVIDER: str = "ollama"       # "ollama", "cohere", "jina"
+RERANKER_MODEL: str = "bge-reranker-v2-m3"  # Ollama model
+RERANKER_TOP_K: int = 10                # Final results after reranking
+RERANKER_INITIAL_TOP_K: int = 100       # Stage 1 fetch size
+OLLAMA_RERANKER_URL: str = "http://localhost:11434"  # Ollama endpoint
+```
+
+### Files to Create
+
+```
+agent_brain_server/providers/reranker/
+├── __init__.py
+├── base.py          # RerankerProvider protocol + BaseRerankerProvider
+└── ollama.py        # OllamaRerankerProvider implementation
+```
+
+### Files to Modify
+
+| File | Changes |
+|------|---------|
+| `config/settings.py` | Add reranking settings |
+| `config/provider_config.py` | Add `RerankerConfig` class |
+| `models/query.py` | Add `rerank_score`, `original_rank` fields |
+| `services/query_service.py` | Add `_rerank_results()` method, integrate into `execute_query()` |
+
+### Implementation Steps
+
+1. **Create reranker provider infrastructure** (base.py)
+   - `RerankResult` model
+   - `RerankerProvider` protocol
+   - `BaseRerankerProvider` abstract class
+
+2. **Implement Ollama reranker** (ollama.py)
+   - Uses Ollama's `/api/embed` or custom rerank endpoint
+   - Cross-encoder style scoring via chat completions
+   - No API keys required - runs locally
+
+3. **Add configuration** (settings.py, provider_config.py)
+   - New settings with sensible defaults
+   - `RerankerConfig` Pydantic model
+
+4. **Integrate into query flow** (query_service.py)
+   - `_rerank_results()` async method
+   - Update `execute_query()` to use two-stage when enabled
+   - Graceful fallback on reranker failure
+
+5. **Update response models** (query.py)
+   - Add reranking metadata fields
+
+6. **Add tests**
+   - Unit tests for reranker provider
+   - Integration tests for two-stage query flow
+
+### Example Usage
+
+```bash
+# Pull reranker model
+ollama pull bge-reranker-v2-m3
+
+# Enable reranking (no API key needed!)
+export ENABLE_RERANKING=true
+export RERANKER_PROVIDER=ollama
+export RERANKER_MODEL=bge-reranker-v2-m3
+
+# Query with reranking (transparent to user)
+agent-brain query "how does authentication work" --mode hybrid
+```
+
+### Graceful Degradation
+
+If reranking fails (API error, timeout, no API key):
+- Log warning
+- Return original stage 1 results
+- No user-facing error
+
+---
+
+## Future Features (After Reranking)
+
+### Feature 122: Schema-Based GraphRAG Enhancement
+
+**Purpose**: Add domain-specific schema for entities to improve code understanding.
+
+**Proposed Entity Types**:
+| Category | Entity Types |
+|----------|-------------|
+| Code | Package, Module, Class, Method, Function, Interface, Enum |
+| Documentation | DesignDoc, UserDoc, PRD, Runbook, README, APIDoc |
+| Infrastructure | Service, Endpoint, Database, ConfigFile |
+
+**Relationship Types to Add**:
+| Predicate | Description |
+|-----------|-------------|
+| `calls` | Function/method invocation |
+| `extends` | Class inheritance |
+| `implements` | Interface implementation |
+| `references` | Documentation references code |
+| `depends_on` | Package/module dependency |
+
+**Implementation Approach**:
+1. Define `EntityTypeSchema` Pydantic enum in `models/graph.py`
+2. Extend `CodeMetadataExtractor` to categorize entities by type
+3. Add schema validation during triplet extraction
+4. Update LLM extraction prompt to use schema vocabulary
+5. Add filtering by entity type in graph queries
+
+**Files to Modify**:
+- `agent_brain_server/models/graph.py` - Add entity type enums
+- `agent_brain_server/indexing/graph_extractors.py` - Schema-aware extraction
+- `agent_brain_server/indexing/graph_index.py` - Type-filtered queries
+
+### Feature 123: Two-Stage Retrieval with Reranking
+
+**Purpose**: Add optional ColBERTv2-style reranking for precision improvement.
+
+**Architecture**:
+```
+Stage 1: Fast Retrieval (BM25 + Vector + Graph, top_k=100)
+    ↓
+RRF Fusion → ~50 candidates
+    ↓
+Stage 2: ColBERTv2/Jina Reranking (optional, top_k=10)
+    ↓
+Final Results
+```
+
+**Implementation Options** (choose one):
+1. **RAGatouille** - Python wrapper for ColBERTv2 (self-hosted)
+2. **Jina Reranker API** - Hosted reranking service
+3. **Cohere Rerank** - Already have Cohere provider infrastructure
+
+**Configuration**:
+```python
+# settings.py
+ENABLE_RERANKING: bool = False
+RERANK_PROVIDER: str = "cohere"  # cohere, jina, colbert
+RERANK_MODEL: str = "rerank-v3.5"
+RERANK_TOP_K: int = 10
+```
+
+**New Files**:
+- `agent_brain_server/services/reranking_service.py`
+- `agent_brain_server/providers/reranking/` (base, cohere, jina, colbert)
+
+### Feature 124: Provider Integration Testing
+
+**Purpose**: Validate all provider combinations work correctly.
+
+**Test Matrix**:
+| Provider | Embeddings | Summarization | Status |
+|----------|------------|---------------|--------|
+| OpenAI | text-embedding-3-large | gpt-4-mini | Needs test |
+| Anthropic | - | claude-haiku-4-5 | Needs test |
+| Ollama | nomic-embed-text | llama3.2 | Working |
+| Cohere | embed-english-v3.0 | - | Needs test |
+| Voyage 4 | voyage-4-large | - | Not implemented |
+
+**Deliverables**:
+1. E2E test suite for each provider
+2. Provider health check endpoint
+3. Documentation updates with verified configurations
+
+---
+
+## Architecture Decisions to Document
+
+### Transport Layer Strategy
+
+**User Preference**: Skill + CLI model over MCP
+
+**Proposed Transports** (in priority order):
+1. **HTTP** - Simple, universal compatibility
+2. **Unix Domain Socket (UDS)** - Fast local path (planned for Phase 4)
+3. **MCP** - Optional ecosystem integration
+
+**Rationale**: MCP perceived as bloated, context-hungry. UDS with Rust CLI provides fast local path without heavyweight protocol.
+
+### Batching Strategy
+
+**Proposal**: CLI-layer request batching
+
+```bash
+# Batch multiple queries in single round-trip
+agent-brain query-batch \
+  "what calls process_payment" \
+  "how does authentication work" \
+  "where is User defined"
+```
+
+**Benefit**: Amortizes connection handshake cost across multiple queries.
+
+---
+
+## Updated Roadmap Proposal
+
+### Phase 5: Pluggable Providers (Feature 103) - CURRENT
+- Complete provider abstraction for embeddings + summarization
+- Add Voyage 4 provider (14% better than OpenAI)
+- Integration tests for all providers
+
+### Phase 5.1: Schema-Based GraphRAG (Feature 122) - NEW
+- Domain-specific entity types
+- Enhanced relationship predicates
+- Type-filtered graph queries
+
+### Phase 5.2: Provider Integration Testing (Feature 124) - NEW
+- E2E test suite per provider
+- Verified configuration documentation
+
+### Phase 6: PostgreSQL Backend (Feature 104) - EXISTING
+- pgvector for similarity search
+- tsvector for full-text (replaces BM25)
+- JSONB for graph storage
+- Migration tool from ChromaDB
+
+### Phase 6.1: Two-Stage Reranking (Feature 123) - NEW
+- Optional ColBERTv2/Cohere/Jina reranking
+- Sub-100ms additional latency
+- +3-4% precision improvement
+
+### Phase 7+: Future Optimizations
+- Embedding cache with content hashing (50-80% index speedup)
+- File watcher for auto-indexing
+- Background incremental updates
+- Query caching with LRU
+
+---
+
+## Implementation Sequence
+
+### Immediate (This Sprint)
+1. Create Feature 122 spec in `.speckit/features/122-schema-graphrag/`
+2. Create Feature 123 spec in `.speckit/features/123-reranking/`
+3. Create Feature 124 spec in `.speckit/features/124-provider-testing/`
+4. Update `docs/roadmaps/product-roadmap.md` with new phases
+
+### Short-term (Next 2-4 Weeks)
+1. Implement Feature 122 (Schema GraphRAG)
+2. Add E2E tests for OpenAI/Anthropic providers
+3. Document verified provider configurations
+
+### Medium-term (1-2 Months)
+1. Implement Feature 123 (Reranking) - start with Cohere (existing infra)
+2. Continue PostgreSQL backend spec refinement
+3. Begin Rust CLI prototype (UDS transport)
+
+---
+
+## Files to Create/Update
+
+### New Spec Directories
+```
+.speckit/features/
+├── 122-schema-graphrag/
+│   ├── spec.md
+│   ├── plan.md
+│   └── tasks.md
+├── 123-reranking/
+│   ├── spec.md
+│   ├── plan.md
+│   └── tasks.md
+└── 124-provider-testing/
+    ├── spec.md
+    ├── plan.md
+    └── tasks.md
+```
+
+### Roadmap Updates
+- `docs/roadmaps/product-roadmap.md` - Add new phases
+- `docs/roadmaps/spec-mapping.md` - Add 122-124 mappings
+
+### Strategic Documentation
+- `docs/strategic/2026-recommendations.md` - Archive the analysis
+- `docs/strategic/architecture-evolution.md` - Target architecture vision
+
+---
+
+## Verification
+
+After implementation:
+1. Run `task before-push` to validate all changes
+2. Verify new specs have proper structure (spec.md, plan.md, tasks.md)
+3. Confirm roadmap reflects accurate priority order
+4. Test GraphRAG schema extraction with sample codebase
+5. Validate reranking improves top-5 precision
+
+---
+
+## Summary
+
+This plan integrates the 2026 strategic recommendations by:
+
+1. **Implementing two-stage reranking as the immediate next phase** (Feature 123)
+   - Start with Ollama (local-first, no API keys)
+   - Optional, off by default, graceful degradation
+   - Expected +3-4% precision improvement
+2. **Schema-based GraphRAG** as follow-on enhancement (Feature 122)
+3. **Provider testing** (Feature 124) before PostgreSQL
+4. **PostgreSQL backend** (existing Phase 6)
+5. **Additional optimizations** (embedding cache, file watcher, etc.)
+
+---
+
+## Next Steps
+
+With this plan documented, the next action is to begin implementing Feature 123 (Two-Stage Reranking) following the implementation steps outlined above.


### PR DESCRIPTION
## Summary

This PR implements Two-Stage Reranking (Feature 123) and includes Phase 2 Pluggable Providers research and planning.

### Two-Stage Reranking Implementation

- **SentenceTransformerRerankerProvider**: CrossEncoder-based reranking with:
  - Availability caching to avoid first-query latency
  - `warm_up()` method for startup preloading
  - Lazy model loading

- **OllamaRerankerProvider**: LLM-based reranking with:
  - Circuit breaker pattern (3 failures → 60s cooldown)
  - Prompt-based relevance scoring (0-10)
  - Rate limiting via semaphore

- **Graceful Fallback**: 
  - Reranking is strictly optional (disabled by default)
  - Falls back to stage-1 results on any reranker failure
  - Empty results from reranker trigger fallback

### Configuration

```python
ENABLE_RERANKING: bool = False  # Off by default
RERANKER_PROVIDER: str = "sentence-transformers"  # or "ollama"
RERANKER_MODEL: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"
RERANKER_TOP_K_MULTIPLIER: int = 10  # Stage 1 retrieves top_k * this
RERANKER_MAX_CANDIDATES: int = 100  # Cap on Stage 1 candidates
```

### Phase 2 Planning (Pluggable Providers)

Includes research and 4 execution plans for Phase 2:
- 02-01: Dimension mismatch prevention (PROV-07)
- 02-02: Strict startup validation (PROV-06)
- 02-03: Provider switching E2E test (PROV-03)
- 02-04: Ollama offline E2E test (PROV-04)

### Files Changed

| Category | Files |
|----------|-------|
| New Providers | `providers/reranker/{base,ollama,sentence_transformers}.py` |
| Config | `config/settings.py` |
| Integration | `services/query_service.py` |
| Tests | `test_reranker_providers.py`, `test_query_modes.py` |
| Planning | `.planning/phases/02-pluggable-providers/` |

## Test Plan

- [x] 460 tests pass
- [x] 71% code coverage
- [x] Type checking passes (mypy)
- [x] Linting passes (ruff)
- [x] Formatting passes (black)
- [x] Circuit breaker tests verify fault tolerance
- [x] Fallback tests verify graceful degradation

🤖 Generated with [Claude Code](https://claude.ai/code)