### PR TITLE
ci: install [cohere] extra in provider-e2e workflow

### DIFF
--- a/.github/workflows/provider-e2e.yml
+++ b/.github/workflows/provider-e2e.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd agent-brain-server
-          poetry install
+          poetry install --extras cohere
 
       - name: Run configuration tests
         run: |
@@ -135,7 +135,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd agent-brain-server
-          poetry install
+          poetry install --extras cohere
 
       - name: Check required API keys
         id: check_keys


### PR DESCRIPTION
## Summary

PR #132 moved \`cohere\` from a hard dependency to an optional \`[cohere]\` extra (closes #122, #125 — avoided tokenizers 0.20.3's malformed sdist on macOS/M1). The provider-e2e workflow's \`poetry install\` no longer pulls cohere, so the post-merge run on main failed with:

\`\`\`
ImportError: Cohere provider selected but the 'cohere' package is not installed.
Install it with: pip install 'agent-brain-rag[cohere]'
\`\`\`

This was called out in PR #132's "things to eyeball" section. Failed run: https://github.com/SpillwaveSolutions/agent-brain/actions/runs/26415545035

## Fix

Add \`--extras cohere\` to both \`poetry install\` steps in \`.github/workflows/provider-e2e.yml\` (config-tests and provider-tests jobs).

## Test plan

- [x] task before-push passes
- [ ] PR QA Gate green on this PR
- [ ] Add \`test-providers\` label to force a real \`provider-e2e.yml\` run; cohere matrix step turns green

🤖 Generated with [Claude Code](https://claude.com/claude-code)