### PR TITLE
chore: triage stale todos and fix Chroma/BM25 singleton path leak (#170, #171, #172)

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,9 +3,9 @@ gsd_state_version: 1.0
 milestone: v9.6.0
 milestone_name: Runtime Support Parity & Backlog Cleanup
 current_phase: 46
-status: active
-stopped_at: "Phase 46 executed; ready for Phase 47 discussion"
-last_updated: "2026-04-01T17:05:30Z"
+status: parked
+stopped_at: "Phase 46 shipped; v10.0.x patch series superseded the v9.6.0 milestone — awaiting next milestone definition"
+last_updated: "2026-05-27T00:00:00Z"
 progress:
   total_phases: 4
   completed_phases: 1
@@ -15,82 +15,94 @@ progress:
 
 # Agent Brain — Project State
 
-**Last Updated:** 2026-04-01
-**Current Milestone:** v9.6.0 Runtime Support Parity & Backlog Cleanup
-**Status:** Phase 46 complete, ready for Phase 47 discussion
-**Current Phase:** 46
+**Last Updated:** 2026-05-27
+**Current Milestone:** v9.6.0 Runtime Support Parity & Backlog Cleanup (parked; v10.0.x patch series shipped instead)
+**Status:** v10.0.6 released; awaiting next milestone definition
+**Current Phase:** 46 complete; v9.6.0 phases 47–49 deferred or absorbed into v10.0.x work
 
 ## Current Position
 
-Phase: 46 (project-local-runtime-install-harness) — COMPLETE
-Plan: 01-02
-Status: Ready for `/gsd-discuss-phase 47`
+Phase: 46 (project-local-runtime-install-harness) — COMPLETE (v9.5.0)
+Plan: 01–02
+Status: Ready for next-milestone planning. The v9.6.0 follow-on phases (47 Codex parity, 48 OpenCode parity, 49 Gemini parity & backlog cleanup) were never executed as planned; instead the project shipped seven v10.0.x patch releases addressing GraphRAG durability, Kuzu resilience, PDF/indexing fixes, and the `agent-brain doctor` diagnostic.
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated 2026-03-31)
+See: .planning/PROJECT.md (last updated 2026-03-31; review before defining next milestone)
 **Core value:** Developers can semantically search their entire codebase and documentation through a single, fast, local-first API that understands code structure and relationships
-**Current focus:** Phase 46 — project-local runtime install harness
+**Current focus:** No active milestone — define v10.1 or v11 next
 
 ## Milestone Summary
 
 ```
-v3.0 Advanced RAG:          [██████████] 100% (shipped 2026-02-10)
-v6.0 PostgreSQL Backend:    [██████████] 100% (shipped 2026-02-13)
-v6.0.4 Plugin & Install:    [██████████] 100% (shipped 2026-02-22)
-v7.0 Index Mgmt & Pipeline: [██████████] 100% (shipped 2026-03-05)
-v8.0 Performance & DX:      [██████████] 100% (shipped 2026-03-15)
-v9.0 Multi-Runtime:         [██████████] 100% (shipped 2026-03-16)
-v9.1.0 Skill-Runtime:       [██████████] 100% (shipped 2026-03-16)
-v9.4.0 Doc Accuracy Audit:  [██████████] 100% (shipped 2026-03-20)
-v9.3.0 LangExtract+Config:  [██████████] 100% (shipped 2026-03-22)
-v9.5.0 Config Val & Lang:   [██████████] 100% (shipped 2026-03-31)
-v9.6.0 Runtime Parity:      [██▌       ]  25% (1/4 phases)
+v3.0 Advanced RAG:           [██████████] 100% (shipped 2026-02-10)
+v6.0 PostgreSQL Backend:     [██████████] 100% (shipped 2026-02-13)
+v6.0.4 Plugin & Install:     [██████████] 100% (shipped 2026-02-22)
+v7.0 Index Mgmt & Pipeline:  [██████████] 100% (shipped 2026-03-05)
+v8.0 Performance & DX:       [██████████] 100% (shipped 2026-03-15)
+v9.0 Multi-Runtime:          [██████████] 100% (shipped 2026-03-16)
+v9.1.0 Skill-Runtime:        [██████████] 100% (shipped 2026-03-16)
+v9.3.0 LangExtract+Config:   [██████████] 100% (shipped 2026-03-22)
+v9.4.0 Doc Accuracy Audit:   [██████████] 100% (shipped 2026-03-20)
+v9.5.0 Config Val & Lang:    [██████████] 100% (shipped 2026-03-31)
+v9.6.0 Runtime Parity:       [██▌       ]  25% (1/4 phases — parked)
+v10.0.0–v10.0.6 Patch Train: [██████████] 100% (shipped 2026-05-25 → 2026-05-27)
+  ├─ v10.0.0: agent-brain doctor diagnostic
+  ├─ v10.0.1–2: release process fixes (changelog, plugin.json)
+  ├─ v10.0.3: PDF chunk-ID collision fix
+  ├─ v10.0.4: Kuzu graph search restoration + exclude_patterns fix
+  ├─ v10.0.5: GraphRAG on Anthropic, jobs detail crash, Kuzu upgrade self-heal
+  └─ v10.0.6: Kuzu corruption self-heal + triplet snapshots (#166)
 ```
 
-## v9.6.0 Phase Overview
+## v9.6.0 Phase Overview (parked)
 
 | Phase | Name | Requirements | Status |
 |-------|------|--------------|--------|
 | 46 | Project-Local Runtime Install Harness | ISO-01..02, PARITY-01 | Completed |
-| 47 | Codex Runtime E2E Parity | CODEX-01..02 | Not started |
-| 48 | OpenCode Runtime E2E Parity | OPEN-01..02 | Not started |
-| 49 | Gemini Runtime E2E Parity & Backlog Cleanup | GCLI-01..02, PARITY-02 | Not started |
+| 47 | Codex Runtime E2E Parity | CODEX-01..02 | Deferred — re-evaluate during next milestone |
+| 48 | OpenCode Runtime E2E Parity | OPEN-01..02 | Deferred — re-evaluate during next milestone |
+| 49 | Gemini Runtime E2E Parity & Backlog Cleanup | GCLI-01..02, PARITY-02 | Deferred — re-evaluate during next milestone |
 
 ## Accumulated Context
 
-### Key Context for v9.6.0
+### Key Context Carried Forward
 
