### PR TITLE
fix(graph): self-heal corrupted Kuzu DB + triplet snapshots (#166)

### DIFF
--- a/agent-brain-cli/agent_brain_cli/diagnostics.py
+++ b/agent-brain-cli/agent_brain_cli/diagnostics.py
@@ -371,6 +371,103 @@ def _check_optional_dep(provider: str, module_name: str, extra: str) -> CheckRes
     )
 
 
+def _graph_index_dir(state_dir: Path) -> Path:
+    """Return the conventional graph_index location under a state dir."""
+    return state_dir / "data" / "graph_index"
+
+
+def _read_graphrag_block(state_dir: Path) -> dict[str, Any] | None:
+    """Read the ``graphrag`` block from the project's config.yaml, if any.
+
+    The CLI's Pydantic ``AgentBrainConfig`` doesn't model graphrag (it's a
+    server concern), so this peeks directly at the YAML. Returns None when
+    no graphrag block is present.
+    """
+    import yaml  # local import to avoid a hard dep at module load
+
+    for name in ("config.yaml", "agent-brain.yaml", "config.yml"):
+        path = state_dir / name
+        if not path.exists():
+            continue
+        try:
+            data = yaml.safe_load(path.read_text()) or {}
+        except (OSError, yaml.YAMLError):
+            continue
+        block = data.get("graphrag")
+        if isinstance(block, dict):
+            return block
+    return None
+
+
+def _check_graph_store_health(state_dir: Path) -> CheckResult | None:
+    """Verify the Kuzu DB opens cleanly when GraphRAG is enabled (Issue #166).
+
+    Returns None when GraphRAG is disabled or the store backend isn't Kuzu —
+    those cases have no graph health to report. Otherwise opens the Kuzu DB
+    in process briefly. A successful open is OK. An IndexError / RuntimeError
+    (the typical kill-mid-write signature) is FAIL with a fix hint pointing
+    at ``--fix`` or manual recovery.
+    """
+    block = _read_graphrag_block(state_dir)
+    if not block or not block.get("enabled"):
+        return None
+    store_type = str(block.get("store_type") or "simple").lower()
+    if store_type != "kuzu":
+        return None
+
+    graph_dir = _graph_index_dir(state_dir)
+    kuzu_db_path = graph_dir / "kuzu_db"
+    if not kuzu_db_path.exists():
+        # Nothing on disk yet — nothing to be corrupted.
+        return CheckResult(
+            "graph_store_health",
+            SEVERITY_OK,
+            f"No Kuzu DB on disk yet at {kuzu_db_path} (will be created on "
+            "first indexing job).",
+            details={"path": str(kuzu_db_path)},
+        )
+
+    try:
+        import kuzu
+    except ImportError:
+        # The langextract optional-dep check already covers missing extras.
+        return None
+
+    try:
+        kuzu.Database(str(kuzu_db_path))
+    except (IndexError, RuntimeError) as exc:
+        return CheckResult(
+            "graph_store_health",
+            SEVERITY_FAIL,
+            f"Kuzu DB at {kuzu_db_path} appears corrupted: {exc}. This "
+            "typically happens when the server was killed mid-indexing.",
+            fix=(
+                "Run `agent-brain doctor --fix` (server must be stopped) to "
+                "quarantine the corrupted file and restore from the latest "
+                "snapshot, or manually `rm` the file (loses all triplets)."
+            ),
+            details={"path": str(kuzu_db_path), "error": str(exc)},
+        )
+    except Exception as exc:  # noqa: BLE001 — anything unexpected
+        return CheckResult(
+            "graph_store_health",
+            SEVERITY_WARN,
+            f"Could not check Kuzu DB at {kuzu_db_path}: {exc}",
+        )
+
+    return CheckResult(
+        "graph_store_health",
+        SEVERITY_OK,
+        f"Kuzu DB at {kuzu_db_path} opens cleanly.",
+        details={"path": str(kuzu_db_path)},
+    )
+
+
+def _server_is_running(state_dir: Path) -> bool:
+    """Best-effort check for an active server lock under state_dir."""
+    return (state_dir / "server.lock").exists() or (state_dir / "lock").exists()
+
+
 def _check_gitignore(project_root: Path) -> CheckResult:
     gi = project_root / ".gitignore"
     if not gi.exists():
@@ -436,6 +533,11 @@ def run_doctor(server_url_override: str | None = None) -> DoctorReport:
             _check_optional_dep("graphrag (langextract)", "langextract", "graphrag")
         )
 
+    # Issue #166 — verify Kuzu DB opens cleanly.
+    graph_check = _check_graph_store_health(state_dir)
+    if graph_check is not None:
+        checks.append(graph_check)
+
     checks.append(_check_gitignore(project_root))
 
     checks.append(_check_server(server_url, runtime_file))
@@ -490,7 +592,117 @@ def apply_safe_fixes(report: DoctorReport) -> list[str]:
                     + "\n"
                 )
                 actions.append(f"Created {cfg_json}.")
+        elif check.name == "graph_store_health" and check.status == SEVERITY_FAIL:
+            # Issue #166 — recover a corrupted Kuzu DB offline.
+            if _server_is_running(state_dir):
+                actions.append(
+                    "Skipped Kuzu recovery: server appears to be running. "
+                    "Stop it with `agent-brain stop` first, then re-run "
+                    "`agent-brain doctor --fix`."
+                )
+                continue
+            graph_dir = _graph_index_dir(state_dir)
+            kuzu_db = graph_dir / "kuzu_db"
+            kuzu_wal = graph_dir / "kuzu_db.wal"
+            stamp = _utc_stamp()
+            for src in (kuzu_db, kuzu_wal):
+                if src.exists():
+                    dest = src.with_name(f"{src.name}.corrupted-{stamp}")
+                    src.rename(dest)
+                    actions.append(
+                        f"Quarantined {src.name} → {dest.name} "
+                        "(forensic preservation)."
+                    )
+            # Restore from latest snapshot, if one exists.
+            restored = _replay_latest_snapshot(graph_dir)
+            if restored is not None:
+                snapshot_name, count = restored
+                actions.append(
+                    f"Restored {count} triplets from snapshot "
+                    f"{snapshot_name} into a fresh Kuzu DB."
+                )
+            else:
+                actions.append(
+                    "No snapshot available to restore; graph index will "
+                    "start empty. Re-run `agent-brain index <folder>` to "
+                    "rebuild."
+                )
     return actions
+
+
+def _utc_stamp() -> str:
+    """Filesystem-safe UTC timestamp suffix shared with the server's
+    quarantine logic (graph_store._corrupted_sibling)."""
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _replay_latest_snapshot(graph_dir: Path) -> tuple[str, int] | None:
+    """Replay triplets from the newest valid snapshot into a fresh Kuzu DB.
+
+    Returns ``(snapshot_filename, triplet_count)`` on success, or ``None`` if
+    there's no usable snapshot. Best-effort: any failure becomes a None
+    return (the caller will report it). The CLI doesn't import the server
+    code path because the CLI may be installed without the server package;
+    instead it reads snapshot JSON directly using a minimal schema.
+    """
+    snap_dir = graph_dir / "snapshots"
+    if not snap_dir.is_dir():
+        return None
+    try:
+        import kuzu
+        from llama_index.core.graph_stores.types import EntityNode, Relation
+        from llama_index.graph_stores.kuzu import KuzuPropertyGraphStore
+    except ImportError:
+        return None
+
+    candidates = sorted(
+        (p for p in snap_dir.iterdir() if p.is_file() and p.suffix == ".json"),
+        key=lambda p: (p.stat().st_mtime, p.name),
+        reverse=True,
+    )
+    for snap in candidates:
+        try:
+            payload = json.loads(snap.read_text())
+            if payload.get("schema_version") != 1:
+                continue
+            triplets = payload.get("triplets") or []
+        except (OSError, json.JSONDecodeError):
+            continue
+
+        try:
+            db = kuzu.Database(str(graph_dir / "kuzu_db"))
+            store = KuzuPropertyGraphStore(db, use_vector_index=False)
+            for t in triplets:
+                subj = EntityNode(
+                    name=t["subject"],
+                    label=t.get("subject_type") or "Entity",
+                )
+                obj = EntityNode(
+                    name=t["object"],
+                    label=t.get("object_type") or "Entity",
+                )
+                store.upsert_nodes([subj, obj])
+                store.upsert_relations(
+                    [
+                        Relation(
+                            label=t["predicate"],
+                            source_id=subj.id,
+                            target_id=obj.id,
+                            properties=(
+                                {"source_chunk_id": t["source_chunk_id"]}
+                                if t.get("source_chunk_id")
+                                else {}
+                            ),
+                        )
+                    ]
+                )
+            return snap.name, len(triplets)
+        except Exception:  # noqa: BLE001
+            # If replay against this snapshot failed, try the next-older.
+            continue
+    return None
 
 
 def doctor_hint_message(project_root: Path | None = None) -> str:

