### PR TITLE
chore(release): guard against poetry.lock drift in before-push (closes #174)

### DIFF
--- a/.claude/commands/ag-brain-release.md
+++ b/.claude/commands/ag-brain-release.md
@@ -37,6 +37,8 @@ Execute a versioned release with these steps:
 4. CLI dependency points to PyPI (not path) - flip if needed
 5. CHANGELOG entry exists for the new version. Calculate the new version from current + bump type, then verify `docs/CHANGELOG.md` contains a `## [X.Y.Z]` heading matching it. If missing, abort with: "Add a `## [X.Y.Z] - YYYY-MM-DD` section to docs/CHANGELOG.md and commit it before re-running. See the existing [10.0.0] entry for the expected Keep-a-Changelog format."
 
+> **Note**: `task before-push` is wrapped by an automatic lock-drift guard (`scripts/before_push_lock_guard.sh`, see issue #174). The guard snapshots clean `agent-brain-{server,cli}/poetry.lock` files at task entry and reverts any in-task churn on exit. The release flow inherits this protection — no separate manual `git checkout HEAD -- poetry.lock` step is required after `task before-push`.
+
 ### Release Steps
 
 1. Calculate new version from current + bump type (also used by pre-release check #5)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -176,6 +176,11 @@ tasks:
   before-push:
     desc: Run all checks before pushing (format, lint, typecheck, yaml, test)
     cmds:
+      # defer: runs at end of task even on failure (Taskfile 3.x).
+      # The guard reverts any in-monorepo poetry.lock drift caused by
+      # `poetry install` running transitively below. See issue #174.
+      - defer: ./scripts/before_push_lock_guard.sh check
+      - ./scripts/before_push_lock_guard.sh start
       - echo "--- Formatting code ---"
       - task: format
       - echo "--- Linting code ---"

--- a/scripts/before_push_lock_guard.sh
+++ b/scripts/before_push_lock_guard.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Wrap-around guard for `task before-push` — see issue #174.
+#
+# Problem: in-monorepo `poetry install` (run transitively by before-push)
+# can silently rewrite agent-brain-cli/poetry.lock to point at the local
+# ../agent-brain-server build instead of the PyPI version pinned in
+# pyproject.toml. If that lockfile change gets committed, CI breaks
+# because CI fetches agent-brain-rag from PyPI.
+#
+# Solution: snapshot which lockfiles were git-clean at task entry. On
+# task exit (via Taskfile defer), revert any clean-at-entry lockfile
+# that's now dirty. Files that were ALREADY dirty at entry are left
+# alone — preserves intentional lockfile edits during dev.
+
+set -euo pipefail
+
+SNAPSHOT_FILE="${TMPDIR:-/tmp}/.ab-before-push-lock-snapshot"
+LOCK_FILES=(
+    "agent-brain-server/poetry.lock"
+    "agent-brain-cli/poetry.lock"
+)
+
+case "${1:-}" in
+    start)
+        : > "$SNAPSHOT_FILE"
+        for f in "${LOCK_FILES[@]}"; do
+            if [ ! -f "$f" ]; then
+                continue
+            fi
+            if git diff --quiet -- "$f" 2>/dev/null; then
+                printf '%s\n' "$f" >> "$SNAPSHOT_FILE"
+            fi
+        done
+        ;;
+    check)
+        if [ ! -f "$SNAPSHOT_FILE" ]; then
+            exit 0
+        fi
+        reverted=0
+        while IFS= read -r f; do
+            if [ -z "$f" ]; then
+                continue
+            fi
+            if ! git diff --quiet -- "$f" 2>/dev/null; then
+                printf 'WARN: %s drifted during before-push (likely monorepo bootstrap).\n' "$f" >&2
+                printf '      Reverting to HEAD. If you intentionally changed it, commit it first then re-run.\n' >&2
+                git checkout HEAD -- "$f"
+                reverted=1
+            fi
+        done < "$SNAPSHOT_FILE"
+        rm -f "$SNAPSHOT_FILE"
+        if [ "$reverted" = "1" ]; then
+            printf '      (lock-drift guard #174 — see https://github.com/SpillwaveSolutions/agent-brain/issues/174)\n' >&2
+        fi
+        ;;
+    *)
+        printf 'Usage: %s {start|check}\n' "$0" >&2
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
## Summary

Adds an automatic lock-drift guard around `task before-push` that prevents the monorepo-path resolver from silently rewriting `agent-brain-cli/poetry.lock` to a local-path build. This class of failure was observed **twice in the v10.0.7 session** (during PR #173 development and again during the release version-bump) and caught manually each time. The guard automates the manual `git checkout HEAD -- poetry.lock` step.

## Approach

Two-piece, defense-in-depth:

1. **`scripts/before_push_lock_guard.sh`** (NEW, ~50 LOC) — wrap-around helper with `start`/`check` subcommands. `start` snapshots which lockfiles were git-clean at task entry; `check` walks the snapshot and reverts any clean-at-entry file that's now dirty.

2. **`Taskfile.yml` `before-push:` target** — wires the script using Taskfile 3.x `defer:` so the check runs at exit even if a tool fails mid-task. `defer` declarations run in reverse order; the check sits at the top of `cmds:` so it fires last.

3. **`.claude/commands/ag-brain-release.md`** — adds a one-paragraph note under "Pre-Release Checks" documenting the guard so future release operators understand the protection. No behavior change to the release command itself; the guard is inherited transitively via `task before-push`.

## Smoke-tested behavior

| Entry state | Exit state | Guard action |
|---|---|---|
| Clean | Clean | No-op |
| Clean | Dirty (bootstrap) | **Revert to HEAD with WARN** (the target scenario) |
| Dirty (user edit) | Different dirty | Leave alone; WARN tells user to commit then re-run |
| Dirty (user edit) | Same dirty | Leave alone |

Both scenarios validated by hash comparison and `git status --porcelain` post-run.

## Test plan

- [x] `task before-push` exits 0; lockfile clean after run (guard fires + reverts)
- [x] `task pr-qa-gate` exits 0 (378 tests, 78.74% coverage)
- [x] Smoke-test #1: clean tree → run before-push → lockfile silently reverted by guard, WARN logged
- [x] Smoke-test #2: pre-existing lockfile edit → run before-push → guard skips, edit preserved
- [ ] Manual verification on next `/ag-brain-release patch` invocation: lockfile should NOT appear in release commit's `git show --stat`

## Files

- `scripts/before_push_lock_guard.sh` — NEW
- `Taskfile.yml` — `before-push:` target gets 2 new lines (defer + start invocation)
- `.claude/commands/ag-brain-release.md` — 1 new paragraph under Pre-Release Checks

## Notes for reviewers

- The guard does NOT fix the root cause (Poetry's monorepo path resolver). It just catches the symptom before it reaches a commit. A deeper fix — instructing Poetry to never resolve `agent-brain-rag` to a local path when run inside `agent-brain-cli/` — is out of scope and would require either pyproject changes or a poetry plugin.
- The 3rd row of the smoke-test table (user-intent-dirty + bootstrap-overwrites) is a known limitation: the guard can't distinguish user intent from bootstrap noise once both have touched the file. The WARN message tells users to commit before re-running, which is the right workflow for that case.

Closes #174