-- `agent-brain install-agent` already exposes `codex`, `opencode`, and `gemini` targets in `agent-brain-cli/agent_brain_cli/commands/install_agent.py`
-- Converter-level and CLI-level tests already validate install behavior for Codex, OpenCode, and Gemini, but they do not yet prove headless runtime execution after project-local install
-- Existing `e2e-cli/` coverage is Claude-oriented and already uses isolated workspaces, making it the natural base for runtime parity work
-- The repo has `.opencode/plugins/agent-brain/` checked in today, no `.gemini/` example tree, and `.codex/` is currently used for GSD skills rather than a generated Agent Brain install tree
-- User constraint: do not mutate the global Codex/OpenCode/Gemini environment; all installs must happen in repo-owned integration folders
-- Desired parity flow: install → verify install artifacts exist → invoke runtime headlessly from the project dir → assert JSON status
+- `agent-brain install-agent` exposes `codex`, `opencode`, `gemini`, and `claude` targets in `agent-brain-cli/agent_brain_cli/commands/install_agent.py`
+- Converter-level and CLI-level tests validate install behavior, but headless runtime parity for Codex/OpenCode/Gemini is still unverified
+- `e2e-cli/` coverage is Claude-oriented and remains the natural base for runtime parity work if/when v9.6.0 phases 47–49 are revived
+- v10.0.x focus was reliability of the graph layer (Kuzu) and operational visibility (`agent-brain doctor`)
 
-### Decisions from Prior Milestones (relevant to v9.6.0)
+### Decisions from Prior Milestones (still load-bearing)
 
 - [Phase 27]: Codex support is a named runtime preset built on skill-runtime and must generate `.codex/skills/agent-brain/` plus idempotent `AGENTS.md`
-- [Phase 43]: OpenCode project installs must update project-local `opencode.json`, keep singular directories, and preserve permission entries
-- [Phase 41]: Gemini provider already migrated to `google-genai`; the pending Gemini migration todo is stale, not a missing shipped capability
-- [v9.5.0 audit]: Runtime install behavior is covered structurally, but end-to-end parity through real external CLIs is still unverified
+- [Phase 41]: Gemini provider migrated to `google-genai` (commit `b19ab35`)
+- [Phase 42]: Object Pascal language support shipped (commits `de34cd0`, `4777890`)
+- [Phase 43]: OpenCode project installs update project-local `opencode.json`, keep singular directories, and preserve permission entries
+- [v9.5.0 audit]: Runtime install behavior covered structurally; headless parity through real external CLIs still unverified
+- [v10.0.6]: Kuzu graph store now self-heals from corruption via triplet snapshots
 
 ### Blockers/Concerns
 
