### PR TITLE
fix(release): add CHANGELOG entry pre-release check

### DIFF
--- a/.claude/agents/release_agent.md
+++ b/.claude/agents/release_agent.md
@@ -125,6 +125,7 @@ Before any release actions:
 3. **Synced with remote**: `git fetch origin && git diff origin/main` must be empty
 4. **Quality gates pass**: `task before-push` must exit 0
 5. **CLI dependency on PyPI**: Check `agent-brain-cli/pyproject.toml` does NOT have `path = "../agent-brain-server"`. If it does, flip to PyPI first.
+6. **CHANGELOG entry present**: Calculate the new version from current + bump type, then `grep -q "^## \[X.Y.Z\]" docs/CHANGELOG.md` must match. If missing, abort with: *"Add a `## [X.Y.Z] - YYYY-MM-DD` section to docs/CHANGELOG.md and commit it before re-running. See the existing [10.0.0] entry for the expected Keep-a-Changelog format."* This preserves curator-authored release notes rather than auto-generating from commit messages.
 
 ## Release Steps
 
@@ -159,6 +160,7 @@ Format with sections: Features, Bug Fixes, Performance, Documentation, Other Cha
 - Out of sync with remote
 - `task before-push` fails
 - Dependency flip fails
+- CHANGELOG entry missing for the new version
 - Any git operation fails
 
 ## Dry-Run Mode

--- a/.claude/commands/ag-brain-release.md
+++ b/.claude/commands/ag-brain-release.md
@@ -35,10 +35,11 @@ Execute a versioned release with these steps:
 2. On `main` branch
 3. Synced with remote origin/main
 4. CLI dependency points to PyPI (not path) - flip if needed
+5. CHANGELOG entry exists for the new version. Calculate the new version from current + bump type, then verify `docs/CHANGELOG.md` contains a `## [X.Y.Z]` heading matching it. If missing, abort with: "Add a `## [X.Y.Z] - YYYY-MM-DD` section to docs/CHANGELOG.md and commit it before re-running. See the existing [10.0.0] entry for the expected Keep-a-Changelog format."
 
 ### Release Steps
 
-1. Calculate new version from current + bump type
+1. Calculate new version from current + bump type (also used by pre-release check #5)
 2. Flip CLI dependency to PyPI if path-based
 3. Update version in 5 files:
    - `agent-brain-server/pyproject.toml`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [10.0.2] - 2026-05-25
+
+### Fixed
+
+- Release automation now refuses to proceed if `docs/CHANGELOG.md` is missing an entry for the new version. Previously the release agent silently shipped without updating the CHANGELOG, requiring a post-release docs catchup commit each time (see PR #139 for v10.0.1). The new pre-release check (Check #6 in `.claude/agents/release_agent.md`, Check #5 in `.claude/commands/ag-brain-release.md`) computes the target version from the bump type and greps `docs/CHANGELOG.md` for a matching `## [X.Y.Z]` heading. On failure it aborts with a clear instruction to add the section and commit before re-running. Same root cause as #135 (release agent's documented contract diverging from automation) — now resolved structurally. Closes #138.
+
+### Internal
+
+- This v10.0.2 CHANGELOG entry self-demonstrates the new check: the release that ships it is the first release to actually run the check, and it will validate its own existence in `docs/CHANGELOG.md` before proceeding.
+
 ## [10.0.1] - 2026-05-25
 
 ### Fixed


### PR DESCRIPTION
## Summary

Closes #138. Adds a pre-release check that refuses to release if `docs/CHANGELOG.md` doesn't have an entry for the new version. Same root cause as #135 — release agent's documented contract diverged from its automation; now resolved structurally.

## Approach

Pre-release check (curator-preserving) rather than auto-generate (commit-message-dumping). The check:

1. Computes the new version from the bump type
2. Greps `docs/CHANGELOG.md` for `## [X.Y.Z]` heading
3. Aborts with actionable error if missing: *"Add a `## [X.Y.Z] - YYYY-MM-DD` section to docs/CHANGELOG.md and commit it before re-running."*

Workflow becomes: write CHANGELOG entry → commit → `/ag-brain-release <bump>`. Same ritual as today but now enforced.

## What changed

- **`.claude/commands/ag-brain-release.md`** — adds Pre-Release Check #5 (runtime source of truth, per PR #137 lessons)
- **`.claude/agents/release_agent.md`** — adds Pre-Release Check #6 + adds "CHANGELOG entry missing" to Abort Conditions list (kept in lockstep with command file)
- **`docs/CHANGELOG.md`** — v10.0.2 entry self-demonstrates the new check (the next release validates this very entry exists)

```
 .claude/agents/release_agent.md      |  2 ++
 .claude/commands/ag-brain-release.md |  3 ++-
 docs/CHANGELOG.md                    | 10 ++++++++++
 3 files changed, 14 insertions(+), 1 deletion(-)
```

## Test plan

- [x] `task before-push` passes locally
- [ ] CI green on this PR
- [ ] After merge, `/ag-brain-release patch --dry-run` succeeds (v10.0.2 entry already present)
- [ ] After merge, real `/ag-brain-release patch` cuts v10.0.2 with all 5 files bumped AND validates CHANGELOG entry pre-bump
- [ ] `agent-brain-rag==10.0.2` and `agent-brain-cli==10.0.2` live on PyPI
- [ ] Confirm: the release commit for v10.0.2 will NOT need a post-release CHANGELOG catchup commit (validates the fix worked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)