--- a/agent-brain-cli/tests/test_resolver_and_doctor.py
+++ b/agent-brain-cli/tests/test_resolver_and_doctor.py
@@ -261,3 +261,166 @@ def test_doctor_fix_flag_creates_state_dir(
     # gitignore (both apply on a clean tmp dir).
     assert payload["applied_fixes"], "expected at least one safe fix action"
     assert (isolated_cwd / ".agent-brain" / "config.json").exists()
+
+
+# ---- Issue #166 — graph store health check & --fix ----
+
+
+def _make_graphrag_config(state_dir: Path, store_type: str = "kuzu") -> None:
+    """Write a minimal config.yaml that enables GraphRAG."""
+    state_dir.mkdir(parents=True, exist_ok=True)
+    # Need both: config.json for project_initialized check, config.yaml so
+    # load_config picks up the graphrag block.
+    (state_dir / "config.json").write_text(
+        json.dumps({"project_root": str(state_dir.parent)}) + "\n"
+    )
+    (state_dir / "config.yaml").write_text(
+        "embedding:\n"
+        "  provider: openai\n"
+        "  model: text-embedding-3-large\n"
+        "summarization:\n"
+        "  provider: anthropic\n"
+        "  model: claude-haiku-4-5\n"
+        "graphrag:\n"
+        "  enabled: true\n"
+        f"  store_type: {store_type}\n"
+    )
+
+
+def test_graph_store_health_check_skipped_when_graphrag_disabled(
+    isolated_cwd: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When GraphRAG is off, the new health check should not show up at all."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    state_dir = isolated_cwd / ".agent-brain"
+    state_dir.mkdir()
+    (state_dir / "config.json").write_text(
+        json.dumps({"project_root": str(isolated_cwd)}) + "\n"
+    )
+
+    report = run_doctor()
+    assert all(c.name != "graph_store_health" for c in report.checks)
+
+
+def test_graph_store_health_check_ok_when_db_missing(
+    isolated_cwd: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No on-disk Kuzu file yet → OK (will be created on first index)."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    state_dir = isolated_cwd / ".agent-brain"
+    _make_graphrag_config(state_dir)
+
+    report = run_doctor()
+    health = [c for c in report.checks if c.name == "graph_store_health"]
+    assert len(health) == 1
+    assert health[0].status == "ok"
+    assert "No Kuzu DB on disk yet" in health[0].message
+
+
+def test_graph_store_health_check_fails_on_corrupted_db(
+    isolated_cwd: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Write a junk-bytes 'kuzu_db' file and verify the check FAILs."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    state_dir = isolated_cwd / ".agent-brain"
+    _make_graphrag_config(state_dir)
+    graph_dir = state_dir / "data" / "graph_index"
+    graph_dir.mkdir(parents=True)
+    (graph_dir / "kuzu_db").write_bytes(b"\x00\x01\x02junk-not-a-valid-kuzu-catalog")
+
+    # Stub kuzu.Database to raise the same way the real bug does
+    import sys
+    import types
+
+    fake_kuzu = types.ModuleType("kuzu")
+
+    def database(_path):  # type: ignore[no-untyped-def]
+        raise IndexError("unordered_map::at: key not found")
+
+    fake_kuzu.Database = database  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "kuzu", fake_kuzu)
+
+    report = run_doctor()
+    health = [c for c in report.checks if c.name == "graph_store_health"]
+    assert len(health) == 1
+    assert health[0].status == "fail"
+    assert "corrupted" in health[0].message.lower()
+    assert health[0].fix is not None and "doctor --fix" in health[0].fix
+
+
+def test_graph_store_fix_quarantines_corrupted_db(
+    isolated_cwd: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--fix should rename the corrupted kuzu_db aside and report the action."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    state_dir = isolated_cwd / ".agent-brain"
+    _make_graphrag_config(state_dir)
+    graph_dir = state_dir / "data" / "graph_index"
+    graph_dir.mkdir(parents=True)
+    db_file = graph_dir / "kuzu_db"
+    db_file.write_bytes(b"junk")
+
+    import sys
+    import types
+
+    fake_kuzu = types.ModuleType("kuzu")
+
+    def database(_path):  # type: ignore[no-untyped-def]
+        raise IndexError("unordered_map::at: key not found")
+
+    fake_kuzu.Database = database  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "kuzu", fake_kuzu)
+
+    report = run_doctor()
+    actions = apply_safe_fixes(report)
+
+    # The kuzu_db file should be renamed to a .corrupted-<ts> sibling.
+    assert not db_file.exists()
+    quarantined = list(graph_dir.glob("kuzu_db.corrupted-*"))
+    assert len(quarantined) == 1
+    assert any("Quarantined kuzu_db" in a for a in actions)
+    # No snapshot was present, so we should also see the "no snapshot" note.
+    assert any("No snapshot available" in a for a in actions)
+
+
+def test_graph_store_fix_skips_when_server_lock_exists(
+    isolated_cwd: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If a server.lock exists, --fix must refuse to touch the kuzu_db so it
+    doesn't race the server."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    state_dir = isolated_cwd / ".agent-brain"
+    _make_graphrag_config(state_dir)
+    graph_dir = state_dir / "data" / "graph_index"
+    graph_dir.mkdir(parents=True)
+    db_file = graph_dir / "kuzu_db"
+    db_file.write_bytes(b"junk")
+    (state_dir / "server.lock").write_text("pid=12345\n")
+
+    import sys
+    import types
+
+    fake_kuzu = types.ModuleType("kuzu")
+
+    def database(_path):  # type: ignore[no-untyped-def]
+        raise IndexError("unordered_map::at: key not found")
+
+    fake_kuzu.Database = database  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "kuzu", fake_kuzu)
+
+    report = run_doctor()
+    actions = apply_safe_fixes(report)
+
+    # File still present, lock detection kept --fix from touching it.
+    assert db_file.exists()
+    assert any("server appears to be running" in a for a in actions)

--- a/agent-brain-server/agent_brain_server/api/main.py
+++ b/agent-brain-server/agent_brain_server/api/main.py
@@ -8,6 +8,7 @@ multiple workers, ensure only one worker handles indexing jobs by using
 the single-worker model or a separate job processor service.
 """
 
+import asyncio
 import logging
 import os
 import socket
@@ -537,6 +538,35 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             _job_worker.set_folder_manager(folder_manager)
             # Wire JobWorker to QueryCacheService (Phase 17)
             _job_worker.set_query_cache(query_cache)
+
+        # Kuzu graph store preflight (Issue #166): proactively open the
+        # Kuzu DB so corruption from a prior kill-mid-write is detected and
+        # self-healed at startup, rather than failing the first user
+        # indexing job. No-op when GraphRAG is disabled or store_type !=
+        # "kuzu". Runs in a thread because kuzu.Database() is sync I/O.
+        try:
+            from agent_brain_server.storage.graph_store import (
+                get_graph_store_manager,
+            )
+
+            graph_store_mgr = get_graph_store_manager()
+            preflight_ok = await asyncio.to_thread(graph_store_mgr.preflight_check)
+            if preflight_ok:
+                logger.info(
+                    "Kuzu graph store preflight: OK " "(entities=%d, relationships=%d)",
+                    graph_store_mgr.entity_count,
+                    graph_store_mgr.relationship_count,
+                )
+        except Exception as preflight_exc:  # pragma: no cover - defensive
+            # Preflight is best-effort. A failure here means recovery
+            # couldn't complete; surface it but don't block startup so the
+            # user can still hit /health and run `agent-brain doctor --fix`.
+            logger.error(
+                "Kuzu graph store preflight failed: %s. Server will start "
+                "but graph operations may fail until you run "
+                "`agent-brain doctor --fix`.",
+                preflight_exc,
+            )
 
         # Set multi-instance metadata on app.state for health endpoint
         app.state.mode = mode

--- a/agent-brain-server/agent_brain_server/config/settings.py
+++ b/agent-brain-server/agent_brain_server/config/settings.py
@@ -79,6 +79,13 @@ class Settings(BaseSettings):
     GRAPH_LANGEXTRACT_PROVIDER: str = ""
     # Override model for LangExtract (default: from summarization config)
     GRAPH_LANGEXTRACT_MODEL: str = ""
+    # Triplet snapshot durability (Issue #166). Snapshots are written
+    # under <graph_index>/snapshots/ during indexing so a process kill
+    # mid-langextract doesn't lose extraction work. Hybrid cadence: a
+    # snapshot is taken whenever EITHER threshold is crossed.
+    GRAPH_SNAPSHOT_CHUNKS: int = 25  # Snapshot every N processed chunks
+    GRAPH_SNAPSHOT_INTERVAL_SEC: int = 60  # ...or after this many seconds
+    GRAPH_SNAPSHOT_KEEP: int = 3  # Number of snapshots to retain (>= 1)
 
     # Job Queue Configuration (Feature 115)
     AGENT_BRAIN_MAX_QUEUE: int = 100  # Max pending jobs in queue

--- a/agent-brain-server/agent_brain_server/indexing/graph_index.py
+++ b/agent-brain-server/agent_brain_server/indexing/graph_index.py
@@ -5,6 +5,7 @@ Coordinates between extractors, graph store, and vector store.
 """
 
 import logging
+import time
 from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any
@@ -24,6 +25,10 @@ from agent_brain_server.models.graph import (
     GraphQueryContext,
     GraphTriple,
     normalize_entity_type,
+)
+from agent_brain_server.storage.graph_snapshot import (
+    GraphSnapshotManager,
+    SnapshotTriplet,
 )
 
 
@@ -101,15 +106,22 @@ class GraphIndexManager:
         self,
         documents: list[Any],
         progress_callback: ProgressCallback | None = None,
+        source_job_id: str | None = None,
     ) -> int:
         """Build graph index from documents.
 
         Extracts entities and relationships from document chunks
-        and stores them in the graph.
+        and stores them in the graph. Periodically snapshots the
+        accumulated triplets to disk (hybrid cadence — every
+        ``GRAPH_SNAPSHOT_CHUNKS`` chunks OR ``GRAPH_SNAPSHOT_INTERVAL_SEC``
+        seconds, whichever comes first) so a process kill mid-langextract
+        does not lose extraction work.
 
         Args:
             documents: List of document chunks with text and metadata.
             progress_callback: Optional callback(current, total, message).
+            source_job_id: Optional job id, recorded in snapshots for
+                attribution.
 
         Returns:
             Total number of triplets extracted and stored.
@@ -128,14 +140,41 @@ class GraphIndexManager:
         total_triplets = 0
         total_docs = len(documents)
 
+        snapshot_mgr = GraphSnapshotManager(self.graph_store.persist_dir)
+        accumulated_snapshot_triplets: list[SnapshotTriplet] = []
+        chunks_since_snapshot = 0
+        last_snapshot_ts = time.monotonic()
+        snapshot_chunk_threshold = max(1, int(settings.GRAPH_SNAPSHOT_CHUNKS))
+        snapshot_interval = max(1, int(settings.GRAPH_SNAPSHOT_INTERVAL_SEC))
+        snapshot_keep = max(1, int(settings.GRAPH_SNAPSHOT_KEEP))
+
         logger.info(
             "graph_index.build_from_documents: starting",
             extra={
                 "document_count": total_docs,
                 "llm_extraction": settings.GRAPH_USE_LLM_EXTRACTION,
                 "code_metadata": settings.GRAPH_USE_CODE_METADATA,
+                "snapshot_chunk_threshold": snapshot_chunk_threshold,
+                "snapshot_interval_sec": snapshot_interval,
             },
         )
+
+        def _take_snapshot() -> None:
+            try:
+                snapshot_mgr.write(
+                    list(accumulated_snapshot_triplets),
+                    source_job_id=source_job_id,
+                )
+                snapshot_mgr.rotate(keep=snapshot_keep)
+            except OSError as exc:
+                # Snapshot is a safety net — never fail indexing because the
+                # snapshot couldn't be written (e.g. disk full).
+                logger.warning(
+                    "graph_index: snapshot write failed (%s); continuing "
+                    "without snapshot — corruption recovery will only restore "
+                    "earlier triplets",
+                    exc,
+                )
 
         for idx, doc in enumerate(documents):
             if progress_callback:
@@ -158,6 +197,31 @@ class GraphIndexManager:
                 )
                 if success:
                     total_triplets += 1
+                    accumulated_snapshot_triplets.append(
+                        SnapshotTriplet(
+                            subject=triplet.subject,
+                            predicate=triplet.predicate,
+                            object=triplet.object,
+                            subject_type=triplet.subject_type,
+                            object_type=triplet.object_type,
+                            source_chunk_id=triplet.source_chunk_id,
+                        )
+                    )
+
+            chunks_since_snapshot += 1
+            elapsed = time.monotonic() - last_snapshot_ts
+            if (
+                chunks_since_snapshot >= snapshot_chunk_threshold
+                or elapsed >= snapshot_interval
+            ):
+                _take_snapshot()
+                chunks_since_snapshot = 0
+                last_snapshot_ts = time.monotonic()
+
+        # Final snapshot at end of build so the on-disk state matches the
+        # full extraction even if neither threshold was reached on the tail.
+        if accumulated_snapshot_triplets and chunks_since_snapshot > 0:
+            _take_snapshot()
 
         # Persist the graph
         self.graph_store.persist()

--- a/agent-brain-server/agent_brain_server/indexing/graph_index.py
+++ b/agent-brain-server/agent_brain_server/indexing/graph_index.py
@@ -8,6 +8,7 @@ import logging
 import time
 from collections.abc import Callable
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from agent_brain_server.config import settings
@@ -140,7 +141,16 @@ class GraphIndexManager:
         total_triplets = 0
         total_docs = len(documents)
 
-        snapshot_mgr = GraphSnapshotManager(self.graph_store.persist_dir)
+        # Snapshots only run when the graph store has a real on-disk
+        # persist_dir. Mock-based unit tests of build_from_documents (where
+        # persist_dir is a MagicMock attribute) should still work without
+        # creating stray directories named after the mock.
+        persist_dir = getattr(self.graph_store, "persist_dir", None)
+        snapshot_mgr: GraphSnapshotManager | None
+        if isinstance(persist_dir, Path):
+            snapshot_mgr = GraphSnapshotManager(persist_dir)
+        else:
+            snapshot_mgr = None
         accumulated_snapshot_triplets: list[SnapshotTriplet] = []
         chunks_since_snapshot = 0
         last_snapshot_ts = time.monotonic()
@@ -160,6 +170,8 @@ class GraphIndexManager:
         )
 
         def _take_snapshot() -> None:
+            if snapshot_mgr is None:
+                return
             try:
                 snapshot_mgr.write(
                     list(accumulated_snapshot_triplets),

--- a/agent-brain-server/agent_brain_server/services/indexing_service.py
+++ b/agent-brain-server/agent_brain_server/services/indexing_service.py
@@ -727,7 +727,9 @@ class IndexingService:
 
                 def _build_graph() -> int:
                     return graph_mgr.build_from_documents(
-                        chunks, progress_callback=graph_progress
+                        chunks,
+                        progress_callback=graph_progress,
+                        source_job_id=job_id,
                     )
 
                 triplet_count = await asyncio.to_thread(_build_graph)

--- a/agent-brain-server/agent_brain_server/storage/graph_snapshot.py
+++ b/agent-brain-server/agent_brain_server/storage/graph_snapshot.py
@@ -1,0 +1,285 @@
+"""Triplet snapshot manager for Kuzu graph store durability (Issue #166).
+
+Provides periodic JSON snapshots of graph triplets so that a process kill
+mid-indexing does not destroy previously-extracted work. Snapshots are
+written atomically (tmp + os.replace) under
+``<persist_dir>/snapshots/snapshot-<ISO8601>.json`` and rotated to keep
+the K most recent.
+
+After the defensive recovery path in ``graph_store._initialize_kuzu_store``
+renames a corrupted ``kuzu_db``, the latest valid snapshot is replayed
+into the fresh database — preserving API spend on previously-extracted
+triplets.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+SNAPSHOT_DIR_NAME = "snapshots"
+SNAPSHOT_FILE_PREFIX = "snapshot-"
+SNAPSHOT_FILE_SUFFIX = ".json"
+DEFAULT_KEEP = 3
+
+# Filename pattern: snapshot-2026-05-26T21-05-32Z.json (colons replaced for
+# filesystem safety) plus an optional ``-NNN`` monotonic suffix for clock
+# collisions within the same second.
+_FILENAME_RE = re.compile(
+    r"^snapshot-(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z)"
+    r"(?:-(?P<seq>\d{3}))?\.json$"
+)
+
+
+@dataclass(frozen=True)
+class SnapshotTriplet:
+    """A single graph triplet, serializable to/from snapshot JSON."""
+
+    subject: str
+    predicate: str
+    object: str
+    subject_type: str | None = None
+    object_type: str | None = None
+    source_chunk_id: str | None = None
+
+
+def _timestamp_for_filename(now: datetime | None = None) -> str:
+    """Return an ISO8601-ish UTC timestamp safe for filenames."""
+    moment = now or datetime.now(timezone.utc)
+    # Replace ':' with '-' so the filename is portable across filesystems.
+    return moment.strftime("%Y-%m-%dT%H-%M-%SZ")
+
+
+class GraphSnapshotManager:
+    """Writes, lists, and rotates triplet snapshots for the graph store.
+
+    Snapshots live under ``<persist_dir>/snapshots/`` as JSON files. The
+    manager is intentionally backend-agnostic — it operates on plain
+    ``SnapshotTriplet`` records and never touches Kuzu directly.
+
+    Attributes:
+        persist_dir: The graph store's persist directory (e.g.
+            ``.agent-brain/data/graph_index``). The snapshots subdirectory
+            is created lazily on first write.
+    """
+
+    def __init__(self, persist_dir: Path) -> None:
+        self.persist_dir = Path(persist_dir)
+
+    @property
+    def snapshot_dir(self) -> Path:
+        """Path of the snapshots subdirectory (may not yet exist)."""
+        return self.persist_dir / SNAPSHOT_DIR_NAME
+
+    def write(
+        self,
+        triplets: list[SnapshotTriplet],
+        source_job_id: str | None = None,
+        kuzu_version: str | None = None,
+        now: datetime | None = None,
+    ) -> Path:
+        """Write a snapshot atomically and return its path.
+
+        Args:
+            triplets: Triplets to snapshot. May be empty (an empty snapshot
+                still writes — it represents "we got here with zero
+                triplets" which is useful for restore-from-empty).
+            source_job_id: Optional indexing job id for attribution.
+            kuzu_version: Optional Kuzu version string for forensic context.
+            now: Override timestamp (testing).
+
+        Returns:
+            Path of the written snapshot file.
+
+        Raises:
+            OSError: If the write fails (disk full, permission, etc.).
+        """
+        self.snapshot_dir.mkdir(parents=True, exist_ok=True)
+
+        moment = now or datetime.now(timezone.utc)
+        base_name = (
+            f"{SNAPSHOT_FILE_PREFIX}{_timestamp_for_filename(moment)}"
+            f"{SNAPSHOT_FILE_SUFFIX}"
+        )
+        target = self.snapshot_dir / base_name
+
+        # Clock-collision tie-break: if a snapshot already exists for this
+        # exact second, append a monotonic 3-digit suffix.
+        if target.exists():
+            for seq in range(1, 1000):
+                candidate = self.snapshot_dir / (
+                    f"{SNAPSHOT_FILE_PREFIX}{_timestamp_for_filename(moment)}"
+                    f"-{seq:03d}{SNAPSHOT_FILE_SUFFIX}"
+                )
+                if not candidate.exists():
+                    target = candidate
+                    break
+
+        payload = {
+            "schema_version": SCHEMA_VERSION,
+            "created_at": moment.isoformat(),
+            "kuzu_version": kuzu_version,
+            "source_job_id": source_job_id,
+            "triplet_count": len(triplets),
+            "triplets": [asdict(t) for t in triplets],
+        }
+
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, target)
+
+        logger.info(
+            "graph_snapshot.write: wrote snapshot",
+            extra={
+                "path": str(target),
+                "triplet_count": len(triplets),
+                "source_job_id": source_job_id,
+            },
+        )
+        return target
+
+    def list_snapshots(self) -> list[Path]:
+        """Return snapshot paths sorted newest-first by filename timestamp."""
+        if not self.snapshot_dir.is_dir():
+            return []
+        candidates = [
+            p
+            for p in self.snapshot_dir.iterdir()
+            if p.is_file() and _FILENAME_RE.match(p.name)
+        ]
+        # Filename sort is equivalent to timestamp sort because of the
+        # zero-padded ISO8601 format.
+        candidates.sort(key=lambda p: p.name, reverse=True)
+        return candidates
+
+    def latest(self) -> Path | None:
+        """Return the newest snapshot path or None if none exist."""
+        snaps = self.list_snapshots()
+        return snaps[0] if snaps else None
+
+    def load(self, path: Path) -> list[SnapshotTriplet]:
+        """Load and parse a snapshot file.
+
+        Args:
+            path: Snapshot file to load.
+
+        Returns:
+            List of triplets parsed from the snapshot.
+
+        Raises:
+            OSError: If the file cannot be read.
+            ValueError: If the file is not a valid snapshot (bad JSON,
+                missing fields, unknown schema version). Callers handle
+                this to fall back to an older snapshot.
+        """
+        try:
+            with open(path, encoding="utf-8") as f:
+                payload = json.load(f)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Snapshot {path} is not valid JSON") from exc
+
+        schema = payload.get("schema_version")
+        if schema != SCHEMA_VERSION:
+            raise ValueError(
+                f"Snapshot {path} has unsupported schema_version={schema} "
+                f"(expected {SCHEMA_VERSION})"
+            )
+
+        raw_triplets = payload.get("triplets")
+        if not isinstance(raw_triplets, list):
+            raise ValueError(f"Snapshot {path} is missing 'triplets' list")
+
+        out: list[SnapshotTriplet] = []
+        for entry in raw_triplets:
+            if not isinstance(entry, dict):
+                raise ValueError(
+                    f"Snapshot {path} contains non-dict triplet: {entry!r}"
+                )
+            try:
+                out.append(
+                    SnapshotTriplet(
+                        subject=entry["subject"],
+                        predicate=entry["predicate"],
+                        object=entry["object"],
+                        subject_type=entry.get("subject_type"),
+                        object_type=entry.get("object_type"),
+                        source_chunk_id=entry.get("source_chunk_id"),
+                    )
+                )
+            except KeyError as exc:
+                raise ValueError(
+                    f"Snapshot {path} triplet missing required key: {exc}"
+                ) from exc
+
+        return out
+
+    def load_latest_valid(self) -> tuple[Path, list[SnapshotTriplet]] | None:
+        """Load the newest valid snapshot, skipping corrupted ones.
+
+        Walks newest-to-oldest, returning the first that parses cleanly.
+        Corrupted snapshots are renamed with a ``.corrupted`` suffix so the
+        next call doesn't re-encounter them, and a WARN is logged.
+
+        Returns:
+            (path, triplets) for the loaded snapshot, or None if no valid
+            snapshot exists.
+        """
+        for path in self.list_snapshots():
+            try:
+                triplets = self.load(path)
+                return path, triplets
+            except (ValueError, OSError) as exc:
+                logger.warning(
+                    "graph_snapshot.load_latest_valid: skipping corrupted "
+                    "snapshot %s (%s)",
+                    path,
+                    exc,
+                )
+                corrupted = path.with_suffix(path.suffix + ".corrupted")
+                try:
+                    path.rename(corrupted)
+                except OSError as rename_exc:
+                    logger.warning(
+                        "graph_snapshot.load_latest_valid: could not rename "
+                        "corrupted snapshot %s: %s",
+                        path,
+                        rename_exc,
+                    )
+        return None
+
+    def rotate(self, keep: int = DEFAULT_KEEP) -> int:
+        """Delete older snapshots, keeping the ``keep`` most recent.
+
+        Args:
+            keep: Number of snapshots to retain. Must be >= 1.
+
+        Returns:
+            Number of snapshots deleted.
+        """
+        if keep < 1:
+            raise ValueError(f"keep must be >= 1, got {keep}")
+        snaps = self.list_snapshots()
+        to_delete = snaps[keep:]
+        for path in to_delete:
+            try:
+                path.unlink()
+            except OSError as exc:
+                logger.warning(
+                    "graph_snapshot.rotate: failed to delete %s: %s", path, exc
+                )
+        if to_delete:
+            logger.debug(
+                "graph_snapshot.rotate: kept %d, deleted %d", keep, len(to_delete)
+            )
+        return len(to_delete)

--- a/agent-brain-server/agent_brain_server/storage/graph_snapshot.py
+++ b/agent-brain-server/agent_brain_server/storage/graph_snapshot.py
@@ -150,7 +150,13 @@ class GraphSnapshotManager:
         return target
 
     def list_snapshots(self) -> list[Path]:
-        """Return snapshot paths sorted newest-first by filename timestamp."""
+        """Return snapshot paths sorted newest-first.
+
+        Sort key is (mtime, filename) — mtime is the primary signal so a
+        snapshot written milliseconds after another is correctly newer,
+        even when both share the same ISO-second filename stamp. Filename
+        breaks ties for determinism in tests that pre-create files.
+        """
         if not self.snapshot_dir.is_dir():
             return []
         candidates = [
@@ -158,9 +164,7 @@ class GraphSnapshotManager:
             for p in self.snapshot_dir.iterdir()
             if p.is_file() and _FILENAME_RE.match(p.name)
         ]
-        # Filename sort is equivalent to timestamp sort because of the
-        # zero-padded ISO8601 format.
-        candidates.sort(key=lambda p: p.name, reverse=True)
+        candidates.sort(key=lambda p: (p.stat().st_mtime, p.name), reverse=True)
         return candidates
 
     def latest(self) -> Path | None:

--- a/agent-brain-server/agent_brain_server/storage/graph_store.py
+++ b/agent-brain-server/agent_brain_server/storage/graph_store.py
@@ -274,10 +274,8 @@ class GraphStoreManager:
                         "location."
                     ) from exc
 
-            self._kuzu_db = self._open_kuzu_with_recovery(kuzu, kuzu_db_path)
-            self._graph_store = KuzuPropertyGraphStore(
-                self._kuzu_db,
-                use_vector_index=False,
+            self._kuzu_db, self._graph_store = self._open_kuzu_with_recovery(
+                kuzu, KuzuPropertyGraphStore, kuzu_db_path
             )
             logger.debug(f"Initialized KuzuPropertyGraphStore at {kuzu_db_path}")
 
@@ -293,42 +291,66 @@ class GraphStoreManager:
             self.store_type = "simple"
             self._initialize_simple_store()
 
-    def _open_kuzu_with_recovery(self, kuzu: Any, kuzu_db_path: Path) -> Any:
-        """Open the Kuzu database, recovering from corruption if needed.
+    def _open_kuzu_with_recovery(
+        self, kuzu: Any, kuzu_store_cls: Any, kuzu_db_path: Path
+    ) -> tuple[Any, Any]:
+        """Open the Kuzu DB *and* its property-graph wrapper, recovering on
+        corruption.
 
-        On a clean DB this is a one-line wrapper around ``kuzu.Database()``.
-        When the on-disk catalog is corrupted (e.g. from a prior process kill
-        mid-write — see issue #166), Kuzu raises ``IndexError`` /
-        ``RuntimeError`` from its pybind11 C++ constructor. In that case we:
+        Both ``kuzu.Database()`` AND ``KuzuPropertyGraphStore(db, ...)`` can
+        fail when the on-disk catalog is corrupted — the wrapper opens a
+        ``kuzu.Connection`` and runs ``init_schema()`` DDL during its
+        constructor. We wrap both calls together so corruption that
+        manifests during connection setup (not just the Database constructor)
+        is also caught and self-healed.
 
-        1. Log a loud, actionable WARN naming the path
+        Sequence on corruption (see issue #166):
+
+        1. Log a loud, actionable WARN naming the path and the originating
+           exception (IndexError ``unordered_map::at: key not found`` is the
+           canonical kill-mid-write signature; we also catch RuntimeError
+           and broadly-typed exceptions raised from pybind11 internals).
         2. Rename ``kuzu_db`` and ``kuzu_db.wal`` to ``.corrupted-<ts>``
-           siblings (preserved for post-mortem, never deleted)
-        3. Retry ``kuzu.Database()`` on the now-empty path
-        4. Trigger snapshot replay (handled by caller after wrapper is built)
+           siblings — preserved for post-mortem, never deleted.
+        3. Retry the open-and-wrap pair on the now-empty path.
+        4. Trigger snapshot replay (handled by caller after this returns).
 
         If the retry *also* fails we raise a structured ``RuntimeError`` with
-        an explicit reset instruction. We never loop.
+        explicit reset instructions. We never loop.
 
-        Sets ``self._recovered_from_corruption`` so ``_restore_from_snapshot``
-        only runs when there's something to restore.
+        Sets ``self._recovered_from_corruption`` so
+        ``_restore_from_snapshot_if_available`` only runs when there's
+        something to restore.
+
+        Returns:
+            ``(kuzu.Database, KuzuPropertyGraphStore)`` tuple.
         """
         self._recovered_from_corruption = False
+
+        def _attempt() -> tuple[Any, Any]:
+            db = kuzu.Database(str(kuzu_db_path))
+            store = kuzu_store_cls(db, use_vector_index=False)
+            return db, store
+
+        # Catch the narrow corruption signatures (IndexError, RuntimeError)
+        # for the Database/Connection layer. We deliberately don't catch
+        # broader Exception here so genuine misconfigurations (e.g.
+        # ImportError from a missing extra) still surface clearly.
         try:
-            return kuzu.Database(str(kuzu_db_path))
+            return _attempt()
         except (IndexError, RuntimeError) as exc:
             logger.warning(
-                "Kuzu DB at %s appears corrupted (likely from a prior "
-                "process kill mid-indexing): %s. Renaming to .corrupted-<ts> "
-                "and starting fresh. Previously-extracted triplets will be "
-                "restored from the latest snapshot if available; otherwise "
-                "re-index to rebuild.",
+                "Kuzu graph store at %s appears corrupted (likely from a "
+                "prior process kill mid-indexing): %s. Renaming to "
+                ".corrupted-<ts> and starting fresh. Previously-extracted "
+                "triplets will be restored from the latest snapshot if "
+                "available; otherwise re-index to rebuild.",
                 kuzu_db_path,
                 exc,
             )
             quarantined_db = _quarantine_file(kuzu_db_path)
             quarantined_wal = _quarantine_file(
-                kuzu_db_path.with_suffix(kuzu_db_path.suffix + ".wal")
+                kuzu_db_path.with_name(kuzu_db_path.name + ".wal")
             )
             logger.info(
                 "Quarantined corrupted Kuzu files: db=%s wal=%s",
@@ -337,7 +359,7 @@ class GraphStoreManager:
             )
             self._recovered_from_corruption = True
             try:
-                return kuzu.Database(str(kuzu_db_path))
+                return _attempt()
             except (IndexError, RuntimeError) as retry_exc:
                 raise RuntimeError(
                     f"Failed to initialize Kuzu graph store at {kuzu_db_path} "

--- a/agent-brain-server/agent_brain_server/storage/graph_store.py
+++ b/agent-brain-server/agent_brain_server/storage/graph_store.py
@@ -10,6 +10,7 @@ All graph operations are no-ops when ENABLE_GRAPH_INDEX is False.
 import json
 import logging
 import os
+import shutil
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -18,8 +19,37 @@ from agent_brain_server.config import settings
 from agent_brain_server.config.provider_config import (
     load_provider_settings,
 )
+from agent_brain_server.storage.graph_snapshot import (
+    GraphSnapshotManager,
+    SnapshotTriplet,
+)
 
 logger = logging.getLogger(__name__)
+
+
+def _corrupted_sibling(path: Path, now: datetime | None = None) -> Path:
+    """Return a sibling path with a .corrupted-<ts> suffix for renaming."""
+    moment = now or datetime.now(timezone.utc)
+    stamp = moment.strftime("%Y%m%dT%H%M%SZ")
+    return path.with_name(f"{path.name}.corrupted-{stamp}")
+
+
+def _quarantine_file(path: Path) -> Path | None:
+    """Rename a (possibly corrupted) file to a .corrupted-<ts> sibling.
+
+    Returns the quarantined path, or ``None`` if the source did not exist.
+    Falls back to ``shutil.move`` if ``Path.rename`` fails (e.g. across
+    filesystem boundaries — shouldn't happen for sibling renames but the
+    extra robustness costs nothing).
+    """
+    if not path.exists():
+        return None
+    dest = _corrupted_sibling(path)
+    try:
+        path.rename(dest)
+    except OSError:
+        shutil.move(str(path), str(dest))
+    return dest
 
 
 def _graphrag_enabled() -> bool:
@@ -244,12 +274,17 @@ class GraphStoreManager:
                         "location."
                     ) from exc
 
-            self._kuzu_db = kuzu.Database(str(kuzu_db_path))
+            self._kuzu_db = self._open_kuzu_with_recovery(kuzu, kuzu_db_path)
             self._graph_store = KuzuPropertyGraphStore(
                 self._kuzu_db,
                 use_vector_index=False,
             )
             logger.debug(f"Initialized KuzuPropertyGraphStore at {kuzu_db_path}")
+
+            # If we just recovered from corruption, replay the latest valid
+            # snapshot to restore previously-extracted triplets. Done after
+            # the graph store wrapper is in place so we can route through it.
+            self._restore_from_snapshot_if_available()
         except ImportError as e:
             logger.warning(
                 f"Kuzu not available ({e}), falling back to SimplePropertyGraphStore. "
@@ -257,6 +292,194 @@ class GraphStoreManager:
             )
             self.store_type = "simple"
             self._initialize_simple_store()
+
+    def _open_kuzu_with_recovery(self, kuzu: Any, kuzu_db_path: Path) -> Any:
+        """Open the Kuzu database, recovering from corruption if needed.
+
+        On a clean DB this is a one-line wrapper around ``kuzu.Database()``.
+        When the on-disk catalog is corrupted (e.g. from a prior process kill
+        mid-write — see issue #166), Kuzu raises ``IndexError`` /
+        ``RuntimeError`` from its pybind11 C++ constructor. In that case we:
+
+        1. Log a loud, actionable WARN naming the path
+        2. Rename ``kuzu_db`` and ``kuzu_db.wal`` to ``.corrupted-<ts>``
+           siblings (preserved for post-mortem, never deleted)
+        3. Retry ``kuzu.Database()`` on the now-empty path
+        4. Trigger snapshot replay (handled by caller after wrapper is built)
+
+        If the retry *also* fails we raise a structured ``RuntimeError`` with
+        an explicit reset instruction. We never loop.
+
+        Sets ``self._recovered_from_corruption`` so ``_restore_from_snapshot``
+        only runs when there's something to restore.
+        """
+        self._recovered_from_corruption = False
+        try:
+            return kuzu.Database(str(kuzu_db_path))
+        except (IndexError, RuntimeError) as exc:
+            logger.warning(
+                "Kuzu DB at %s appears corrupted (likely from a prior "
+                "process kill mid-indexing): %s. Renaming to .corrupted-<ts> "
+                "and starting fresh. Previously-extracted triplets will be "
+                "restored from the latest snapshot if available; otherwise "
+                "re-index to rebuild.",
+                kuzu_db_path,
+                exc,
+            )
+            quarantined_db = _quarantine_file(kuzu_db_path)
+            quarantined_wal = _quarantine_file(
+                kuzu_db_path.with_suffix(kuzu_db_path.suffix + ".wal")
+            )
+            logger.info(
+                "Quarantined corrupted Kuzu files: db=%s wal=%s",
+                quarantined_db,
+                quarantined_wal,
+            )
+            self._recovered_from_corruption = True
+            try:
+                return kuzu.Database(str(kuzu_db_path))
+            except (IndexError, RuntimeError) as retry_exc:
+                raise RuntimeError(
+                    f"Failed to initialize Kuzu graph store at {kuzu_db_path} "
+                    f"even after quarantining the corrupted database "
+                    f"({quarantined_db}). The retry attempt also raised: "
+                    f"{retry_exc}. To fully reset, stop the server and "
+                    f"`rm -rf {kuzu_db_path.parent}` (this loses all "
+                    "previously-extracted triplets)."
+                ) from retry_exc
+
+    def _restore_from_snapshot_if_available(self) -> int:
+        """Replay the latest valid triplet snapshot into the graph store.
+
+        Only runs when ``self._recovered_from_corruption`` is True — on a
+        clean DB there's nothing to restore. Walks newest-to-oldest
+        snapshots, skipping (and renaming) corrupted ones, until a valid
+        snapshot is found.
+
+        Returns:
+            Number of triplets restored (0 if no snapshot available).
+        """
+        if not getattr(self, "_recovered_from_corruption", False):
+            return 0
+
+        snapshot_mgr = GraphSnapshotManager(self.persist_dir)
+        loaded = snapshot_mgr.load_latest_valid()
+        if loaded is None:
+            logger.info(
+                "graph_store: no snapshot available after recovery; "
+                "starting with empty graph at %s",
+                self.persist_dir,
+            )
+            return 0
+
+        snapshot_path, triplets = loaded
+        restored = 0
+        for triplet in triplets:
+            if self._apply_triplet_to_store(triplet):
+                restored += 1
+        # Update bookkeeping counters so subsequent persist/load matches reality
+        self._relationship_count = restored
+        self._last_updated = datetime.now(timezone.utc)
+
+        logger.warning(
+            "Restored %d triplets from snapshot %s after recovering "
+            "corrupted kuzu_db at %s",
+            restored,
+            snapshot_path.name,
+            self.persist_dir / "kuzu_db",
+        )
+        return restored
+
+    def _apply_triplet_to_store(self, triplet: SnapshotTriplet) -> bool:
+        """Insert a triplet into the underlying graph store backend.
+
+        This is the same body as ``add_triplet`` but without the
+        ``_initialized`` guard, so it can run during initialization (during
+        snapshot replay). Returns True on success.
+        """
+        store = self._graph_store
+        if store is None:
+            return False
+        try:
+            if hasattr(store, "upsert_triplet"):
+                store.upsert_triplet(
+                    subject=triplet.subject,
+                    predicate=triplet.predicate,
+                    object_=triplet.object,
+                )
+            elif hasattr(store, "upsert_relations") and hasattr(store, "upsert_nodes"):
+                from llama_index.core.graph_stores.types import (
+                    EntityNode,
+                    Relation,
+                )
+
+                subj_node = EntityNode(
+                    name=triplet.subject,
+                    label=triplet.subject_type or "Entity",
+                )
+                obj_node = EntityNode(
+                    name=triplet.object,
+                    label=triplet.object_type or "Entity",
+                )
+                store.upsert_nodes([subj_node, obj_node])
+                store.upsert_relations(
+                    [
+                        Relation(
+                            label=triplet.predicate,
+                            source_id=subj_node.id,
+                            target_id=obj_node.id,
+                            properties=(
+                                {"source_chunk_id": triplet.source_chunk_id}
+                                if triplet.source_chunk_id
+                                else {}
+                            ),
+                        )
+                    ]
+                )
+            elif hasattr(store, "add_triplet"):
+                store.add_triplet(triplet.subject, triplet.predicate, triplet.object)
+            elif hasattr(store, "_add_triplet"):
+                store._add_triplet(
+                    triplet.subject,
+                    triplet.predicate,
+                    triplet.object,
+                    triplet.subject_type,
+                    triplet.object_type,
+                    triplet.source_chunk_id,
+                )
+            else:
+                return False
+            return True
+        except Exception as exc:
+            logger.warning(
+                "graph_store._apply_triplet_to_store: failed for %s -%s-> %s: %s",
+                triplet.subject,
+                triplet.predicate,
+                triplet.object,
+                exc,
+            )
+            return False
+
+    def preflight_check(self) -> bool:
+        """Open the Kuzu DB proactively so corruption is caught at startup.
+
+        Called from the server lifespan before any indexing job runs, so the
+        first user-facing job doesn't pay the corruption-recovery tax. Safe
+        to call multiple times; no-ops if GraphRAG is disabled or already
+        initialized.
+
+        Returns:
+            True if the store is healthy (possibly after recovery), False
+            if the preflight was skipped (graphrag disabled, non-kuzu).
+        """
+        if not _graphrag_enabled():
+            return False
+        if self.store_type != "kuzu":
+            return False
+        if self._initialized:
+            return True
+        self.initialize()
+        return True
 
     def persist(self) -> None:
         """Persist graph to disk.

--- a/agent-brain-server/tests/unit/storage/test_graph_snapshot.py
+++ b/agent-brain-server/tests/unit/storage/test_graph_snapshot.py
@@ -1,0 +1,248 @@
+"""Tests for GraphSnapshotManager (Issue #166).
+
+Snapshots are the durability safety net for graph triplets: a kill
+mid-indexing should never lose more than the most recent snapshot's worth
+of work. These tests cover the write/list/load/rotate lifecycle plus the
+corruption-recovery path used by the graph store on startup.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from agent_brain_server.storage.graph_snapshot import (
+    DEFAULT_KEEP,
+    SCHEMA_VERSION,
+    GraphSnapshotManager,
+    SnapshotTriplet,
+)
+
+
+@pytest.fixture
+def snap_dir(tmp_path: Path) -> Path:
+    """Persist dir that doesn't yet contain a snapshots/ subdir."""
+    return tmp_path / "graph_index"
+
+
+@pytest.fixture
+def manager(snap_dir: Path) -> GraphSnapshotManager:
+    return GraphSnapshotManager(snap_dir)
+
+
+@pytest.fixture
+def sample_triplets() -> list[SnapshotTriplet]:
+    return [
+        SnapshotTriplet(
+            subject="FunctionA",
+            predicate="calls",
+            object="FunctionB",
+            subject_type="Function",
+            object_type="Function",
+            source_chunk_id="chunk_1",
+        ),
+        SnapshotTriplet(
+            subject="ClassX",
+            predicate="inherits",
+            object="ClassY",
+        ),
+    ]
+
+
+def _fake_now(offset_seconds: int = 0) -> datetime:
+    return datetime(2026, 5, 26, 21, 5, 32, tzinfo=timezone.utc) + timedelta(
+        seconds=offset_seconds
+    )
+
+
+class TestWrite:
+    def test_creates_snapshot_dir_on_first_write(
+        self, manager: GraphSnapshotManager, sample_triplets
+    ):
+        assert not manager.snapshot_dir.exists()
+        manager.write(sample_triplets)
+        assert manager.snapshot_dir.is_dir()
+
+    def test_writes_valid_json_payload(
+        self, manager: GraphSnapshotManager, sample_triplets
+    ):
+        path = manager.write(
+            sample_triplets,
+            source_job_id="job_abc",
+            kuzu_version="0.11.3",
+            now=_fake_now(),
+        )
+
+        payload = json.loads(path.read_text())
+        assert payload["schema_version"] == SCHEMA_VERSION
+        assert payload["source_job_id"] == "job_abc"
+        assert payload["kuzu_version"] == "0.11.3"
+        assert payload["triplet_count"] == 2
+        assert payload["created_at"].startswith("2026-05-26T21:05:32")
+        assert len(payload["triplets"]) == 2
+        assert payload["triplets"][0]["subject"] == "FunctionA"
+        assert payload["triplets"][0]["subject_type"] == "Function"
+        assert payload["triplets"][1]["subject_type"] is None
+
+    def test_empty_triplets_writes_zero_count_snapshot(
+        self, manager: GraphSnapshotManager
+    ):
+        path = manager.write([], now=_fake_now())
+        payload = json.loads(path.read_text())
+        assert payload["triplet_count"] == 0
+        assert payload["triplets"] == []
+
+    def test_atomic_write_leaves_no_tmp_file(
+        self, manager: GraphSnapshotManager, sample_triplets
+    ):
+        manager.write(sample_triplets, now=_fake_now())
+        leftover = list(manager.snapshot_dir.glob("*.tmp"))
+        assert leftover == []
+
+    def test_clock_collision_uses_sequence_suffix(
+        self, manager: GraphSnapshotManager, sample_triplets
+    ):
+        moment = _fake_now()
+        first = manager.write(sample_triplets, now=moment)
+        second = manager.write(sample_triplets, now=moment)
+        third = manager.write(sample_triplets, now=moment)
+        assert {first.name, second.name, third.name} == {
+            "snapshot-2026-05-26T21-05-32Z.json",
+            "snapshot-2026-05-26T21-05-32Z-001.json",
+            "snapshot-2026-05-26T21-05-32Z-002.json",
+        }
+
+
+class TestListAndLatest:
+    def test_empty_dir_returns_empty_list(self, manager: GraphSnapshotManager):
+        assert manager.list_snapshots() == []
+        assert manager.latest() is None
+
+    def test_listing_is_newest_first(
+        self, manager: GraphSnapshotManager, sample_triplets
+    ):
+        oldest = manager.write(sample_triplets, now=_fake_now(0))
+        middle = manager.write(sample_triplets, now=_fake_now(60))
+        newest = manager.write(sample_triplets, now=_fake_now(120))
+
+        snaps = manager.list_snapshots()
+        assert snaps == [newest, middle, oldest]
+        assert manager.latest() == newest
+
+    def test_ignores_unrelated_files(
+        self, manager: GraphSnapshotManager, sample_triplets
+    ):
+        manager.write(sample_triplets, now=_fake_now())
+        # Drop a junk file in the snapshot dir
+        (manager.snapshot_dir / "README.md").write_text("not a snapshot")
+        (manager.snapshot_dir / "snapshot-garbage.json").write_text("{}")
+        snaps = manager.list_snapshots()
+        assert len(snaps) == 1
+
+
+class TestLoad:
+    def test_round_trip(self, manager: GraphSnapshotManager, sample_triplets):
+        path = manager.write(sample_triplets, now=_fake_now())
+        loaded = manager.load(path)
+        assert loaded == sample_triplets
+
+    def test_bad_json_raises_value_error(
+        self, manager: GraphSnapshotManager, sample_triplets
+    ):
+        path = manager.write(sample_triplets, now=_fake_now())
+        path.write_text("{ not json")
+        with pytest.raises(ValueError, match="not valid JSON"):
+            manager.load(path)
+
+    def test_wrong_schema_version_raises(
+        self, manager: GraphSnapshotManager, sample_triplets
+    ):
+        path = manager.write(sample_triplets, now=_fake_now())
+        payload = json.loads(path.read_text())
+        payload["schema_version"] = 999
+        path.write_text(json.dumps(payload))
+        with pytest.raises(ValueError, match="unsupported schema_version"):
+            manager.load(path)
+
+    def test_missing_triplets_key_raises(
+        self, manager: GraphSnapshotManager, sample_triplets
+    ):
+        path = manager.write(sample_triplets, now=_fake_now())
+        path.write_text(json.dumps({"schema_version": SCHEMA_VERSION}))
+        with pytest.raises(ValueError, match="missing 'triplets'"):
+            manager.load(path)
+
+    def test_triplet_missing_required_key_raises(self, manager: GraphSnapshotManager):
+        path = manager.write([], now=_fake_now())
+        payload = json.loads(path.read_text())
+        payload["triplets"] = [{"subject": "A", "predicate": "calls"}]  # no object
+        path.write_text(json.dumps(payload))
+        with pytest.raises(ValueError, match="missing required key"):
+            manager.load(path)
+
+
+class TestLoadLatestValid:
+    def test_returns_none_when_empty(self, manager: GraphSnapshotManager):
+        assert manager.load_latest_valid() is None
+
+    def test_returns_newest_valid_snapshot(
+        self, manager: GraphSnapshotManager, sample_triplets
+    ):
+        manager.write(sample_triplets, now=_fake_now(0))
+        newest = manager.write(sample_triplets, now=_fake_now(60))
+        result = manager.load_latest_valid()
+        assert result is not None
+        path, triplets = result
+        assert path == newest
+        assert triplets == sample_triplets
+
+    def test_skips_corrupted_newest_and_falls_back(
+        self, manager: GraphSnapshotManager, sample_triplets
+    ):
+        oldest = manager.write(sample_triplets, now=_fake_now(0))
+        newest = manager.write(sample_triplets, now=_fake_now(60))
+        # Corrupt the newest
+        newest.write_text("{ broken json")
+
+        result = manager.load_latest_valid()
+        assert result is not None
+        path, triplets = result
+        assert path == oldest
+        assert triplets == sample_triplets
+
+        # The corrupted snapshot should have been renamed so it isn't
+        # retried next time.
+        assert not newest.exists()
+        assert (newest.parent / (newest.name + ".corrupted")).exists()
+
+
+class TestRotate:
+    def test_keep_one_of_five(self, manager: GraphSnapshotManager, sample_triplets):
+        paths = [
+            manager.write(sample_triplets, now=_fake_now(i * 60)) for i in range(5)
+        ]
+        deleted = manager.rotate(keep=1)
+        assert deleted == 4
+        remaining = manager.list_snapshots()
+        assert remaining == [paths[-1]]
+
+    def test_keep_default_three(self, manager: GraphSnapshotManager, sample_triplets):
+        for i in range(5):
+            manager.write(sample_triplets, now=_fake_now(i * 60))
+        manager.rotate()  # default keep=3
+        assert len(manager.list_snapshots()) == DEFAULT_KEEP
+
+    def test_rejects_keep_below_one(self, manager: GraphSnapshotManager):
+        with pytest.raises(ValueError):
+            manager.rotate(keep=0)
+
+    def test_noop_when_fewer_than_keep(
+        self, manager: GraphSnapshotManager, sample_triplets
+    ):
+        manager.write(sample_triplets, now=_fake_now())
+        deleted = manager.rotate(keep=10)
+        assert deleted == 0
+        assert len(manager.list_snapshots()) == 1

--- a/agent-brain-server/tests/unit/storage/test_graph_store_recovery.py
+++ b/agent-brain-server/tests/unit/storage/test_graph_store_recovery.py
@@ -1,0 +1,319 @@
+"""Tests for Kuzu graph store corruption recovery (Issue #166).
+
+Covers the defensive path added to ``_initialize_kuzu_store``: when
+``kuzu.Database()`` raises ``IndexError`` or ``RuntimeError`` from the
+pybind11 C++ constructor (typical symptom of a kill-mid-write corruption),
+the store quarantines the corrupted files, retries on a fresh path, and
+replays the latest valid snapshot.
+
+The Kuzu library is mocked because we want to exercise the recovery
+state machine without depending on actual Kuzu C++ corruption — which is
+hard to synthesize portably.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_brain_server.storage.graph_snapshot import (
+    GraphSnapshotManager,
+    SnapshotTriplet,
+)
+from agent_brain_server.storage.graph_store import (
+    GraphStoreManager,
+    _corrupted_sibling,
+    _quarantine_file,
+    reset_graph_store_manager,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    reset_graph_store_manager()
+    yield
+    reset_graph_store_manager()
+
+
+@pytest.fixture
+def persist_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "graph_index"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def kuzu_db_file(persist_dir: Path) -> Path:
+    """Pre-create a 'corrupted' kuzu_db file with junk bytes."""
+    f = persist_dir / "kuzu_db"
+    f.write_bytes(b"\x00\x01\x02junk-not-a-valid-kuzu-catalog")
+    return f
+
+
+@pytest.fixture
+def sample_triplets() -> list[SnapshotTriplet]:
+    return [
+        SnapshotTriplet(
+            subject="FunctionA",
+            predicate="calls",
+            object="FunctionB",
+            subject_type="Function",
+            object_type="Function",
+            source_chunk_id="chunk_1",
+        ),
+        SnapshotTriplet(
+            subject="ClassX",
+            predicate="extends",
+            object="ClassY",
+        ),
+    ]
+
+
+class TestQuarantineHelpers:
+    def test_corrupted_sibling_includes_timestamp(self, tmp_path: Path):
+        sibling = _corrupted_sibling(tmp_path / "kuzu_db")
+        assert sibling.parent == tmp_path
+        assert sibling.name.startswith("kuzu_db.corrupted-")
+
+    def test_quarantine_file_renames(self, tmp_path: Path):
+        src = tmp_path / "kuzu_db"
+        src.write_bytes(b"corrupted")
+        dest = _quarantine_file(src)
+        assert dest is not None
+        assert dest.exists()
+        assert not src.exists()
+        assert dest.read_bytes() == b"corrupted"
+
+    def test_quarantine_missing_file_returns_none(self, tmp_path: Path):
+        assert _quarantine_file(tmp_path / "does-not-exist") is None
+
+
+class TestCorruptionRecovery:
+    """End-to-end tests for the recovery path with a mocked Kuzu."""
+
+    def _make_kuzu_mock(self, fail_first: bool):
+        """Return a mock 'kuzu' module whose Database() raises on first call.
+
+        If ``fail_first`` is True, the first call raises IndexError (like the
+        real bug); subsequent calls return a MagicMock instance representing
+        a healthy Database. If False, every call succeeds.
+        """
+        db_instance = MagicMock(name="kuzu.Database()")
+        calls = {"count": 0}
+
+        def database_factory(path):
+            calls["count"] += 1
+            if fail_first and calls["count"] == 1:
+                raise IndexError("unordered_map::at: key not found")
+            return db_instance
+
+        kuzu_mod = MagicMock()
+        kuzu_mod.Database.side_effect = database_factory
+        return kuzu_mod, calls
+
+    def _make_kuzu_store_class(self):
+        """Return a fake KuzuPropertyGraphStore class for monkeypatching."""
+
+        class FakeKuzuPropertyGraphStore:
+            def __init__(self, db, use_vector_index=False):
+                self.db = db
+                self._upserted_triplets = []
+                self._upserted_nodes = []
+                self._upserted_relations = []
+
+            def upsert_nodes(self, nodes):
+                self._upserted_nodes.extend(nodes)
+
+            def upsert_relations(self, relations):
+                self._upserted_relations.extend(relations)
+
+        return FakeKuzuPropertyGraphStore
+
+    def _install_mocks(self, monkeypatch, kuzu_mod, store_cls):
+        """Patch sys.modules so the import inside _initialize_kuzu_store
+        picks up our fakes instead of the real Kuzu library."""
+        import sys
+        import types
+
+        monkeypatch.setitem(sys.modules, "kuzu", kuzu_mod)
+
+        # The store import is `from llama_index.graph_stores.kuzu import
+        # KuzuPropertyGraphStore` — patch that path.
+        fake_pkg = types.ModuleType("llama_index.graph_stores.kuzu")
+        fake_pkg.KuzuPropertyGraphStore = store_cls
+        monkeypatch.setitem(sys.modules, "llama_index.graph_stores.kuzu", fake_pkg)
+
+    @patch("agent_brain_server.storage.graph_store._graphrag_enabled")
+    def test_clean_open_skips_recovery(
+        self,
+        mock_enabled,
+        monkeypatch,
+        persist_dir: Path,
+    ):
+        mock_enabled.return_value = True
+        kuzu_mod, calls = self._make_kuzu_mock(fail_first=False)
+        store_cls = self._make_kuzu_store_class()
+        self._install_mocks(monkeypatch, kuzu_mod, store_cls)
+
+        mgr = GraphStoreManager(persist_dir, store_type="kuzu")
+        mgr.initialize()
+
+        assert calls["count"] == 1  # opened exactly once
+        assert mgr._recovered_from_corruption is False
+
+    @patch("agent_brain_server.storage.graph_store._graphrag_enabled")
+    def test_corruption_triggers_quarantine_and_retry(
+        self,
+        mock_enabled,
+        monkeypatch,
+        persist_dir: Path,
+        kuzu_db_file: Path,
+    ):
+        mock_enabled.return_value = True
+        kuzu_mod, calls = self._make_kuzu_mock(fail_first=True)
+        store_cls = self._make_kuzu_store_class()
+        self._install_mocks(monkeypatch, kuzu_mod, store_cls)
+
+        mgr = GraphStoreManager(persist_dir, store_type="kuzu")
+        mgr.initialize()
+
+        # Database() called twice: once before quarantine, once after
+        assert calls["count"] == 2
+        # Original kuzu_db file moved aside
+        assert not kuzu_db_file.exists()
+        corrupted = list(persist_dir.glob("kuzu_db.corrupted-*"))
+        assert len(corrupted) == 1
+        assert corrupted[0].read_bytes().startswith(b"\x00\x01\x02")
+        assert mgr._recovered_from_corruption is True
+
+    @patch("agent_brain_server.storage.graph_store._graphrag_enabled")
+    def test_corruption_with_wal_quarantines_both(
+        self,
+        mock_enabled,
+        monkeypatch,
+        persist_dir: Path,
+        kuzu_db_file: Path,
+    ):
+        wal = persist_dir / "kuzu_db.wal"
+        wal.write_bytes(b"wal-data")
+
+        mock_enabled.return_value = True
+        kuzu_mod, _ = self._make_kuzu_mock(fail_first=True)
+        store_cls = self._make_kuzu_store_class()
+        self._install_mocks(monkeypatch, kuzu_mod, store_cls)
+
+        mgr = GraphStoreManager(persist_dir, store_type="kuzu")
+        mgr.initialize()
+
+        assert not wal.exists()
+        wal_corrupted = list(persist_dir.glob("kuzu_db.wal.corrupted-*"))
+        assert len(wal_corrupted) == 1
+
+    @patch("agent_brain_server.storage.graph_store._graphrag_enabled")
+    def test_recovery_replays_snapshot(
+        self,
+        mock_enabled,
+        monkeypatch,
+        persist_dir: Path,
+        kuzu_db_file: Path,
+        sample_triplets,
+    ):
+        # Pre-write a snapshot the recovery path should restore from
+        snap_mgr = GraphSnapshotManager(persist_dir)
+        snap_mgr.write(sample_triplets, source_job_id="job_prior")
+
+        mock_enabled.return_value = True
+        kuzu_mod, _ = self._make_kuzu_mock(fail_first=True)
+        store_cls = self._make_kuzu_store_class()
+        self._install_mocks(monkeypatch, kuzu_mod, store_cls)
+
+        mgr = GraphStoreManager(persist_dir, store_type="kuzu")
+        mgr.initialize()
+
+        store = mgr._graph_store
+        # Two triplets → 4 entity nodes (2 per triplet), 2 relations
+        assert len(store._upserted_nodes) == 4
+        assert len(store._upserted_relations) == 2
+        labels = {r.label for r in store._upserted_relations}
+        assert labels == {"calls", "extends"}
+        assert mgr._relationship_count == 2
+
+    @patch("agent_brain_server.storage.graph_store._graphrag_enabled")
+    def test_recovery_with_no_snapshot_starts_empty(
+        self,
+        mock_enabled,
+        monkeypatch,
+        persist_dir: Path,
+        kuzu_db_file: Path,
+    ):
+        mock_enabled.return_value = True
+        kuzu_mod, _ = self._make_kuzu_mock(fail_first=True)
+        store_cls = self._make_kuzu_store_class()
+        self._install_mocks(monkeypatch, kuzu_mod, store_cls)
+
+        mgr = GraphStoreManager(persist_dir, store_type="kuzu")
+        mgr.initialize()  # should not raise
+
+        assert mgr._graph_store is not None
+        assert mgr._graph_store._upserted_relations == []
+
+    @patch("agent_brain_server.storage.graph_store._graphrag_enabled")
+    def test_double_failure_raises_structured_error(
+        self,
+        mock_enabled,
+        monkeypatch,
+        persist_dir: Path,
+        kuzu_db_file: Path,
+    ):
+        mock_enabled.return_value = True
+
+        # Database() raises every single time — quarantine doesn't help
+        kuzu_mod = MagicMock()
+        kuzu_mod.Database.side_effect = IndexError("unordered_map::at: key not found")
+        store_cls = self._make_kuzu_store_class()
+        self._install_mocks(monkeypatch, kuzu_mod, store_cls)
+
+        mgr = GraphStoreManager(persist_dir, store_type="kuzu")
+        with pytest.raises(RuntimeError, match="Failed to initialize Kuzu"):
+            mgr.initialize()
+
+
+class TestPreflightCheck:
+    @patch("agent_brain_server.storage.graph_store._graphrag_enabled")
+    def test_preflight_no_op_when_graphrag_disabled(
+        self, mock_enabled, persist_dir: Path
+    ):
+        mock_enabled.return_value = False
+        mgr = GraphStoreManager(persist_dir, store_type="kuzu")
+        assert mgr.preflight_check() is False
+        assert not mgr.is_initialized
+
+    @patch("agent_brain_server.storage.graph_store._graphrag_enabled")
+    def test_preflight_no_op_when_not_kuzu(self, mock_enabled, persist_dir: Path):
+        mock_enabled.return_value = True
+        mgr = GraphStoreManager(persist_dir, store_type="simple")
+        assert mgr.preflight_check() is False
+
+    @patch("agent_brain_server.storage.graph_store._graphrag_enabled")
+    def test_preflight_initializes_when_kuzu(
+        self,
+        mock_enabled,
+        monkeypatch,
+        persist_dir: Path,
+    ):
+        mock_enabled.return_value = True
+
+        recovery_test = TestCorruptionRecovery()
+        kuzu_mod, calls = recovery_test._make_kuzu_mock(fail_first=False)
+        store_cls = recovery_test._make_kuzu_store_class()
+        recovery_test._install_mocks(monkeypatch, kuzu_mod, store_cls)
+
+        mgr = GraphStoreManager(persist_dir, store_type="kuzu")
+        assert mgr.preflight_check() is True
+        assert mgr.is_initialized
+        # Calling again should be a no-op
+        calls_after_first = calls["count"]
+        assert mgr.preflight_check() is True
+        assert calls["count"] == calls_after_first

--- a/agent-brain-server/tests/unit/storage/test_graph_store_recovery.py
+++ b/agent-brain-server/tests/unit/storage/test_graph_store_recovery.py
@@ -279,6 +279,54 @@ class TestCorruptionRecovery:
         with pytest.raises(RuntimeError, match="Failed to initialize Kuzu"):
             mgr.initialize()
 
+    @patch("agent_brain_server.storage.graph_store._graphrag_enabled")
+    def test_corruption_in_wrapper_init_is_also_recovered(
+        self,
+        mock_enabled,
+        monkeypatch,
+        persist_dir: Path,
+        kuzu_db_file: Path,
+    ):
+        """Real Kuzu corruption can surface during ``KuzuPropertyGraphStore``
+        construction (which opens a Connection and runs ``init_schema()``),
+        not just during ``kuzu.Database()``. The recovery wrapper must
+        cover both."""
+        mock_enabled.return_value = True
+
+        kuzu_mod = MagicMock()
+        kuzu_mod.Database.return_value = MagicMock(name="kuzu.Database()")
+
+        wrapper_calls = {"count": 0}
+
+        class FlakyKuzuStore:
+            def __init__(self, db, use_vector_index=False):
+                wrapper_calls["count"] += 1
+                if wrapper_calls["count"] == 1:
+                    raise RuntimeError(
+                        "kuzu.Connection: catalog corruption (synthetic)"
+                    )
+                self.db = db
+                self._upserted_nodes = []
+                self._upserted_relations = []
+
+            def upsert_nodes(self, nodes):
+                self._upserted_nodes.extend(nodes)
+
+            def upsert_relations(self, relations):
+                self._upserted_relations.extend(relations)
+
+        self._install_mocks(monkeypatch, kuzu_mod, FlakyKuzuStore)
+
+        mgr = GraphStoreManager(persist_dir, store_type="kuzu")
+        mgr.initialize()
+
+        # Wrapper construction attempted twice: first failed, second
+        # succeeded after the recovery path quarantined the bad file.
+        assert wrapper_calls["count"] == 2
+        assert mgr._recovered_from_corruption is True
+        assert not kuzu_db_file.exists()
+        assert list(persist_dir.glob("kuzu_db.corrupted-*"))
+
 
 class TestPreflightCheck:
     @patch("agent_brain_server.storage.graph_store._graphrag_enabled")

--- a/agent-brain-server/tests/unit/test_graph_index_snapshot.py
+++ b/agent-brain-server/tests/unit/test_graph_index_snapshot.py
@@ -1,0 +1,263 @@
+"""Tests for periodic triplet snapshots during graph indexing (Issue #166).
+
+These tests focus on the cadence hook inside ``build_from_documents``: a
+snapshot must be written every ``GRAPH_SNAPSHOT_CHUNKS`` chunks OR every
+``GRAPH_SNAPSHOT_INTERVAL_SEC`` seconds (whichever first), so a kill
+mid-langextract doesn't lose extraction work.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_brain_server.indexing.graph_index import GraphIndexManager
+from agent_brain_server.models.graph import GraphTriple
+from agent_brain_server.storage.graph_snapshot import GraphSnapshotManager
+
+
+@pytest.fixture
+def real_persist_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "graph_index"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def mock_graph_store_with_real_dir(real_persist_dir: Path):
+    """A graph store mock whose persist_dir is a real tmp path so the
+    snapshot manager can actually write to disk."""
+    mock = MagicMock()
+    mock.is_initialized = True
+    mock.entity_count = 0
+    mock.relationship_count = 0
+    mock.store_type = "kuzu"
+    mock.persist_dir = real_persist_dir
+    mock.add_triplet.return_value = True
+    mock.graph_store = MagicMock()
+    return mock
+
+
+@pytest.fixture
+def mock_llm_extractor():
+    mock = MagicMock()
+    mock.extract_triplets.return_value = []
+    return mock
+
+
+@pytest.fixture
+def mock_code_extractor():
+    mock = MagicMock()
+    mock.extract_from_metadata.return_value = []
+    mock.extract_from_text.return_value = []
+    return mock
+
+
+@pytest.fixture
+def mock_langextract_extractor():
+    mock = MagicMock()
+    mock.extract_triplets.return_value = []
+    return mock
+
+
+@dataclass
+class _FakeChunk:
+    text: str
+    chunk_id: str
+
+    @dataclass
+    class _Metadata:
+        source_type: str = "code"
+        language: str = "python"
+
+        def to_dict(self):
+            return {"source_type": self.source_type, "language": self.language}
+
+    metadata: object = None
+
+    def __post_init__(self):
+        self.metadata = self._Metadata()
+
+
+def _build_manager(graph_store, llm, code, langextract) -> GraphIndexManager:
+    return GraphIndexManager(
+        graph_store=graph_store,
+        llm_extractor=llm,
+        code_extractor=code,
+        langextract_extractor=langextract,
+    )
+
+
+def _make_triplet(i: int) -> GraphTriple:
+    return GraphTriple(
+        subject=f"sub_{i}",
+        predicate="rel",
+        object=f"obj_{i}",
+        source_chunk_id=f"chunk_{i}",
+    )
+
+
+@patch("agent_brain_server.indexing.graph_index._graphrag_enabled")
+@patch("agent_brain_server.indexing.graph_index.settings")
+def test_snapshot_written_at_chunk_threshold(
+    mock_settings,
+    mock_enabled,
+    mock_graph_store_with_real_dir,
+    mock_llm_extractor,
+    mock_code_extractor,
+    mock_langextract_extractor,
+    real_persist_dir,
+):
+    mock_enabled.return_value = True
+    mock_settings.GRAPH_USE_CODE_METADATA = True
+    mock_settings.GRAPH_USE_LLM_EXTRACTION = False
+    mock_settings.GRAPH_SNAPSHOT_CHUNKS = 5
+    mock_settings.GRAPH_SNAPSHOT_INTERVAL_SEC = 999  # effectively disabled
+    mock_settings.GRAPH_SNAPSHOT_KEEP = 3
+
+    # Each chunk produces 1 triplet
+    mock_code_extractor.extract_from_metadata.side_effect = [
+        [_make_triplet(i)] for i in range(12)
+    ]
+
+    docs = [_FakeChunk(text="x", chunk_id=f"c{i}") for i in range(12)]
+    manager = _build_manager(
+        mock_graph_store_with_real_dir,
+        mock_llm_extractor,
+        mock_code_extractor,
+        mock_langextract_extractor,
+    )
+    manager.build_from_documents(docs, source_job_id="job_test")
+
+    snap_mgr = GraphSnapshotManager(real_persist_dir)
+    snaps = snap_mgr.list_snapshots()
+    # 12 chunks @ threshold=5 → snapshots at 5 and 10, plus a final tail
+    # snapshot for the last 2 chunks. With rotation keeping 3, we still see 3.
+    assert len(snaps) == 3
+
+    latest_triplets = snap_mgr.load(snaps[0])
+    assert len(latest_triplets) == 12  # final snapshot has all
+    assert latest_triplets[0].subject == "sub_0"
+    assert latest_triplets[-1].subject == "sub_11"
+
+
+@patch("agent_brain_server.indexing.graph_index._graphrag_enabled")
+@patch("agent_brain_server.indexing.graph_index.settings")
+def test_final_snapshot_when_below_threshold(
+    mock_settings,
+    mock_enabled,
+    mock_graph_store_with_real_dir,
+    mock_llm_extractor,
+    mock_code_extractor,
+    mock_langextract_extractor,
+    real_persist_dir,
+):
+    """A run that ends before crossing any threshold still gets a tail
+    snapshot — otherwise the trailing triplets would be lost on a kill
+    right after the build completes."""
+    mock_enabled.return_value = True
+    mock_settings.GRAPH_USE_CODE_METADATA = True
+    mock_settings.GRAPH_USE_LLM_EXTRACTION = False
+    mock_settings.GRAPH_SNAPSHOT_CHUNKS = 100
+    mock_settings.GRAPH_SNAPSHOT_INTERVAL_SEC = 999
+    mock_settings.GRAPH_SNAPSHOT_KEEP = 3
+
+    mock_code_extractor.extract_from_metadata.side_effect = [
+        [_make_triplet(i)] for i in range(3)
+    ]
+
+    docs = [_FakeChunk(text="x", chunk_id=f"c{i}") for i in range(3)]
+    manager = _build_manager(
+        mock_graph_store_with_real_dir,
+        mock_llm_extractor,
+        mock_code_extractor,
+        mock_langextract_extractor,
+    )
+    manager.build_from_documents(docs, source_job_id="job_short")
+
+    snaps = GraphSnapshotManager(real_persist_dir).list_snapshots()
+    assert len(snaps) == 1
+    triplets = GraphSnapshotManager(real_persist_dir).load(snaps[0])
+    assert len(triplets) == 3
+
+
+@patch("agent_brain_server.indexing.graph_index._graphrag_enabled")
+@patch("agent_brain_server.indexing.graph_index.settings")
+def test_no_snapshot_when_no_triplets_extracted(
+    mock_settings,
+    mock_enabled,
+    mock_graph_store_with_real_dir,
+    mock_llm_extractor,
+    mock_code_extractor,
+    mock_langextract_extractor,
+    real_persist_dir,
+):
+    """A build that yields zero triplets should not produce a snapshot."""
+    mock_enabled.return_value = True
+    mock_settings.GRAPH_USE_CODE_METADATA = True
+    mock_settings.GRAPH_USE_LLM_EXTRACTION = False
+    mock_settings.GRAPH_SNAPSHOT_CHUNKS = 5
+    mock_settings.GRAPH_SNAPSHOT_INTERVAL_SEC = 999
+    mock_settings.GRAPH_SNAPSHOT_KEEP = 3
+
+    mock_code_extractor.extract_from_metadata.return_value = []
+
+    docs = [_FakeChunk(text="x", chunk_id=f"c{i}") for i in range(3)]
+    manager = _build_manager(
+        mock_graph_store_with_real_dir,
+        mock_llm_extractor,
+        mock_code_extractor,
+        mock_langextract_extractor,
+    )
+    manager.build_from_documents(docs)
+
+    snaps = GraphSnapshotManager(real_persist_dir).list_snapshots()
+    assert snaps == []
+
+
+@patch("agent_brain_server.indexing.graph_index._graphrag_enabled")
+@patch("agent_brain_server.indexing.graph_index.settings")
+def test_snapshot_write_failure_doesnt_break_indexing(
+    mock_settings,
+    mock_enabled,
+    mock_graph_store_with_real_dir,
+    mock_llm_extractor,
+    mock_code_extractor,
+    mock_langextract_extractor,
+    real_persist_dir,
+):
+    """If the snapshot can't be written (e.g. disk full), indexing must
+    still complete successfully — the snapshot is a safety net, not a
+    critical path."""
+    mock_enabled.return_value = True
+    mock_settings.GRAPH_USE_CODE_METADATA = True
+    mock_settings.GRAPH_USE_LLM_EXTRACTION = False
+    mock_settings.GRAPH_SNAPSHOT_CHUNKS = 1
+    mock_settings.GRAPH_SNAPSHOT_INTERVAL_SEC = 999
+    mock_settings.GRAPH_SNAPSHOT_KEEP = 3
+
+    mock_code_extractor.extract_from_metadata.side_effect = [
+        [_make_triplet(i)] for i in range(3)
+    ]
+    docs = [_FakeChunk(text="x", chunk_id=f"c{i}") for i in range(3)]
+
+    manager = _build_manager(
+        mock_graph_store_with_real_dir,
+        mock_llm_extractor,
+        mock_code_extractor,
+        mock_langextract_extractor,
+    )
+
+    with patch(
+        "agent_brain_server.indexing.graph_index.GraphSnapshotManager.write",
+        side_effect=OSError("disk full"),
+    ):
+        result = manager.build_from_documents(docs)
+
+    # Indexing still succeeded — all 3 triplets added even though snapshots
+    # all failed to write
+    assert result == 3
+    assert mock_graph_store_with_real_dir.add_triplet.call_count == 3

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-last_validated: 2026-05-25
+last_validated: 2026-05-26
 ---
 
 # Changelog
@@ -8,6 +8,23 @@ All notable changes to Agent Brain will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [10.0.6] - 2026-05-26
+
+### Fixed
+
+- **Kuzu graph store now self-heals from kill-mid-write corruption.** When the server was killed (SIGKILL or even SIGTERM) during the `langextract` triplet phase, the on-disk Kuzu catalog at `.agent-brain/data/graph_index/kuzu_db` could enter a state where `kuzu.Database(path)` raises `IndexError: unordered_map::at: key not found` from the pybind11 C++ constructor — every subsequent `agent-brain index` job then failed instantly inside `_initialize_kuzu_store` with no actionable recovery hint. Manual `rm kuzu_db` worked but destroyed all previously-extracted triplets (real `gpt-4o-mini` API spend). `_initialize_kuzu_store` in `agent_brain_server/storage/graph_store.py` now wraps `kuzu.Database()` in defensive `try/except (IndexError, RuntimeError)`. On catch it logs a loud actionable WARN, quarantines `kuzu_db` (and `kuzu_db.wal`) to `.corrupted-<ts>` sibling files (never deletes — forensic preservation), then retries on the now-empty path. A second failure raises a structured `RuntimeError` with explicit reset instructions. The lifespan in `agent_brain_server/api/main.py` calls a new `preflight_check()` at startup so corruption is detected once at boot rather than on the first user-facing indexing job. Same shape as the existing `#151` stale-directory self-heal pattern. Cross-reference: upstream [kuzudb/kuzu#6020](https://github.com/kuzudb/kuzu/issues/6020) tracks the catalog-load fragility on a different code path. Closes #166.
+
+### Added
+
+- **Triplet snapshots during langextract** (`agent_brain_server/storage/graph_snapshot.py` + hook in `agent_brain_server/indexing/graph_index.py`). `build_from_documents` now writes JSON triplet snapshots to `<graph_index>/snapshots/snapshot-<ISO8601>.json` on a hybrid cadence — whenever either `GRAPH_SNAPSHOT_CHUNKS` chunks (default 25) OR `GRAPH_SNAPSHOT_INTERVAL_SEC` seconds (default 60) have elapsed — plus a final tail snapshot at end-of-build. Rotation keeps the `GRAPH_SNAPSHOT_KEEP` most recent (default 3). Writes are atomic (`tmp + os.fsync + os.replace`). When the corruption-recovery path detects a quarantined Kuzu DB, it walks newest-to-oldest snapshots (skipping any that themselves got corrupted) and replays the triplets into the fresh database — silently restoring previously-extracted work with a single WARN log line. Snapshot write failure is non-fatal (a disk-full `OSError` logs WARN and indexing continues; the snapshot is a safety net, not a critical path). New env-var settings: `GRAPH_SNAPSHOT_CHUNKS`, `GRAPH_SNAPSHOT_INTERVAL_SEC`, `GRAPH_SNAPSHOT_KEEP`.
+- **`agent-brain doctor` now checks Kuzu DB health** (`agent_brain_cli/agent_brain_cli/diagnostics.py`). When GraphRAG is enabled with `store_type: kuzu`, the new `graph_store_health` check briefly opens `kuzu_db` in-process and reports OK / FAIL with an actionable fix hint. `agent-brain doctor --fix` extends to recover a corrupted Kuzu DB offline: refuses to run while a `server.lock` exists (avoids racing the live server), quarantines `kuzu_db` + `kuzu_db.wal` to `.corrupted-<ts>` siblings, and replays the newest valid triplet snapshot into a fresh DB. The CLI peeks at `config.yaml` directly for the `graphrag` block since `AgentBrainConfig` doesn't model graphrag (server concern). Closes the remaining graph DB durability gap from `#146`.
+
+### Internal
+
+- Server-side snapshot manager (`GraphSnapshotManager`) is deliberately backend-agnostic — operates on plain `SnapshotTriplet` dataclasses, never imports Kuzu directly. Same module could later snapshot SimplePropertyGraphStore. Loads sort snapshots by mtime (with filename tie-break) rather than filename alone — collision-suffixed names like `snapshot-T-001.json` sort *before* `snapshot-T.json` lexically, the wrong direction for "newest first". Test coverage: 36 new unit tests across `tests/unit/storage/test_graph_snapshot.py` (write/list/load/rotate lifecycle, corruption handling), `tests/unit/storage/test_graph_store_recovery.py` (defensive recovery state machine with a mocked Kuzu), and `tests/unit/test_graph_index_snapshot.py` (hybrid-cadence hook). Five new doctor tests in `agent-brain-cli/tests/test_resolver_and_doctor.py`.
 
 ---
 

--- a/docs/GRAPHRAG_GUIDE.md
+++ b/docs/GRAPHRAG_GUIDE.md
@@ -477,6 +477,46 @@ agent-brain reset --yes
 agent-brain index /path/to/project
 ```
 
+#### Kuzu DB recovers automatically from kill-mid-write (v10.0.6+)
+
+When the server is killed during indexing — especially during the
+`langextract` triplet-extraction phase — the on-disk Kuzu catalog can
+corrupt. As of **v10.0.6** agent-brain self-heals:
+
+1. On the next server start (or first indexing job), `kuzu.Database()`
+   raises `IndexError: unordered_map::at: key not found`.
+2. The server quarantines `kuzu_db` and `kuzu_db.wal` to
+   `.corrupted-<timestamp>` sibling files (never deleted — preserved for
+   post-mortem).
+3. A fresh `kuzu_db` is opened.
+4. The most recent valid **triplet snapshot** (see below) is replayed
+   into the fresh database so previously-extracted triplets aren't lost.
+
+You'll see a single WARN log line like:
+
+```
+Kuzu DB at .../kuzu_db appears corrupted ... Renaming to .corrupted-<ts>
+Restored 1247 triplets from snapshot snapshot-2026-05-26T21-05-32Z.json
+```
+
+If automatic recovery doesn't kick in, run `agent-brain doctor --fix`
+(server must be stopped) to perform the same recovery offline.
+
+#### Triplet snapshots
+
+To survive process kills, the indexer writes periodic JSON snapshots of
+extracted triplets to `.agent-brain/data/graph_index/snapshots/`. The
+hybrid cadence (whichever comes first) keeps disk and CPU overhead small:
+
+| Setting | Default | What it does |
+|---|---|---|
+| `GRAPH_SNAPSHOT_CHUNKS` | 25 | Snapshot every N processed chunks |
+| `GRAPH_SNAPSHOT_INTERVAL_SEC` | 60 | ...or after this many seconds |
+| `GRAPH_SNAPSHOT_KEEP` | 3 | Number of snapshots to retain |
+
+A `kill -9` mid-build loses at most ~60 seconds (or 25 chunks) of
+triplet work — not the entire run.
+
 ---
 
 ## Next Steps

--- a/docs/plans/issue-166-kuzu-resilience.md
+++ b/docs/plans/issue-166-kuzu-resilience.md
@@ -1,0 +1,218 @@
+# Plan: Kuzu Graph Store Durability & Self-Heal (Issue #166)
+
+## Context
+
+**Problem:** When the agent-brain server is killed mid-indexing — especially during the `langextract` triplet-extraction phase that writes to the Kuzu graph DB — the on-disk Kuzu catalog at `.agent-brain/data/graph_index/kuzu_db` becomes corrupted. Every subsequent `agent-brain index` job fails immediately inside `_initialize_kuzu_store` with `IndexError: unordered_map::at: key not found` from the pybind11 C++ extension. Only manual recovery (delete `kuzu_db`, restart) works — destroying all previously-extracted triplets, which represent real API spend (`gpt-4o-mini` calls cost real money).
+
+**Why now:** v10.0.4/v10.0.5 closed several Kuzu API-shape bugs (#144, #149, #150, #151) but left the durability gap. The upstream Kuzu issue ([kuzudb#6020](https://github.com/kuzudb/kuzu/issues/6020)) has been open 8+ months with no fix — we can't wait for them.
+
+**Intended outcome:** Agent-brain detects corrupted Kuzu state, self-heals without user intervention, and preserves as many previously-extracted triplets as possible via periodic JSON snapshots. A `kill -9` mid-build becomes a "lose ~60s of work" event instead of a "lose everything" event.
+
+## Scope (User-Confirmed)
+
+1. **Defensive recovery in `_initialize_kuzu_store`** — try/except, rename to `.corrupted-{ts}`, retry on fresh path
+2. **Pre-emptive integrity check on server startup** — pay corruption tax once at boot, not on first user job
+3. **`agent-brain doctor` check + `--fix`** — graph DB opens cleanly; auto-rename + restore if it doesn't
+4. **Periodic JSON snapshots during langextract** — hybrid cadence (every N=25 chunks OR T=60s), kept under `.agent-brain/data/graph_index/snapshots/`, last K=3 retained
+5. **Auto-restore from latest snapshot** after corruption recovery (silent + single WARN log line)
+6. **CHANGELOG / runbook docs** — explain new behavior and the (now much narrower) sharp edge
+
+**Out of scope** (explicitly deferred): job resume/checkpoint across pipeline phases, ChromaDB/BM25 corruption recovery (those backends don't have this failure mode at present), graceful-shutdown plumbing for `_build_graph` cancellation (separate work — see "Follow-ups").
+
+## Architecture
+
+### Module boundaries
+
+| Concern | Location | New code? |
+|---|---|---|
+| Defensive Kuzu open + rename-on-fail | `agent-brain-server/agent_brain_server/storage/graph_store.py` | Modify `_initialize_kuzu_store()` |
+| Startup integrity check | `agent-brain-server/agent_brain_server/api/main.py` lifespan | New helper call |
+| Snapshot writer/reader/rotator | `agent-brain-server/agent_brain_server/storage/graph_snapshot.py` | **New file** |
+| Snapshot hook during langextract | `agent-brain-server/agent_brain_server/indexing/graph_index.py` `build_from_documents()` | Add callback inside batch loop |
+| Doctor check + `--fix` for graph DB | `agent-brain-cli/agent_brain_cli/diagnostics.py` + `commands/doctor.py` | New check function |
+| Tests | `agent-brain-server/tests/storage/test_graph_store_recovery.py` and `test_graph_snapshot.py` | **New files** |
+
+### Reusable existing patterns
+
+- **Self-heal template:** `graph_store.py:230-245` (stale-dir cleanup for #151) — same shape: detect, log loud + actionable, rename (don't delete), retry. Extend with corruption-detection branch.
+- **Doctor `--fix` framework:** `agent-brain-cli/agent_brain_cli/commands/doctor.py` already has the safe-idempotent-offline-remediation pattern from v10.0.5. New check plugs into it.
+- **Structured user-facing errors:** `RuntimeError` pattern at `graph_store.py:239-245` (names the path, suggests env var) — reuse for snapshot/restore failure modes.
+- **Retry with backoff:** `agent-brain-server/agent_brain_server/storage/postgres/connection.py:84-143` — not directly applicable here (Kuzu open is one-shot), but the structured `StorageError` raising style is.
+
+### Snapshot format
+
+JSON file `snapshot-{ISO8601}.json`:
+
+```json
+{
+  "schema_version": 1,
+  "created_at": "2026-05-26T21:05:32Z",
+  "kuzu_version": "0.11.3",
+  "triplet_count": 1247,
+  "source_job_id": "job_170be31f233e",
+  "triplets": [
+    {"subject": "...", "predicate": "...", "object": "...", "metadata": {...}},
+    ...
+  ]
+}
+```
+
+Rotation: keep last 3 by `created_at`, delete older. Atomic write via `tmp + os.replace`.
+
+### Snapshot cadence (hybrid)
+
+Inside `graph_index.build_from_documents()`, between langextract batches:
+- Maintain `chunks_since_snapshot` counter and `last_snapshot_ts`
+- After each batch: if `chunks_since_snapshot >= 25` OR `now - last_snapshot_ts >= 60s`, take a snapshot of current Kuzu triplets to JSON
+- If either threshold is configurable via env (`GRAPH_SNAPSHOT_CHUNKS`, `GRAPH_SNAPSHOT_INTERVAL_SEC`), expose them in `config/settings.py` with sensible defaults
+
+### Recovery flow
+
+```
+Server startup or _initialize_kuzu_store called
+  ↓
+try kuzu.Database(path)
+  ↓ raises IndexError / RuntimeError from C++
+catch → log WARN with actionable text + path
+  ↓
+rename kuzu_db → kuzu_db.corrupted-{ts}
+rename kuzu_db.wal → kuzu_db.wal.corrupted-{ts} (if exists)
+  ↓
+retry kuzu.Database(path)  # now fresh
+  ↓
+look for latest snapshot in snapshots/
+  ↓ found?
+load triplets, replay into fresh Kuzu DB
+log WARN: "Restored N triplets from snapshot {ts} after recovering corrupted kuzu_db"
+  ↓ not found?
+log INFO: "No snapshot available; starting with empty graph"
+  ↓
+continue normally
+```
+
+If the retry of `kuzu.Database(path)` *also* fails: raise a clear `RuntimeError` with the corrupted-path name and explicit "delete graph_index/ to fully reset" instruction. Don't loop.
+
+## Implementation Steps
+
+> Each step lands as its own commit. Run `task before-push` between commits. The branch must be created before any work begins (see project memory: never work on main).
+
+### Step 0 — Branch setup
+- `git checkout -b fix/issue-166-kuzu-resilience`
+
+### Step 1 — Snapshot module
+- Create `agent-brain-server/agent_brain_server/storage/graph_snapshot.py` with:
+  - `class GraphSnapshotManager` — `__init__(persist_dir)`, `write(triplets, source_job_id)`, `latest()`, `load(path)`, `rotate(keep=3)`
+  - `write` uses tmp-file + `os.replace` for atomicity
+  - Schema constants and JSON encode/decode helpers
+- Unit tests `tests/storage/test_graph_snapshot.py`: write, read-back, rotation (keep=3 of 5), corrupt file ignored gracefully
+
+### Step 2 — Defensive recovery in graph_store
+- Modify `_initialize_kuzu_store()` in `agent_brain_server/storage/graph_store.py`:
+  - Wrap line 247 `kuzu.Database(...)` in `try / except (IndexError, RuntimeError) as exc`
+  - On catch: log WARN with the exact text from the issue, rename `kuzu_db` and `kuzu_db.wal` files (use `Path.rename` to a sibling `.corrupted-{ts}` path; if rename fails, fall back to `shutil.move`)
+  - Retry `kuzu.Database(...)`; if THAT raises, re-raise as `RuntimeError` with explicit reset instructions
+  - After successful (re-)open, call new `_restore_from_snapshot_if_available()` helper that uses `GraphSnapshotManager` and replays triplets via the new `KuzuPropertyGraphStore` interface
+- Tests `tests/storage/test_graph_store_recovery.py`: simulate corrupted DB (write junk bytes to `kuzu_db`), verify rename + fresh open succeeds, verify triplets restored when snapshot present
+
+### Step 3 — Snapshot hook during langextract
+- Modify `agent-brain-server/agent_brain_server/indexing/graph_index.py` `build_from_documents()`:
+  - Instantiate `GraphSnapshotManager(persist_dir)` once
+  - Wrap the existing batch loop with `chunks_since_snapshot` counter and `last_snapshot_ts` timestamp
+  - After each batch completion: check thresholds, call `snapshot_mgr.write(...)` + `rotate()` if either crossed
+  - Read thresholds from `settings.GRAPH_SNAPSHOT_CHUNKS` (default 25) and `settings.GRAPH_SNAPSHOT_INTERVAL_SEC` (default 60)
+- Add the two settings to `agent_brain_server/config/settings.py` with `Field(...)` defaults and env-var binding
+- Tests: mock langextract, run `build_from_documents` with 60 chunks, assert ≥2 snapshots written
+
+### Step 4 — Pre-emptive startup check
+- In `agent-brain-server/agent_brain_server/api/main.py` lifespan (after lock acquired, before serving):
+  - If GraphRAG enabled and `store_type == "kuzu"`: call new `graph_store_manager.preflight_check()` which attempts a read-only open + trivial query, triggering the same corruption-detection-and-recover path as step 2 — but proactively
+- Log a clear startup line either way: `"Kuzu graph store preflight: OK"` or `"Kuzu graph store preflight: recovered from corruption (N triplets restored)"`
+
+### Step 5 — Doctor check + `--fix`
+- Add to `agent-brain-cli/agent_brain_cli/diagnostics.py` a new check function `check_graph_store_health()`:
+  - When GraphRAG enabled, attempt to open `kuzu_db` via the same defensive helper; report OK/WARN/FAIL with `fix:` field
+  - `--fix` mode: invoke the rename-and-restore path
+- Plug into the existing doctor check registry in `commands/doctor.py`
+- Tests: doctor on a fresh project (OK), doctor on a corrupted project (FAIL with fix hint), doctor --fix on corrupted project (FIXED)
+
+### Step 6 — CHANGELOG + runbook
+- Add v10.0.6 (or v10.1.0 — defer naming to release skill) CHANGELOG entry under `CHANGELOG.md` describing the fix, the snapshot behavior, the new doctor check, the two new env vars
+- Add a short "Graph DB resilience" subsection under `docs/USER_GUIDE.md` (or `docs/DEVELOPERS_GUIDE.md` — whichever has the closest existing content) explaining: snapshots exist, where they live, what `--fix` does
+
+### Step 7 — End-to-end validation
+- Run `./scripts/quick_start_guide.sh` to validate full workflow
+- Manual repro of issue #166:
+  1. Fresh `.agent-brain/`, enable GraphRAG
+  2. `agent-brain index <large_folder> --generate-summaries --include-code`
+  3. Mid-langextract: `pkill -9 -f agent-brain-serve`
+  4. Restart server, re-run `agent-brain index <same_folder>`
+  5. Verify: job succeeds, WARN log mentions corruption + snapshot restore, `agent-brain status` shows triplet count near pre-kill value
+- Verify `agent-brain doctor` reports OK on the recovered project
+
+### Step 8 — Mandatory validation before push
+- `task before-push` — must exit 0 (format, lint, typecheck, tests)
+- `task pr-qa-gate` — must exit 0 (full PR gate)
+- Only then `git push -u origin fix/issue-166-kuzu-resilience`
+- Open PR referencing issue #166; include manual repro evidence in PR body
+
+## Files Modified / Created
+
+| Path | Change |
+|---|---|
+| `agent-brain-server/agent_brain_server/storage/graph_store.py` | Modify `_initialize_kuzu_store()`; add `preflight_check()` and `_restore_from_snapshot_if_available()` |
+| `agent-brain-server/agent_brain_server/storage/graph_snapshot.py` | **NEW** — snapshot writer/reader/rotator |
+| `agent-brain-server/agent_brain_server/indexing/graph_index.py` | Add snapshot cadence hook in batch loop |
+| `agent-brain-server/agent_brain_server/api/main.py` | Add preflight call in lifespan |
+| `agent-brain-server/agent_brain_server/config/settings.py` | Add `GRAPH_SNAPSHOT_CHUNKS`, `GRAPH_SNAPSHOT_INTERVAL_SEC` |
+| `agent-brain-server/tests/storage/test_graph_snapshot.py` | **NEW** — unit tests |
+| `agent-brain-server/tests/storage/test_graph_store_recovery.py` | **NEW** — corruption recovery tests |
+| `agent-brain-cli/agent_brain_cli/diagnostics.py` | Add `check_graph_store_health()` |
+| `agent-brain-cli/agent_brain_cli/commands/doctor.py` | Register new check |
+| `agent-brain-cli/tests/test_doctor.py` (or existing) | Add cases for graph health + --fix |
+| `CHANGELOG.md` | Add v10.0.6 entry |
+| `docs/USER_GUIDE.md` (or DEVELOPERS_GUIDE) | Add "Graph DB resilience" section |
+
+## Verification
+
+### Automated
+- Unit tests for snapshot module (rotation, atomic write, corrupt-file handling)
+- Unit tests for graph_store corruption recovery (synthesize a corrupted file, assert rename + retry succeeds, assert snapshot restore replays triplets)
+- Doctor command tests (OK / FAIL / FIXED paths)
+- `task before-push` exits 0 with coverage ≥50%
+- `task pr-qa-gate` exits 0
+
+### Manual (must-do before merge)
+- Run the issue #166 repro on a real machine, confirm self-heal kicks in
+- Verify snapshots dir is populated during a long index job and rotation keeps only K=3
+- Verify `agent-brain doctor --fix` recovers a deliberately-corrupted Kuzu DB
+- Verify the new WARN log line is clear and actionable
+
+### Edge cases to test
+- Corrupted DB + no snapshot present → fresh start, no crash, clear INFO log
+- Corrupted DB + corrupted snapshot file → rename snapshot, try the next-older, else fresh start
+- Snapshot write fails mid-indexing (disk full) → log WARN, continue indexing (don't fail the job)
+- Rename of corrupted file fails (file locked) → raise clear RuntimeError with manual-recovery instructions
+- Two snapshots with same timestamp (clock collision) → tie-break on filename or use monotonic counter suffix
+
+## Follow-ups (Separate Issues, NOT This PR)
+
+These came up during exploration but are explicitly out of scope:
+
+1. **Graceful drain for `_build_graph`** — currently `asyncio.to_thread(_build_graph)` ignores cancellation tokens. SIGTERM during graph build is still uncatchable mid-batch. File as new issue; needs API design for thread-cancellable extraction.
+2. **`task agent-brain:stop` integration** — `agent-brain-server/Taskfile.yml` has no `stop` task. Add one that SIGTERM-then-wait-then-SIGKILL with sensible timeout.
+3. **Apply same defensive pattern to ChromaDB/BM25** — both could in principle corrupt under the same conditions; not observed today but worth proactive coverage.
+4. **Track upstream [kuzudb/kuzu#6020](https://github.com/kuzudb/kuzu/issues/6020)** — if/when fixed, our defensive code becomes belt-and-suspenders, not load-bearing.
+
+## Risks
+
+- **Snapshot I/O overhead** — JSON-encoding 1000s of triplets every 25 chunks could slow indexing. Mitigation: thresholds are env-configurable; default cadence sized for low overhead; measure during validation and tune if needed.
+- **Restored triplets may not match exactly** — replaying triplets into a fresh Kuzu DB may produce slightly different internal IDs. Should not affect query results, but worth verifying with a query-equivalence test.
+- **Disk usage from snapshots** — bounded by K=3 rotation. For a 100K-triplet corpus, ~10-30MB each. Acceptable.
+- **Concurrent doctor --fix during active indexing** — could race the snapshot writer. Mitigation: doctor --fix should detect running server (via lockfile) and refuse, with clear message.
+
+## Memory / Project Rules Reminders
+
+- Create feature branch first; never work on main
+- `task before-push` exits 0 BEFORE every `git push` — no exceptions
+- Conventional commits (`fix:`, `feat:`, `test:`, `docs:`)
+- After plan approval, also save a copy of this plan to `docs/plans/issue-166-kuzu-resilience.md` (per project CLAUDE.md planning rule)


### PR DESCRIPTION
## Summary

Closes #166. Makes Kuzu graph store kill-resilient: when the server is killed mid-`langextract`, the on-disk Kuzu catalog can corrupt and every subsequent `agent-brain index` job fails inside `_initialize_kuzu_store` with `IndexError: unordered_map::at: key not found`. This PR adds defensive recovery + periodic JSON triplet snapshots so a `kill -9` becomes a "lose ~60s of work" event instead of a "lose everything" event.

### What changed
- **`_initialize_kuzu_store`** wraps `kuzu.Database()` in `try/except (IndexError, RuntimeError)`. On catch: logs a loud actionable WARN, quarantines `kuzu_db` + `kuzu_db.wal` to `.corrupted-<ts>` siblings (never deletes), retries on the fresh path, raises a structured `RuntimeError` with reset instructions if the retry also fails.
- **New `GraphSnapshotManager`** (`storage/graph_snapshot.py`) writes versioned JSON snapshots of triplets to `<graph_index>/snapshots/`. Atomic writes (`tmp + os.fsync + os.replace`), clock-collision tie-break, gracefully walks past corrupted snapshots.
- **Hybrid-cadence snapshot hook** in `graph_index.build_from_documents()` — snapshots every `GRAPH_SNAPSHOT_CHUNKS` chunks (default 25) OR `GRAPH_SNAPSHOT_INTERVAL_SEC` seconds (default 60), plus a tail snapshot at end-of-build. Rotation keeps `GRAPH_SNAPSHOT_KEEP` (default 3).
- **Auto-restore** after corruption recovery — the newest valid snapshot replays into the fresh DB, a single WARN log line tells the user what happened. Failure to write a snapshot is non-fatal (disk full → log WARN, keep indexing).
- **Server startup preflight** (`api/main.py` lifespan) — proactively opens Kuzu so corruption is caught at boot, not on the first user job.
- **`agent-brain doctor`** gets a `graph_store_health` check + `--fix` handler that performs the same quarantine + snapshot-replay offline. Refuses to run while a `server.lock` exists.

### Files
- New: `agent-brain-server/agent_brain_server/storage/graph_snapshot.py`
- Modified: `storage/graph_store.py`, `indexing/graph_index.py`, `services/indexing_service.py`, `api/main.py`, `config/settings.py`
- CLI: `agent-brain-cli/agent_brain_cli/diagnostics.py`
- Docs: `docs/CHANGELOG.md` (v10.0.6), `docs/GRAPHRAG_GUIDE.md` (resilience section)
- Tests: 36 new unit tests across 3 new test files + 5 in existing doctor tests

### Quality gates

```
$ task before-push    → exit 0
$ task pr-qa-gate     → exit 0 (coverage 78%)
```

## Test plan

- [x] Unit tests pass (`task before-push` exits 0, 378 CLI + 251 graph-related server tests)
- [x] Coverage ≥ 50% (`task pr-qa-gate` → 78%)
- [x] `mypy` strict-mode passes on changed modules
- [x] `ruff` + `black` clean
- [ ] Manual repro of issue #166 on a real machine (deferred to post-merge — needs gpt-4o-mini key + long index)
  - Reproducer: fresh `.agent-brain/`, enable GraphRAG, `agent-brain index <large_folder>`, `pkill -9` mid-langextract, restart, `agent-brain index <same_folder>` → should self-heal silently with a WARN log
- [ ] `agent-brain doctor --fix` recovers a manually-corrupted Kuzu DB

## Follow-ups (intentionally out of scope)

These came up during exploration but are deferred to separate issues:

1. Graceful drain for `_build_graph` cancellation (currently `asyncio.to_thread` ignores cancellation tokens)
2. `task agent-brain:stop` task in the server Taskfile
3. Same defensive pattern for ChromaDB / BM25 (not observed today)
4. Track upstream [kuzudb/kuzu#6020](https://github.com/kuzudb/kuzu/issues/6020) — if/when fixed, our defensive code becomes belt-and-suspenders

🤖 Generated with [Claude Code](https://claude.com/claude-code)