-- Headless Codex, OpenCode, and Gemini CLI binaries may not be installed in every environment where the parity suite runs
-- External CLIs may differ in JSON output guarantees, so the parity contract must normalize status reporting without falling back to manual inspection
+- Headless Codex, OpenCode, and Gemini CLI binaries not guaranteed in every environment where a parity suite would run
+- No active milestone — next planning step needs owner input on whether to revive v9.6.0 phases 47–49 or pivot to new themes (MCP server #167, Voyage AI #152, federated search #157, etc.)
 
 ### Pending Todos
 
-- Audit and reconcile stale runtime-related pending todos, especially shipped Gemini migration and setup-fatigue items that no longer reflect the current codebase
-- Confirm there is no missing Codex implementation work before creating new backlog items; current evidence points to verification gaps, not missing converter code
+All 7 previously-pending todos relating to shipped work were archived to `.planning/todos/done/` on 2026-05-27 with `closed_by_release` annotations. The remaining 3 todos have been promoted to GitHub issues:
+
+- **[#170](https://github.com/SpillwaveSolutions/agent-brain/issues/170)** — fix(server): resolve chroma/bm25 dirs relative to `AGENT_BRAIN_STATE_DIR`, not CWD (real bug — `settings.py:34-35` defaults are CWD-relative)
+- **[#171](https://github.com/SpillwaveSolutions/agent-brain/issues/171)** — feat(plugin): pre-authorize setup-assistant agent across 6 setup commands (audit-and-verify — spot-check shows all 6 commands have `context: fork` + `agent: setup-assistant`; needs fresh end-to-end run)
+- **[#172](https://github.com/SpillwaveSolutions/agent-brain/issues/172)** — chore(plugin): verify setup-assistant permission scopes (audit-and-verify — required Bash/Write/Edit scopes already present in `setup-assistant.md:23-33`)
+
+See `.planning/todos/pending/` for the source todo files; each carries a `Tracked in:` cross-reference back to its issue.
 
 ## Session Continuity
 
-**Last Session:** 2026-03-31T19:25:34Z
-**Stopped At:** Phase 46 executed
-**Resume File:** .planning/phases/46-project-local-runtime-install-harness/46-02-SUMMARY.md
-**Next Action:** Run `/gsd-discuss-phase 47` to start Codex runtime parity planning
+**Last Session:** 2026-05-27
+**Stopped At:** v10.0.6 released; backlog triaged; 3 remaining todos promoted to GitHub issues
+**Resume File:** None (no active phase)
+**Next Action:** Run `/gsd:new-milestone` (or owner-led milestone definition) to scope v10.1 / v11. Likely candidates: revive runtime parity (v9.6.0 phases 47–49), MCP server (#153, #167), or queue prioritization (#157, #156).
 
 ---
-*State updated: 2026-04-01*
+*State updated: 2026-05-27 — synced with v10.0.6 release reality*

--- a/.planning/todos/done/2026-03-18-review-and-merge-object-pascal-support-pr-115.md
+++ b/.planning/todos/done/2026-03-18-review-and-merge-object-pascal-support-pr-115.md
@@ -7,7 +7,12 @@ files:
   - agent-brain-server/agent_brain_server/config/file_type_presets.py
   - agent-brain-cli/agent_brain_cli/commands/types.py
   - agent-brain-server/tests/unit/test_pascal_chunker.py
+status: closed
+closed_at: 2026-05-27
+closed_by_release: v9.5.0
 ---
+
+> **✅ Closed (2026-05-27)** — PR #115 was closed without merge, but the work landed via Phase 42 direct commits: `de34cd0` (`feat(42): add .dpk extension support for Object Pascal`) and `4777890` (`feat(42): add object-pascal preset alias, sync CLI types, fix verification gap`). Object Pascal is fully supported.
 
 ## Problem
 

--- a/.planning/todos/done/2026-03-19-add-ast-for-code-plus-langextract-for-docs-as-first-class-graphrag-option-in-agent-brain-config-wizard.md
+++ b/.planning/todos/done/2026-03-19-add-ast-for-code-plus-langextract-for-docs-as-first-class-graphrag-option-in-agent-brain-config-wizard.md
@@ -4,7 +4,12 @@ title: Add "AST for code + LangExtract for docs" as a first-class GraphRAG optio
 area: tooling
 files:
   - agent-brain-plugin/commands/agent-brain-config.md:544-690
+status: closed
+closed_at: 2026-05-27
+closed_by_release: v9.3.0
 ---
+
+> **✅ Closed (2026-05-27)** — Shipped in v9.3.0 (LangExtract + Config milestone). Verified at `agent-brain-plugin/commands/agent-brain-config.md:590-592` which now lists `2) AST + LangExtract (Recommended for mixed repos)` and `3) Kuzu + AST + LangExtract` as top-level Step 7 options.
 
 ## Problem
 

--- a/.planning/todos/done/2026-03-19-auto-discover-available-port-in-agent-brain-config-step-12-deployment-wizard-to-prevent-multi-project-port-conflicts.md
+++ b/.planning/todos/done/2026-03-19-auto-discover-available-port-in-agent-brain-config-step-12-deployment-wizard-to-prevent-multi-project-port-conflicts.md
@@ -4,7 +4,12 @@ title: Auto-discover available port in agent-brain-config Step 12 deployment wiz
 area: tooling
 files:
   - agent-brain-plugin/commands/agent-brain-config.md:997-1047
+status: closed
+closed_at: 2026-05-27
+closed_by_release: v9.5.0
 ---
+
+> **✅ Closed (2026-05-27)** — Auto-port shipped. Verified at `agent-brain-plugin/commands/agent-brain-start.md:58,275` which documents `auto-select (8000-8100)` and the `auto_port` config flag enabled by default.
 
 ## Problem
 

--- a/.planning/todos/done/2026-03-19-fix-agent-brain-start-timeout-too-short-for-sentence-transformers-reranker-first-init.md
+++ b/.planning/todos/done/2026-03-19-fix-agent-brain-start-timeout-too-short-for-sentence-transformers-reranker-first-init.md
@@ -5,7 +5,12 @@ area: tooling
 files:
   - agent-brain-server/agent_brain_server/api/main.py
   - agent-brain-cli/agent_brain_cli/commands/
+status: closed
+closed_at: 2026-05-27
+closed_by_release: v9.5.0
 ---
+
+> **✅ Closed (2026-05-27)** — Approach A shipped (default timeout raised from 30s to 120s). Verified at `agent-brain-cli/agent_brain_cli/commands/start.py:166-169` (`--timeout` Click option, `default=120`).
 
 ## Problem
 

--- a/.planning/todos/done/2026-03-19-fix-indexing-jobs-failing-with-broken-pipe-under-concurrent-ollama-load.md
+++ b/.planning/todos/done/2026-03-19-fix-indexing-jobs-failing-with-broken-pipe-under-concurrent-ollama-load.md
@@ -5,7 +5,12 @@ area: tooling
 files:
   - agent-brain-server/agent_brain_server/services/indexing_service.py
   - agent-brain-server/agent_brain_server/api/routers/
+status: closed
+closed_at: 2026-05-27
+closed_by_release: v9.5.0
 ---
+
+> **✅ Closed (2026-05-27)** — Solution item 1 (retry on dropped connection) shipped. Verified at `agent-brain-server/agent_brain_server/providers/embedding/ollama.py:88` which catches `BrokenPipeError` and `ConnectionResetError` and retries with backoff. Solution items 2–5 (job-progress separation, watch streaming, concurrency limit, false-failure verification) are nice-to-have polish — file follow-up issues separately if observed in v10.x.
 
 ## Problem
 

--- a/.planning/todos/done/2026-03-19-migrate-gemini-provider-from-deprecated-google-generativeai-to-google-genai-package.md
+++ b/.planning/todos/done/2026-03-19-migrate-gemini-provider-from-deprecated-google-generativeai-to-google-genai-package.md
@@ -5,7 +5,13 @@ area: tooling
 files:
   - agent-brain-server/agent_brain_server/providers/summarization/gemini.py:6
   - agent-brain-server/pyproject.toml
+status: closed
+closed_at: 2026-05-27
+closed_by_commit: b19ab35
+closed_by_release: v9.5.0
 ---
+
+> **✅ Closed (2026-05-27)** — Migration shipped in commit `b19ab35` (`fix(38-03): migrate Gemini provider to google-genai SDK`). Verified by `agent-brain-server/pyproject.toml:51` declaring `google-genai = "^1.0.0"`. Regression tests added in commit `48816cf`.
 
 ## Problem
 

--- a/.planning/todos/done/2026-03-19-suppress-or-fix-chromadb-telemetry-posthog-capture-argument-error-on-startup.md
+++ b/.planning/todos/done/2026-03-19-suppress-or-fix-chromadb-telemetry-posthog-capture-argument-error-on-startup.md
@@ -5,7 +5,12 @@ area: tooling
 files:
   - agent-brain-server/pyproject.toml
   - agent-brain-server/agent_brain_server/api/main.py
+status: closed
+closed_at: 2026-05-27
+closed_by_release: v9.5.0
 ---
+
+> **✅ Closed (2026-05-27)** — Approach A shipped. Verified at `agent-brain-server/agent_brain_server/api/main.py:167-169` which sets `os.environ.setdefault("ANONYMIZED_TELEMETRY", "False")` and demotes `chromadb.telemetry` / `posthog` loggers to WARNING.
 
 ## Problem
 

--- a/.planning/todos/pending/2026-03-19-eliminate-approval-fatigue-in-agent-brain-plugin-setup-commands-via-pre-authorized-agent-and-scripts.md
+++ b/.planning/todos/pending/2026-03-19-eliminate-approval-fatigue-in-agent-brain-plugin-setup-commands-via-pre-authorized-agent-and-scripts.md
@@ -11,7 +11,11 @@ files:
   - agent-brain-plugin/commands/agent-brain-start.md
   - agent-brain-plugin/commands/agent-brain-verify.md
   - agent-brain-plugin/scripts/ab-setup-check.sh
+tracked_in:
+  - https://github.com/SpillwaveSolutions/agent-brain/issues/171
 ---
+
+> **Tracked in:** [#171](https://github.com/SpillwaveSolutions/agent-brain/issues/171) — Related: [#170](https://github.com/SpillwaveSolutions/agent-brain/issues/170), [#172](https://github.com/SpillwaveSolutions/agent-brain/issues/172)
 
 ## Problem
 

--- a/.planning/todos/pending/2026-03-19-fix-chroma-db-and-cache-dirs-resolving-relative-to-cwd-instead-of-state-dir-agent-brain-data.md
+++ b/.planning/todos/pending/2026-03-19-fix-chroma-db-and-cache-dirs-resolving-relative-to-cwd-instead-of-state-dir-agent-brain-data.md
@@ -6,7 +6,11 @@ files:
   - agent-brain-server/agent_brain_server/config/settings.py
   - agent-brain-server/agent_brain_server/storage/vector_store.py
   - agent-brain-server/agent_brain_server/api/main.py
+tracked_in:
+  - https://github.com/SpillwaveSolutions/agent-brain/issues/170
 ---
+
+> **Tracked in:** [#170](https://github.com/SpillwaveSolutions/agent-brain/issues/170) — Related: [#171](https://github.com/SpillwaveSolutions/agent-brain/issues/171), [#172](https://github.com/SpillwaveSolutions/agent-brain/issues/172)
 
 ## Problem
 

--- a/.planning/todos/pending/2026-03-19-fix-two-permission-gaps-in-setup-assistant-agent-scoped-bash-and-write-edit-for-agent-brain-config-paths.md
+++ b/.planning/todos/pending/2026-03-19-fix-two-permission-gaps-in-setup-assistant-agent-scoped-bash-and-write-edit-for-agent-brain-config-paths.md
@@ -6,7 +6,11 @@ files:
   - agent-brain-plugin/agents/setup-assistant.md
   - agent-brain-plugin/commands/agent-brain-config.md:56-63
   - agent-brain-plugin/scripts/ab-setup-check.sh
+tracked_in:
+  - https://github.com/SpillwaveSolutions/agent-brain/issues/172
 ---
+
+> **Tracked in:** [#172](https://github.com/SpillwaveSolutions/agent-brain/issues/172) — Related: [#170](https://github.com/SpillwaveSolutions/agent-brain/issues/170), [#171](https://github.com/SpillwaveSolutions/agent-brain/issues/171)
 
 ## Problem
 

--- a/agent-brain-plugin/agents/setup-assistant.md
+++ b/agent-brain-plugin/agents/setup-assistant.md
@@ -31,7 +31,7 @@ allowed_tools:
   - "Edit(~/.config/agent-brain/**)"
   - "Write(.claude/agent-brain/**)"
   - "Edit(.claude/agent-brain/**)"
-last_validated: 2026-03-16
+last_validated: 2026-05-27
 ---
 
 # Setup Assistant Agent

--- a/agent-brain-server/agent_brain_server/api/main.py
+++ b/agent-brain-server/agent_brain_server/api/main.py
@@ -30,7 +30,7 @@ from agent_brain_server.config.provider_config import (
     load_provider_settings,
     validate_provider_config,
 )
-from agent_brain_server.indexing.bm25_index import BM25IndexManager
+from agent_brain_server.indexing.bm25_index import BM25IndexManager, set_bm25_manager
 from agent_brain_server.job_queue import JobQueueService, JobQueueStore, JobWorker
 from agent_brain_server.locking import (
     acquire_lock,
@@ -45,6 +45,7 @@ from agent_brain_server.storage import (
     VectorStoreManager,
     get_effective_backend_type,
     get_storage_backend,
+    set_vector_store,
 )
 from agent_brain_server.storage_paths import resolve_state_dir, resolve_storage_paths
 
@@ -73,6 +74,42 @@ _job_worker: JobWorker | None = None
 
 # Module-level reference to file watcher service for cleanup
 _file_watcher: object = None
+
+
+_STRAY_CWD_DATA_DIRS = ("chroma_db", "bm25_index", "graph_index")
+
+
+def _warn_about_stray_cwd_data_dirs(state_dir: Path) -> None:
+    """Log a warning if CWD-relative data dirs from older versions exist.
+
+    Issue #170: prior to the singleton setter fix, calling
+    get_vector_store() or get_bm25_manager() before the FastAPI lifespan
+    had registered the state-dir-resolved instance would create stray
+    directories named ``chroma_db/`` or ``bm25_index/`` at the current
+    working directory. The fix prevents new strays but does not migrate
+    existing ones — silent data motion is dangerous.
+
+    Args:
+        state_dir: The resolved state directory, used to build the
+            recommended ``mv`` command in the warning message.
+    """
+    cwd = Path.cwd().resolve()
+    for name in _STRAY_CWD_DATA_DIRS:
+        stray = cwd / name
+        if not stray.is_dir():
+            continue
+        canonical = state_dir / "data" / name
+        if stray.resolve() == canonical.resolve():
+            continue
+        logger.warning(
+            "Detected stray data directory %s (likely from a pre-fix "
+            "release of agent-brain — issue #170). The canonical "
+            "location is %s. If this directory holds valuable data, "
+            "merge it manually; otherwise remove it: rm -rf %s",
+            stray,
+            canonical,
+            stray,
+        )
 
 
 def _build_provider_fingerprint() -> str:
@@ -264,6 +301,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     assert state_dir is not None, "state_dir must be resolved by lifespan"
     logger.info(f"Resolved storage paths: state_dir={state_dir}")
 
+    # Warn if stray CWD-relative data dirs from older versions are present.
+    # See issue #170 — older versions could leak ./chroma_db and ./bm25_index
+    # next to the project root if the singleton getters were hit before
+    # lifespan registered the explicit state-dir-resolved instances.
+    _warn_about_stray_cwd_data_dirs(state_dir)
+
     # Determine project root for path validation
     project_root: Path | None = None
     if state_dir is not None:
@@ -315,6 +358,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 persist_dir=chroma_dir,
             )
             await vector_store.initialize()
+            # Register the singleton so downstream services that pull
+            # through get_vector_store() share this state-dir-resolved
+            # instance instead of constructing a CWD-relative one.
+            set_vector_store(vector_store)
             app.state.vector_store = vector_store
             logger.info("Vector store initialized")
 
@@ -331,6 +378,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 persist_dir=bm25_dir,
             )
             bm25_manager.initialize()
+            set_bm25_manager(bm25_manager)
             app.state.bm25_manager = bm25_manager
             logger.info("BM25 index manager initialized")
         else:

--- a/agent-brain-server/agent_brain_server/indexing/__init__.py
+++ b/agent-brain-server/agent_brain_server/indexing/__init__.py
@@ -1,6 +1,10 @@
 """Indexing pipeline components for document processing."""
 
-from agent_brain_server.indexing.bm25_index import BM25IndexManager, get_bm25_manager
+from agent_brain_server.indexing.bm25_index import (
+    BM25IndexManager,
+    get_bm25_manager,
+    set_bm25_manager,
+)
 from agent_brain_server.indexing.chunking import CodeChunker, ContextAwareChunker
 from agent_brain_server.indexing.document_loader import DocumentLoader
 from agent_brain_server.indexing.embedding import (
@@ -28,6 +32,7 @@ __all__ = [
     "get_embedding_generator",
     "BM25IndexManager",
     "get_bm25_manager",
+    "set_bm25_manager",
     # Graph indexing (Feature 113)
     "LLMEntityExtractor",
     "CodeMetadataExtractor",

--- a/agent-brain-server/agent_brain_server/indexing/bm25_index.py
+++ b/agent-brain-server/agent_brain_server/indexing/bm25_index.py
@@ -178,8 +178,32 @@ _bm25_manager: BM25IndexManager | None = None
 
 
 def get_bm25_manager() -> BM25IndexManager:
-    """Get the global BM25 manager instance."""
+    """Get the global BM25 manager instance.
+
+    If unset, falls back to constructing with default settings — which
+    resolves to the CWD-relative legacy path. Callers that need the
+    state-dir-resolved path must call set_bm25_manager() during startup
+    (the FastAPI lifespan does this).
+    """
     global _bm25_manager
     if _bm25_manager is None:
+        logger.warning(
+            "get_bm25_manager() called before set_bm25_manager(); "
+            "using CWD-relative default %r. This indicates the FastAPI "
+            "lifespan did not run, e.g. in a unit test or misconfigured "
+            "ad-hoc script.",
+            settings.BM25_INDEX_PATH,
+        )
         _bm25_manager = BM25IndexManager()
     return _bm25_manager
+
+
+def set_bm25_manager(instance: BM25IndexManager) -> None:
+    """Register the singleton BM25 manager.
+
+    Called by the FastAPI lifespan after constructing the manager with
+    the state-dir-resolved path so that downstream services share the
+    same instance instead of falling back to the CWD-relative default.
+    """
+    global _bm25_manager
+    _bm25_manager = instance

--- a/agent-brain-server/agent_brain_server/storage/__init__.py
+++ b/agent-brain-server/agent_brain_server/storage/__init__.py
@@ -17,7 +17,12 @@ from .protocol import (
     StorageBackendProtocol,
     StorageError,
 )
-from .vector_store import VectorStoreManager, get_vector_store, initialize_vector_store
+from .vector_store import (
+    VectorStoreManager,
+    get_vector_store,
+    initialize_vector_store,
+    set_vector_store,
+)
 
 __all__ = [
     # Storage backend protocol (Phase 5)
@@ -31,6 +36,7 @@ __all__ = [
     # Vector store (legacy, for backward compat)
     "VectorStoreManager",
     "get_vector_store",
+    "set_vector_store",
     "initialize_vector_store",
     # Graph store (Feature 113)
     "GraphStoreManager",

--- a/agent-brain-server/agent_brain_server/storage/vector_store.py
+++ b/agent-brain-server/agent_brain_server/storage/vector_store.py
@@ -568,11 +568,36 @@ _vector_store: VectorStoreManager | None = None
 
 
 def get_vector_store() -> VectorStoreManager:
-    """Get the global vector store instance."""
+    """Get the global vector store instance.
+
+    If unset, falls back to constructing with default settings — which
+    resolves to the CWD-relative legacy path. Callers that need the
+    state-dir-resolved path must call set_vector_store() during startup
+    (the FastAPI lifespan does this).
+    """
     global _vector_store
     if _vector_store is None:
+        logger.warning(
+            "get_vector_store() called before set_vector_store(); "
+            "using CWD-relative default %r. This indicates the FastAPI "
+            "lifespan did not run, e.g. in a unit test or misconfigured "
+            "ad-hoc script.",
+            settings.CHROMA_PERSIST_DIR,
+        )
         _vector_store = VectorStoreManager()
     return _vector_store
+
+
+def set_vector_store(instance: VectorStoreManager) -> None:
+    """Register the singleton vector store.
+
+    Called by the FastAPI lifespan after constructing the manager with
+    the state-dir-resolved path so that downstream services
+    (IndexingService, QueryService, ChromaBackend) all share the same
+    instance instead of falling back to the CWD-relative default.
+    """
+    global _vector_store
+    _vector_store = instance
 
 
 async def initialize_vector_store() -> VectorStoreManager:

--- a/agent-brain-server/tests/unit/test_issue_170_singleton_path_resolution.py
+++ b/agent-brain-server/tests/unit/test_issue_170_singleton_path_resolution.py
@@ -1,0 +1,164 @@
+"""Regression tests for issue #170: chroma/bm25 paths leaking to CWD.
+
+Before the fix, calling ``get_vector_store()`` or ``get_bm25_manager()``
+without prior ``set_*`` would create a singleton with the CWD-relative
+default. The lifespan registered its own state-dir-resolved instance in
+``app.state`` but never updated the module-level singleton, so any
+service that pulled through the singleton (IndexingService,
+QueryService, ChromaBackend) ended up with a *different* manager writing
+to ``./chroma_db`` next to the project root.
+
+The fix introduces ``set_vector_store()`` and ``set_bm25_manager()``
+which the lifespan calls after constructing each manager with the
+resolved path. These tests lock that contract in.
+"""
+
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent_brain_server.api.main import _warn_about_stray_cwd_data_dirs
+from agent_brain_server.indexing.bm25_index import (
+    BM25IndexManager,
+    get_bm25_manager,
+    set_bm25_manager,
+)
+from agent_brain_server.storage.vector_store import (
+    VectorStoreManager,
+    get_vector_store,
+    set_vector_store,
+)
+
+
+class TestSetVectorStoreOverridesSingleton:
+    def test_set_vector_store_makes_get_return_same_instance(
+        self, tmp_path: Path
+    ) -> None:
+        explicit = VectorStoreManager(persist_dir=str(tmp_path / "data" / "chroma_db"))
+        set_vector_store(explicit)
+        try:
+            assert get_vector_store() is explicit
+        finally:
+            set_vector_store(None)  # type: ignore[arg-type]
+
+    def test_get_vector_store_unset_logs_warning_and_uses_default(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Force fresh singleton state for this test.
+        set_vector_store(None)  # type: ignore[arg-type]
+        try:
+            with caplog.at_level(
+                logging.WARNING, logger="agent_brain_server.storage.vector_store"
+            ):
+                instance = get_vector_store()
+            assert isinstance(instance, VectorStoreManager)
+            assert any(
+                "called before set_vector_store" in record.message
+                for record in caplog.records
+            )
+        finally:
+            set_vector_store(None)  # type: ignore[arg-type]
+
+
+class TestSetBm25ManagerOverridesSingleton:
+    def test_set_bm25_manager_makes_get_return_same_instance(
+        self, tmp_path: Path
+    ) -> None:
+        explicit = BM25IndexManager(persist_dir=str(tmp_path / "data" / "bm25_index"))
+        set_bm25_manager(explicit)
+        try:
+            assert get_bm25_manager() is explicit
+        finally:
+            set_bm25_manager(None)  # type: ignore[arg-type]
+
+    def test_get_bm25_manager_unset_logs_warning_and_uses_default(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        set_bm25_manager(None)  # type: ignore[arg-type]
+        try:
+            with caplog.at_level(
+                logging.WARNING, logger="agent_brain_server.indexing.bm25_index"
+            ):
+                instance = get_bm25_manager()
+            assert isinstance(instance, BM25IndexManager)
+            assert any(
+                "called before set_bm25_manager" in record.message
+                for record in caplog.records
+            )
+        finally:
+            set_bm25_manager(None)  # type: ignore[arg-type]
+
+
+class TestStrayCwdDataDirWarning:
+    """``_warn_about_stray_cwd_data_dirs`` emits a guided manual-migration log."""
+
+    def test_warns_when_stray_chroma_db_exists_at_cwd(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Build a fake CWD with a stray chroma_db and a separate state dir.
+        fake_cwd = tmp_path / "project"
+        fake_cwd.mkdir()
+        (fake_cwd / "chroma_db").mkdir()
+        state_dir = fake_cwd / ".agent-brain"
+        state_dir.mkdir()
+
+        with patch("agent_brain_server.api.main.Path.cwd", return_value=fake_cwd):
+            with caplog.at_level(logging.WARNING, logger="agent_brain_server.api.main"):
+                _warn_about_stray_cwd_data_dirs(state_dir)
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("stray data directory" in r.message for r in warnings)
+        assert any("chroma_db" in r.message for r in warnings)
+        # No silent move — message must point at a manual rm command.
+        assert any("rm -rf" in r.message for r in warnings)
+
+    def test_does_not_warn_when_no_stray_dirs(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        clean_cwd = tmp_path / "clean"
+        clean_cwd.mkdir()
+        state_dir = clean_cwd / ".agent-brain"
+        state_dir.mkdir()
+
+        with patch("agent_brain_server.api.main.Path.cwd", return_value=clean_cwd):
+            with caplog.at_level(logging.WARNING, logger="agent_brain_server.api.main"):
+                _warn_about_stray_cwd_data_dirs(state_dir)
+
+        assert not any("stray data directory" in r.message for r in caplog.records)
+
+    def test_does_not_warn_when_state_dir_is_inside_cwd_only(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The canonical state-dir-relative path must not be flagged."""
+        fake_cwd = tmp_path / "project"
+        fake_cwd.mkdir()
+        state_dir = fake_cwd / ".agent-brain"
+        (state_dir / "data" / "chroma_db").mkdir(parents=True)
+        # No stray chroma_db at CWD root, only inside state_dir.
+
+        with patch("agent_brain_server.api.main.Path.cwd", return_value=fake_cwd):
+            with caplog.at_level(logging.WARNING, logger="agent_brain_server.api.main"):
+                _warn_about_stray_cwd_data_dirs(state_dir)
+
+        assert not any("stray data directory" in r.message for r in caplog.records)
+
+
+class TestLifespanContractIsDocumented:
+    """Surface-level: the lifespan source still calls the new setters."""
+
+    def test_main_py_calls_set_vector_store(self) -> None:
+        main_path = (
+            Path(__file__).parent.parent.parent
+            / "agent_brain_server"
+            / "api"
+            / "main.py"
+        )
+        source = main_path.read_text()
+        assert (
+            "set_vector_store(vector_store)" in source
+        ), "lifespan must register the state-dir-resolved vector store singleton"
+        assert (
+            "set_bm25_manager(bm25_manager)" in source
+        ), "lifespan must register the state-dir-resolved bm25 manager singleton"

--- a/docs/plans/2026-05-27-low-hanging-fruit-triage.md
+++ b/docs/plans/2026-05-27-low-hanging-fruit-triage.md
@@ -1,0 +1,158 @@
+# Low-Hanging Fruit Triage & Cross-Referenced Issue Tracking
+
+## Context
+
+`.planning/STATE.md` is pinned at **v9.6.0 / Phase 46**, but the repo has shipped **v10.0.6** (releases v9.3.0 → v10.0.6 happened between then and now). Ten todos sit in `.planning/todos/pending/` — **six are demonstrably resolved** in shipped code, **one is partially done**, and **three are still real bugs/UX gaps**.
+
+The goal of this work:
+1. Close the planning-artifact drift (archive stale todos, sync STATE.md)
+2. Promote the remaining three items into trackable GitHub issues with bidirectional cross-references (todo → issue → commit)
+3. Implement the three items in low-to-high risk order, each in its own commit referencing its issue
+
+This converts ad-hoc markdown notes into a queryable, linked work graph and clears noise so the next milestone (Phase 47) starts from a true picture of the project.
+
+## Phase Plan
+
+### Step 0 — Clean feature branch
+- Branch from `main`: `git checkout -b chore/triage-pending-todos-v10`
+- Verify clean tree before starting.
+
+### Step 1 — Archive 6 stale todos
+
+For each file in `.planning/todos/pending/` that maps to shipped work, prepend a `## Closed` block (release tag, commit SHA, brief evidence), then move to `.planning/todos/done/`.
+
+| Pending file | Closed by |
+|---|---|
+| `2026-03-19-migrate-gemini-provider-from-deprecated-google-generativeai-to-google-genai-package.md` | commit `b19ab35` (Phase 41) — pyproject.toml `google-genai ^1.0.0` |
+| `2026-03-19-suppress-or-fix-chromadb-telemetry-posthog-capture-argument-error-on-startup.md` | `agent-brain-server/agent_brain_server/api/main.py` sets `ANONYMIZED_TELEMETRY=False` |
+| `2026-03-19-fix-agent-brain-start-timeout-too-short-for-sentence-transformers-reranker-first-init.md` | start command default param now `120` (was 30) |
+| `2026-03-19-fix-indexing-jobs-failing-with-broken-pipe-under-concurrent-ollama-load.md` | retry logic in `providers/embedding/ollama.py` for `BrokenPipeError`/`ConnectionResetError` |
+| `2026-03-19-add-ast-for-code-plus-langextract-for-docs-as-first-class-graphrag-option-in-agent-brain-config-wizard.md` | v9.3.0 — option listed in `agent-brain-plugin/commands/agent-brain-config.md` Step 7 |
+| `2026-03-19-auto-discover-available-port-in-agent-brain-config-step-12-deployment-wizard-to-prevent-multi-project-port-conflicts.md` | port scan pattern present in `agent-brain-start.md` (8000–8100) |
+| `2026-03-18-review-and-merge-object-pascal-support-pr-115.md` | merged — Phase 42 commits (`feat(42): add object-pascal preset alias`, `.dpk` extension) |
+
+### Step 2 — Sync `.planning/STATE.md`
+
+Replace the milestone-summary block + "Current Position" + "Pending Todos" sections to reflect:
+- Shipped: v9.6.0, v9.7.0+ (verify versions from `git tag --sort=-creatordate`), v10.0.0–v10.0.6
+- Stopped At / Next Action: realistic next-phase prompt (or "ready for v10.1 milestone planning")
+- Pending Todos: only the 3 items that move to GitHub issues
+- Update `last_updated`
+
+### Step 3 — Create 3 GitHub issues with cross-references
+
+Use `gh issue create` against `SpillwaveSolutions/agent-brain`. Each issue body must include:
+- Symptom + reproduction (copied from the todo file)
+- Affected files (concrete paths)
+- Acceptance criteria
+- `Source todo: .planning/todos/pending/<file>.md`
+
+Then **edit each pending todo file** to prepend a `Tracked in: #NNN` line — the bidirectional link.
+
+| Issue | Title | Source todo |
+|---|---|---|
+| A | `fix(server): resolve chroma/cache dirs relative to AGENT_BRAIN_STATE_DIR, not CWD` | `2026-03-19-fix-chroma-db-and-cache-dirs-resolving-relative-to-cwd...md` |
+| B | `feat(plugin): pre-authorize setup-assistant agent on 6 setup commands to eliminate approval fatigue` | `2026-03-19-eliminate-approval-fatigue-in-agent-brain-plugin-setup-commands...md` |
+| C | `chore(plugin): close permission scope gaps in setup-assistant (Bash + Write/Edit paths)` | `2026-03-19-fix-two-permission-gaps-in-setup-assistant-agent-scoped-bash-and-write-edit...md` |
+
+Issues A, B, C must each link to each other (`Related: #B, #C`) so reviewers see the cluster.
+
+### Step 4 — Implement Issue C (permission scope gaps, smallest)
+
+Verify that the setup-assistant agent definition at `agent-brain-plugin/agents/setup-assistant.md` (or similar) has:
+- `Bash(~/.claude/plugins/agent-brain/scripts/*)`
+- `Write/Edit(~/.agent-brain/**)`
+- `Write/Edit(~/.config/agent-brain/**)` (per memory note about config migration)
+
+If anything missing → add it. If all present → close issue C as "already implemented in last_validated 2026-03-16" with link to the commit that added them.
+
+Commit message: `chore(plugin): verify setup-assistant permission scopes (closes #C)`
+
+### Step 5 — Implement Issue B (pre-authorize 6 setup commands)
+
+For each command file in `agent-brain-plugin/commands/`:
+- `agent-brain-config.md`
+- `agent-brain-install.md`
+- `agent-brain-setup.md`
+- `agent-brain-init.md`
+- `agent-brain-start.md`
+- `agent-brain-verify.md`
+
+Verify and (if missing) add YAML frontmatter binding to the pre-authorized agent. The pattern to use is the one already established in this repo — check `agent-brain-plugin/commands/agent-brain-config.md` first to see the current frontmatter shape; mirror it for consistency. **Do not invent a new convention** — reuse what other commands in this plugin already use.
+
+⚠️ **Memory note** (`feedback_auto_mode_agent_config_edits.md`): edits under `.claude/agents/` and `.claude/commands/` can be blocked by auto-mode even with plan approval. These edits target `agent-brain-plugin/commands/` (not `.claude/commands/`), so should be fine — but if blocked, fall back to single-message batched edits.
+
+Commit message: `feat(plugin): bind setup-assistant to setup commands (closes #B)`
+
+### Step 6 — Implement Issue A (Chroma/cache path resolution, highest risk)
+
+Concrete change:
+- `agent-brain-server/agent_brain_server/config/settings.py:34-35` — replace `./chroma_db` / `./bm25_index` defaults so they resolve via `AGENT_BRAIN_STATE_DIR` (which already defaults to `~/.agent-brain/<project>/`).
+- Validate the lifespan/resolution path. The `test_lifespan_path_resolution.py` test (if it exists per agent report) is the regression anchor — add cases if missing.
+- Affected files (representative): `config/settings.py`, `storage/vector_store.py`, BM25 index init in `services/`.
+
+**Migration concern**: existing users may have `./chroma_db` next to their `pyproject.toml` from prior runs. Approach:
+- On startup, if old `./chroma_db` exists at CWD **and** new path is empty, log a warning with a one-liner migration command. Do **not** auto-move (silent data motion is dangerous).
+- Document in CHANGELOG.
+
+Commit message: `fix(server): resolve chroma/bm25 dirs under AGENT_BRAIN_STATE_DIR (closes #A)`
+
+### Step 7 — Validation (MANDATORY, per CLAUDE.md)
+
+Run from repo root:
+1. `task before-push` — must exit 0 (Black, Ruff, mypy strict, pytest)
+2. `task pr-qa-gate` — must exit 0
+3. Spot-check: start a fresh `agent-brain-server`, confirm Chroma writes under `~/.agent-brain/<project>/data/chroma_db`, not `./chroma_db`
+4. Spot-check: run `/agent-brain:agent-brain-config` and confirm no permission prompts on commands that were bound
+
+### Step 8 — PR
+
+Single PR titled: `chore: triage stale todos, track remaining as issues, close 3 (#A, #B, #C)`
+
+Body includes:
+- Table of triaged todos with closing release links
+- The three issue numbers with one-line descriptions
+- Test plan checklist
+
+After PR is open, copy this plan to `docs/plans/2026-05-27-low-hanging-fruit-triage.md` per repo convention (CLAUDE.md planning rule).
+
+## Critical Files
+
+- `.planning/todos/pending/*.md` — 7 files moving, 3 getting `Tracked in: #NNN` headers
+- `.planning/todos/done/` — destination for archived files
+- `.planning/STATE.md` — milestone summary refresh
+- `agent-brain-server/agent_brain_server/config/settings.py` — Chroma/BM25 path defaults
+- `agent-brain-server/agent_brain_server/api/main.py` — verify lifespan path resolution (read-only check)
+- `agent-brain-plugin/commands/agent-brain-{config,install,setup,init,start,verify}.md` — frontmatter additions
+- `agent-brain-plugin/agents/setup-assistant.md` (or wherever the agent lives) — permission scope verification
+
+## Reuse Notes
+
+- Existing path-resolution patterns: the server already resolves `AGENT_BRAIN_STATE_DIR` somewhere (per Phase 109 multi-instance architecture). Find and reuse — do not introduce a parallel resolver.
+- Existing pre-auth frontmatter: copy whatever shape is already used by the first command that has it.
+- Existing migration-warning helpers: search for prior "old path detected" warnings before adding a new one.
+
+## Verification
+
+End-to-end check after all 3 commits land locally, before pushing:
+
+```bash
+# 1. All quality gates green
+task before-push && task pr-qa-gate
+
+# 2. Storage path verification
+rm -rf /tmp/ab-verify && mkdir /tmp/ab-verify && cd /tmp/ab-verify
+agent-brain init && agent-brain start
+agent-brain index ./README.md  # any test file
+ls ~/.agent-brain/*/data/chroma_db  # should exist
+ls ./chroma_db 2>/dev/null         # should NOT exist
+
+# 3. Permission prompt check (manual)
+# In a fresh Claude Code session, run /agent-brain:agent-brain-config and
+# confirm no Bash/Write approval prompts on the 6 setup commands.
+
+# 4. Optional: scripts/quick_start_guide.sh end-to-end
+./scripts/quick_start_guide.sh
+```
+
+Only push after all four pass.


### PR DESCRIPTION
## Summary

Low-hanging-fruit sweep over `.planning/todos/pending/`. Found 10 pending todos — 7 already shipped between v9.3.0 and v9.5.0, 3 needed cleanup, 1 was a real bug.

- **Triaged 7 stale todos** out of `pending/` into `done/` with closing-release annotations. Most surprising: `STATE.md` was pinned at v9.6.0 but the repo had shipped through v10.0.6. The planning system had drifted ~3 months behind code.
- **Promoted the 3 remaining todos to GitHub issues with bidirectional cross-references** (todo → issue → sibling issues):
  - **#170** real bug — `chroma_db/` and `bm25_index/` leak to CWD instead of `.agent-brain/data/`
  - **#171** verify-and-close — pre-authorize setup-assistant agent on 6 setup commands
  - **#172** verify-and-close — setup-assistant permission scope gaps
- **Fixed #170** — the lifespan was creating state-dir-resolved `VectorStoreManager`/`BM25IndexManager` but never updating the module-level singletons, so any service that pulled through `get_vector_store()` / `get_bm25_manager()` (IndexingService, QueryService, ChromaBackend) ended up with a *different* manager writing to `./chroma_db` at CWD. Fix: add `set_vector_store()` / `set_bm25_manager()` helpers; lifespan now calls them after construction. Added stray-CWD-directory warning (no silent migration). 8 new regression tests.
- **Static-verified #171 and #172** by reading the relevant files. All 6 commands carry `context: fork` + `agent: setup-assistant`; the agent declares every permission scope called out in the original todos. Refreshed `last_validated` to today. Runtime verification (fresh `/agent-brain-config` run in a clean Claude Code session) remains as the final close-out step for both issues — left open with status comments.

## Triaged todos (already shipped)

| Todo | Closed by |
|---|---|
| Gemini → `google-genai` migration | commit `b19ab35`, v9.5.0 |
| ChromaDB telemetry suppression | `main.py:167-169`, v9.5.0 |
| `agent-brain start` 30s→120s timeout | `start.py:166-169`, v9.5.0 |
| Ollama broken-pipe retry | `providers/embedding/ollama.py:88`, v9.5.0 |
| AST + LangExtract config wizard | `agent-brain-config.md:590-592`, v9.3.0 |
| Port auto-discover | `agent-brain-start.md:58,275`, v9.5.0 |
| Object Pascal PR #115 | commits `de34cd0`, `4777890`, v9.5.0 |

## Commits

1. `41fe62e` — chore(planning): triage stale todos and promote 3 remaining to issues
2. `0bebccb` — chore(plugin): refresh setup-assistant last_validated date (#172)
3. `4f09e98` — fix(server): converge vector store & bm25 singletons on lifespan path (closes #170)

## Test plan

- [x] `task before-push` exits 0 (Black, Ruff, mypy strict, 378 pytest)
- [x] `task pr-qa-gate` exits 0 (78.74% coverage, well above 50% gate)
- [x] 8 new regression tests in `test_issue_170_singleton_path_resolution.py` pass
- [x] Existing `test_lifespan_path_resolution.py` (10 tests) and `test_bugfix_regressions.py` (8 tests) still pass — no regression
- [ ] **Runtime spot-check (manual, before merge):** start a fresh server in a clean dir; index a small file; confirm `~/.agent-brain/<project>/data/chroma_db` exists and `./chroma_db` does NOT
- [ ] **Runtime spot-check (manual, before closing #171/#172):** run `/agent-brain-config` in a fresh Claude Code session; confirm zero Bash/Write approval prompts on the 6 setup commands

## Notes for reviewers

- The CWD-relative defaults `./chroma_db` and `./bm25_index` in `settings.py:34-35` are deliberately preserved as documented legacy fallbacks. Changing them would break ad-hoc scripts and tests that instantiate managers without a state dir. The fix is in the wiring, not the defaults.
- No silent data migration — if a user has a stray `./chroma_db` from a pre-fix release, the server logs a warning with the canonical path and a manual `rm -rf` command. Silent motion of valuable data is too dangerous to do automatically.

Plan file: `docs/plans/2026-05-27-low-hanging-fruit-triage.md` (to be copied from `~/.claude/plans/humble-jingling-rainbow.md` post-merge per CLAUDE.md planning rule).