### PR TITLE
fix: repair pre-release gate script and extend release agent file list

### DIFF
--- a/.claude/agents/release_agent.md
+++ b/.claude/agents/release_agent.md
@@ -130,11 +130,12 @@ Before any release actions:
 
 1. **Calculate new version** based on bump type (major/minor/patch)
 2. **Flip dependency to PyPI** if needed (perl + poetry lock)
-3. **Update version** in 4 files:
+3. **Update version** in 5 files:
    - `agent-brain-server/pyproject.toml`
    - `agent-brain-server/agent_brain_server/__init__.py`
    - `agent-brain-cli/pyproject.toml` (both package version AND `agent-brain-rag` dependency)
    - `agent-brain-cli/agent_brain_cli/__init__.py`
+   - `agent-brain-plugin/.claude-plugin/plugin.json` (top-level `"version"` field — must match CLI/server)
 4. **Run quality gates**: `task before-push` (format, lint, typecheck, tests)
 5. **Commit version bump**: `chore(release): bump version to X.Y.Z`
 6. **Create git tag**: `git tag -a vX.Y.Z -m "Release vX.Y.Z"`

--- a/scripts/quick_start_guide.sh
+++ b/scripts/quick_start_guide.sh
@@ -9,7 +9,7 @@ CLI_DIR="agent-brain-cli"
 WORKSPACE="integration/tests/quick_start"
 BASE_URL="http://127.0.0.1:$PORT"
 
-echo "=== Doc-Serve Quick Start Test Script ==="
+echo "=== Agent Brain Quick Start Test Script ==="
 
 # Check prerequisites
 if ! command -v poetry >/dev/null 2>&1; then
@@ -39,7 +39,7 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 # 1. Cleanup old processes
-echo "Checking for old Doc-Serve processes on port $PORT..."
+echo "Checking for old Agent Brain processes on port $PORT..."
 PIDS=$(lsof -ti :$PORT || true)
 if [ ! -z "$PIDS" ]; then
     echo "Found processes: $PIDS. Killing..."
@@ -63,9 +63,9 @@ export DATABASE_PATH=$DB_PATH
 export DEBUG=true
 
 # 4. Start Server
-echo "Starting Doc-Serve server on port $PORT..."
+echo "Starting Agent Brain server on port $PORT..."
 cd $SERVER_DIR
-nohup poetry run doc-serve > "../$WORKSPACE/server.log" 2>&1 &
+nohup poetry run agent-brain-serve > "../$WORKSPACE/server.log" 2>&1 &
 SERVER_PID=$!
 cd ..
 
@@ -92,7 +92,7 @@ done
 echo "Installing CLI tool..."
 cd $CLI_DIR
 poetry install > /dev/null
-export DOC_SERVE_URL=$BASE_URL
+export AGENT_BRAIN_URL=$BASE_URL
 cd ..
 
 # 6. Index Project


### PR DESCRIPTION
## Summary

Two follow-ups from the v10.0.0 release, bundled into one small PR to unblock a clean v10.0.1 patch release.

- **Closes #134** — `scripts/quick_start_guide.sh` has been silently broken since v9.0.0 because line 68 still invoked the legacy `doc-serve` binary (renamed to `agent-brain-serve` in v9.0.0). Also fixed three echo banners and an `export DOC_SERVE_URL` (renamed to `AGENT_BRAIN_URL`) that the modern CLI no longer reads — meaning the script wasn't actually pointing the CLI at the custom test port either. The `.claude/CLAUDE.md` doc cites this script as a mandatory pre-release gate, so we had a release-doc that lied for an entire major version.

- **Closes #135** — `.claude/agents/release_agent.md` already documented (line 119) that `agent-brain-plugin/.claude-plugin/plugin.json` must match the CLI/server version, but its Release Steps section only enumerated 4 files to bump. Result: every release needed a manual catchup commit (e.g. `4997007` for v10.0.0). This PR adds the plugin manifest as the 5th file in the agent's version-bump list so the next release picks it up automatically.

## Diff scope

```
 .claude/agents/release_agent.md |  3 ++-
 scripts/quick_start_guide.sh    | 10 +++++-----
 2 files changed, 7 insertions(+), 6 deletions(-)
```

No functional code changes — pure docs/scripting.

## Test plan

- [x] `task before-push` passes locally (1043 server + 356 CLI tests, 77%/78% coverage)
- [ ] CI green on this PR
- [ ] After merge, run `/ag-brain-release patch` and confirm `plugin.json` shows up in the resulting `chore(release):` diff (validates issue #135 fix in production)
- [ ] Confirm `agent-brain-rag==10.0.1` and `agent-brain-cli==10.0.1` resolvable on PyPI after the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)