### PR TITLE
fix: extend ag-brain-release command file list to include plugin.json

### DIFF
--- a/.claude/commands/ag-brain-release.md
+++ b/.claude/commands/ag-brain-release.md
@@ -40,11 +40,12 @@ Execute a versioned release with these steps:
 
 1. Calculate new version from current + bump type
 2. Flip CLI dependency to PyPI if path-based
-3. Update version in 4 files:
+3. Update version in 5 files:
    - `agent-brain-server/pyproject.toml`
    - `agent-brain-server/agent_brain_server/__init__.py`
    - `agent-brain-cli/pyproject.toml`
    - `agent-brain-cli/agent_brain_cli/__init__.py`
+   - `agent-brain-plugin/.claude-plugin/plugin.json` (top-level `"version"` field — must match CLI/server)
 4. Commit: `chore(release): bump version to X.Y.Z`
 5. Tag: `vX.Y.Z`
 6. Push branch and tag


### PR DESCRIPTION
## Summary

Follow-up to PR #136 — fully closes #135.

The `/ag-brain-release` slash command at `.claude/commands/ag-brain-release.md` has its **own** duplicate file list (lines 43-47), separate from the agent definition at `.claude/agents/release_agent.md`. PR #136 updated only the agent definition. A dry-run of `/ag-brain-release patch` against `main` after PR #136 merged confirmed the gap — the skill still listed only 4 files to bump and would have skipped `plugin.json` again.

This PR adds `agent-brain-plugin/.claude-plugin/plugin.json` as the 5th file in the command file's Release Steps section. Now both the agent definition and the slash command agree on the 5-file list.

## Diff

```
 .claude/commands/ag-brain-release.md | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)
```

Pure docs/instruction change — no code, no functional behavior change in Python.

## Test plan

- [x] `task before-push` passes locally
- [ ] CI green on this PR
- [ ] After merge, re-run `/ag-brain-release patch --dry-run` and confirm the file list now shows 5 files including `plugin.json`
- [ ] Then run the real release; `chore(release):` commit should include `plugin.json` in the diff with no manual catchup needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)