### PR TITLE
docs: add v10.0.1 CHANGELOG entry

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [10.0.1] - 2026-05-25
+
+### Fixed
+
+- `scripts/quick_start_guide.sh` was silently broken since v9.0.0 — line 68 still invoked the legacy `doc-serve` binary (renamed to `agent-brain-serve` in v9.0.0) and the script's exported `DOC_SERVE_URL` env var was no longer read by the modern CLI. The script is cited as a mandatory pre-release gate in `.claude/CLAUDE.md`, so the gate had been effectively bypassed for the entire v9.x line. Replaced the binary call, updated three echo banners from "Doc-Serve" to "Agent Brain", and renamed `DOC_SERVE_URL` to `AGENT_BRAIN_URL`. Closes #134.
+- Release automation now bumps `agent-brain-plugin/.claude-plugin/plugin.json` in lockstep with `pyproject.toml` and `__init__.py` files. The release agent's documented contract required the plugin manifest to match (line 119) but its actual step list only enumerated 4 files, requiring a manual catchup commit each release (see `4997007` for v10.0.0). Both `.claude/agents/release_agent.md` and `.claude/commands/ag-brain-release.md` now list 5 files. The v10.0.1 release commit (`fc8f9bb`) is the first to bump `plugin.json` automatically. Closes #135.
+
+### Internal
+
+- Identified `.claude/commands/ag-brain-release.md` as the runtime source of truth for the release slash command — its "Task" section is what the skill follows, not the duplicate file list in the agent definition. PR #137 was needed because PR #136 only updated the agent file.
+
 ## [10.0.0] - 2026-05-25
 
 ### Breaking


### PR DESCRIPTION
## Summary

Post-release docs catchup for v10.0.1. The release automation doesn't (yet) auto-update `docs/CHANGELOG.md`, so this lands the entry manually — same workflow as `4997007` for v10.0.0.

## What's in the entry

- **Fixed**: the `quick_start_guide.sh` rename fix (closes #134, already closed by PR #136 but now properly documented in CHANGELOG)
- **Fixed**: the release agent now bumps `plugin.json` in lockstep (closes #135)
- **Internal**: note about the slash-command vs agent-definition file duplication that surfaced during the release

## Related

- #138 — tracks the structural fix so future releases don't need this manual catchup

## Diff

```
 docs/CHANGELOG.md | 11 +++++++++++
 1 file changed, 11 insertions(+)
```

Pure docs change, no code.

## Test plan

- [x] `task before-push` passes locally
- [ ] CI green
- [ ] After merge, `docs/CHANGELOG.md` reflects v10.0.1 changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)