### PR TITLE
feat(query): add explain=true parameter (closes #159)

### DIFF
--- a/agent-brain-cli/agent_brain_cli/client/api_client.py
+++ b/agent-brain-cli/agent_brain_cli/client/api_client.py
@@ -54,6 +54,22 @@ class IndexingStatus:
 
 
 @dataclass
+class ResultExplanation:
+    """Structured per-result explanation (issue #159).
+
+    Populated only when the request set `explain=true`. All fields are
+    optional because their relevance depends on retrieval mode.
+    """
+
+    reason: str
+    matched_terms: list[str] | None = None
+    fusion: dict[str, float] | None = None
+    graph_path: list[str] | None = None
+    rerank_movement: int | None = None
+    graph_fallback: bool | None = None
+
+
+@dataclass
 class QueryResult:
     """Single query result."""
 
@@ -64,6 +80,14 @@ class QueryResult:
     metadata: dict[str, Any]
     vector_score: float | None = None
     bm25_score: float | None = None
+    graph_score: float | None = None
+    rerank_score: float | None = None
+    original_rank: int | None = None
+    relationship_path: list[str] | None = None
+    related_entities: list[str] | None = None
+    source_type: str = "doc"
+    language: str | None = None
+    explanation: ResultExplanation | None = None
 
 
 @dataclass
@@ -93,6 +117,39 @@ class IndexResponse:
     job_id: str
     status: str
     message: str | None
+
+
+def _parse_query_result(payload: dict[str, Any]) -> QueryResult:
+    """Build a QueryResult from a server response dict, including optional
+    explanation block (issue #159)."""
+    explanation_data = payload.get("explanation")
+    explanation: ResultExplanation | None = None
+    if explanation_data is not None:
+        explanation = ResultExplanation(
+            reason=explanation_data.get("reason", ""),
+            matched_terms=explanation_data.get("matched_terms"),
+            fusion=explanation_data.get("fusion"),
+            graph_path=explanation_data.get("graph_path"),
+            rerank_movement=explanation_data.get("rerank_movement"),
+            graph_fallback=explanation_data.get("graph_fallback"),
+        )
+    return QueryResult(
+        text=payload["text"],
+        source=payload["source"],
+        score=payload["score"],
+        chunk_id=payload["chunk_id"],
+        metadata=payload.get("metadata", {}),
+        vector_score=payload.get("vector_score"),
+        bm25_score=payload.get("bm25_score"),
+        graph_score=payload.get("graph_score"),
+        rerank_score=payload.get("rerank_score"),
+        original_rank=payload.get("original_rank"),
+        relationship_path=payload.get("relationship_path"),
+        related_entities=payload.get("related_entities"),
+        source_type=payload.get("source_type", "doc"),
+        language=payload.get("language"),
+        explanation=explanation,
+    )
 
 
 class DocServeClient:
@@ -229,6 +286,7 @@ class DocServeClient:
         source_types: list[str] | None = None,
         languages: list[str] | None = None,
         file_paths: list[str] | None = None,
+        explain: bool = False,
     ) -> QueryResponse:
         """
         Query indexed documents.
@@ -242,11 +300,14 @@ class DocServeClient:
             source_types: Filter by source types (doc, code, test).
             languages: Filter by programming languages.
             file_paths: Filter by file path patterns.
+            explain: When True, include structured per-result explanations
+                (matched terms, fusion breakdown, graph path, rerank movement,
+                and a 'why this rank' summary). See issue #159.
 
         Returns:
             QueryResponse with matching results.
         """
-        request_data = {
+        request_data: dict[str, Any] = {
             "query": query_text,
             "top_k": top_k,
             "similarity_threshold": similarity_threshold,
@@ -259,21 +320,12 @@ class DocServeClient:
             request_data["languages"] = languages
         if file_paths is not None:
             request_data["file_paths"] = file_paths
+        if explain:
+            request_data["explain"] = True
 
         data = self._request("POST", "/query/", json=request_data)
 
-        results = [
-            QueryResult(
-                text=r["text"],
-                source=r["source"],
-                score=r["score"],
-                chunk_id=r["chunk_id"],
-                metadata=r.get("metadata", {}),
-                vector_score=r.get("vector_score"),
-                bm25_score=r.get("bm25_score"),
-            )
-            for r in data.get("results", [])
-        ]
+        results = [_parse_query_result(r) for r in data.get("results", [])]
 
         return QueryResponse(
             results=results,

--- a/agent-brain-cli/agent_brain_cli/commands/query.py
+++ b/agent-brain-cli/agent_brain_cli/commands/query.py
@@ -3,9 +3,11 @@
 import click
 from rich.console import Console
 from rich.panel import Panel
+from rich.table import Table
 from rich.text import Text
 
 from ..client import ConnectionError, DocServeClient, ServerError
+from ..client.api_client import ResultExplanation
 from ..config import get_server_url
 from ..diagnostics import doctor_hint_message
 
@@ -15,6 +17,50 @@ console = Console()
 def _get_default_url() -> str:
     """Get default server URL from config."""
     return get_server_url()
+
+
+def _render_explanation(explanation: ResultExplanation) -> None:
+    """Render a ResultExplanation as a sub-panel below the main result.
+
+    Layout (only rows that have data are emitted):
+        Why:      <reason string>
+        Matched:  term1, term2, ...
+        Fusion:   key=value | key=value | ...
+        Graph:    subject -> predicate -> object
+        Rerank:   moved up/down N places (if any)
+        Fallback: graph -> vector
+    """
+    table = Table(show_header=False, box=None, padding=(0, 1), expand=False)
+    table.add_column("label", style="cyan", no_wrap=True)
+    table.add_column("value", style="dim")
+
+    table.add_row("Why:", explanation.reason)
+
+    if explanation.matched_terms:
+        highlighted = Text(", ".join(explanation.matched_terms))
+        highlighted.highlight_words(explanation.matched_terms, style="bold yellow")
+        table.add_row("Matched:", highlighted)
+
+    if explanation.fusion:
+        parts = [f"{k}={v:.4f}" for k, v in explanation.fusion.items()]
+        table.add_row("Fusion:", " | ".join(parts))
+
+    if explanation.graph_path:
+        table.add_row("Graph:", " -> ".join(explanation.graph_path))
+
+    if explanation.rerank_movement is not None:
+        if explanation.rerank_movement > 0:
+            arrow = f"+{explanation.rerank_movement} (moved up)"
+        elif explanation.rerank_movement < 0:
+            arrow = f"{explanation.rerank_movement} (moved down)"
+        else:
+            arrow = "0 (held position)"
+        table.add_row("Rerank:", arrow)
+
+    if explanation.graph_fallback:
+        table.add_row("Fallback:", "graph returned no hits -> vector")
+
+    console.print(table)
 
 
 @click.command("query")
@@ -64,6 +110,15 @@ def _get_default_url() -> str:
 @click.option("--full", is_flag=True, help="Show full text content")
 @click.option("--scores", is_flag=True, help="Show individual vector/BM25 scores")
 @click.option(
+    "--explain",
+    is_flag=True,
+    help=(
+        "Show structured 'why this rank' explanations under each result: "
+        "matched terms, fusion breakdown, graph path, and rerank movement "
+        "(issue #159)."
+    ),
+)
+@click.option(
     "--source-types",
     help="Comma-separated source types to filter by (doc,code,test)",
 )
@@ -85,6 +140,7 @@ def query_command(
     json_output: bool,
     full: bool,
     scores: bool,
+    explain: bool,
     source_types: str | None,
     languages: str | None,
     file_paths: str | None,
@@ -115,6 +171,7 @@ def query_command(
                 source_types=source_types_list,
                 languages=languages_list,
                 file_paths=file_paths_list,
+                explain=explain,
             )
 
             if json_output:
@@ -201,6 +258,10 @@ def query_command(
                         padding=(0, 1),
                     )
                 )
+
+                # Issue #159: optional structured explanation block.
+                if explain and result.explanation is not None:
+                    _render_explanation(result.explanation)
 
     except ConnectionError as e:
         if json_output:

--- a/agent-brain-cli/tests/test_query_explain_render.py
+++ b/agent-brain-cli/tests/test_query_explain_render.py
@@ -1,0 +1,151 @@
+"""Tests for the --explain flag on `agent-brain query` (issue #159).
+
+These exercise the CLI render path via Click's CliRunner with a mocked
+DocServeClient. The --explain block should only appear when the flag is
+set; without it the output is byte-identical to the existing behavior.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from agent_brain_cli.client.api_client import (
+    QueryResponse,
+    QueryResult,
+    ResultExplanation,
+)
+from agent_brain_cli.commands.query import query_command
+
+
+def _make_response(with_explanation: bool) -> QueryResponse:
+    explanation = None
+    if with_explanation:
+        explanation = ResultExplanation(
+            reason="Hybrid match (alpha=0.50): vector 0.44 + BM25 0.41 -> fused 0.85",
+            matched_terms=["authentication", "setup"],
+            fusion={
+                "vector_score_weighted": 0.44,
+                "bm25_score_weighted": 0.41,
+                "alpha": 0.5,
+                "fused_score": 0.85,
+            },
+            graph_path=None,
+            rerank_movement=None,
+            graph_fallback=None,
+        )
+    return QueryResponse(
+        results=[
+            QueryResult(
+                text="Authentication setup is documented in the README.",
+                source="docs/setup.md",
+                score=0.85,
+                chunk_id="chunk_abc",
+                metadata={},
+                vector_score=0.88,
+                bm25_score=0.82,
+                explanation=explanation,
+            )
+        ],
+        query_time_ms=12.5,
+        total_results=1,
+    )
+
+
+def _patch_client(response: QueryResponse):
+    """Build a context manager that patches DocServeClient.query."""
+    mock_client = MagicMock()
+    mock_client.__enter__ = MagicMock(return_value=mock_client)
+    mock_client.__exit__ = MagicMock(return_value=False)
+    mock_client.query = MagicMock(return_value=response)
+    return patch(
+        "agent_brain_cli.commands.query.DocServeClient",
+        return_value=mock_client,
+    )
+
+
+class TestExplainRender:
+    def test_explain_block_absent_by_default(self) -> None:
+        """Without --explain, the CLI output omits the explanation rows."""
+        runner = CliRunner()
+        with _patch_client(_make_response(with_explanation=False)):
+            result = runner.invoke(query_command, ["test query"])
+        assert result.exit_code == 0
+        # Explanation labels must not appear.
+        assert "Why:" not in result.output
+        assert "Matched:" not in result.output
+        assert "Fusion:" not in result.output
+
+    def test_explain_block_renders_with_flag(self) -> None:
+        """With --explain, the CLI shows the structured explanation rows."""
+        runner = CliRunner()
+        with _patch_client(_make_response(with_explanation=True)):
+            result = runner.invoke(query_command, ["test query", "--explain"])
+        assert result.exit_code == 0
+        assert "Why:" in result.output
+        assert "Hybrid match" in result.output
+        assert "Matched:" in result.output
+        assert "authentication" in result.output
+        assert "setup" in result.output
+        assert "Fusion:" in result.output
+        assert "fused_score=0.8500" in result.output
+
+    def test_explain_renders_graph_path_when_present(self) -> None:
+        """Graph mode results: graph_path joined with arrows."""
+        response = _make_response(with_explanation=False)
+        response.results[0].explanation = ResultExplanation(
+            reason="Graph match (score 0.70)",
+            matched_terms=None,
+            fusion=None,
+            graph_path=["AuthManager", "contains", "authenticate"],
+            rerank_movement=None,
+            graph_fallback=False,
+        )
+        runner = CliRunner()
+        with _patch_client(response):
+            result = runner.invoke(query_command, ["test", "--explain"])
+        assert result.exit_code == 0
+        assert "Graph:" in result.output
+        assert "AuthManager -> contains -> authenticate" in result.output
+
+    def test_explain_renders_rerank_movement(self) -> None:
+        """Positive movement is reported as 'moved up'."""
+        response = _make_response(with_explanation=False)
+        response.results[0].explanation = ResultExplanation(
+            reason="Reranked up 2 places from #5 (cross-encoder score 0.95)",
+            matched_terms=None,
+            fusion=None,
+            graph_path=None,
+            rerank_movement=2,
+            graph_fallback=None,
+        )
+        runner = CliRunner()
+        with _patch_client(response):
+            result = runner.invoke(query_command, ["test", "--explain"])
+        assert result.exit_code == 0
+        assert "Rerank:" in result.output
+        assert "+2 (moved up)" in result.output
+
+    def test_explain_omits_rows_when_data_missing(self) -> None:
+        """Only populated rows show — sparse explanations don't pad output."""
+        response = _make_response(with_explanation=False)
+        response.results[0].explanation = ResultExplanation(
+            reason="Vector similarity match (score 0.88)",
+            matched_terms=None,
+            fusion=None,
+            graph_path=None,
+            rerank_movement=None,
+            graph_fallback=None,
+        )
+        runner = CliRunner()
+        with _patch_client(response):
+            result = runner.invoke(query_command, ["test", "--explain"])
+        assert result.exit_code == 0
+        assert "Why:" in result.output
+        # These should not appear since the corresponding fields are None.
+        assert "Matched:" not in result.output
+        assert "Fusion:" not in result.output
+        assert "Graph:" not in result.output
+        assert "Rerank:" not in result.output
+        assert "Fallback:" not in result.output

--- a/agent-brain-server/agent_brain_server/api/routers/query.py
+++ b/agent-brain-server/agent_brain_server/api/routers/query.py
@@ -3,6 +3,7 @@
 import logging
 
 from fastapi import APIRouter, HTTPException, Request, status
+from fastapi.responses import JSONResponse
 
 from agent_brain_server.models import QueryRequest, QueryResponse
 
@@ -17,9 +18,7 @@ router = APIRouter()
     summary="Query Documents",
     description="Perform semantic, keyword, or hybrid search on indexed documents.",
 )
-async def query_documents(
-    request_body: QueryRequest, request: Request
-) -> QueryResponse:
+async def query_documents(request_body: QueryRequest, request: Request) -> JSONResponse:
     """Execute a search query on indexed documents.
 
     Args:
@@ -83,7 +82,16 @@ async def query_documents(
             detail=f"Query failed: {str(e)}",
         ) from e
 
-    return response
+    # Issue #159: when explain=false (default), omit `explanation` per result
+    # so the wire format is byte-identical to historical responses. When
+    # explain=true, dump normally — `null` values inside ResultExplanation are
+    # explicit signals (e.g., matched_terms=null means no BM25 contribution)
+    # and are intentionally preserved.
+    if not request_body.explain:
+        payload = response.model_dump(exclude={"results": {"__all__": {"explanation"}}})
+    else:
+        payload = response.model_dump()
+    return JSONResponse(content=payload)
 
 
 @router.get(

--- a/agent-brain-server/agent_brain_server/models/__init__.py
+++ b/agent-brain-server/agent_brain_server/models/__init__.py
@@ -37,7 +37,13 @@ from .job import (
     JobSummary,
     QueueStats,
 )
-from .query import QueryMode, QueryRequest, QueryResponse, QueryResult
+from .query import (
+    QueryMode,
+    QueryRequest,
+    QueryResponse,
+    QueryResult,
+    ResultExplanation,
+)
 
 __all__ = [
     # Folder management models (Feature 12)
@@ -50,6 +56,7 @@ __all__ = [
     "QueryRequest",
     "QueryResponse",
     "QueryResult",
+    "ResultExplanation",
     # Index models
     "IndexRequest",
     "IndexResponse",

--- a/agent-brain-server/agent_brain_server/models/query.py
+++ b/agent-brain-server/agent_brain_server/models/query.py
@@ -85,6 +85,17 @@ class QueryRequest(BaseModel):
         examples=[["calls", "extends"], ["imports", "contains"]],
     )
 
+    # Issue #159 — opt-in structured explanation payload
+    explain: bool = Field(
+        default=False,
+        description=(
+            "When true, each result includes a structured `explanation` "
+            "block (matched terms, fusion breakdown, graph path, rerank "
+            "movement, and a 'why this rank' summary). Default keeps the "
+            "wire format byte-identical to historical responses."
+        ),
+    )
+
     @field_validator("languages")
     @classmethod
     def validate_languages(cls, v: list[str] | None) -> list[str] | None:
@@ -128,9 +139,73 @@ class QueryRequest(BaseModel):
                     "source_types": ["doc", "code"],
                     "file_paths": ["docs/api/*.md", "src/**/*.py"],
                 },
+                {
+                    "query": "authentication setup",
+                    "top_k": 3,
+                    "mode": "hybrid",
+                    "explain": True,
+                },
             ]
         }
     }
+
+
+class ResultExplanation(BaseModel):
+    """Structured per-result explanation, populated when QueryRequest.explain=True.
+
+    All fields are optional because their relevance depends on the retrieval
+    mode and configuration that produced the result (e.g., `matched_terms` is
+    BM25-only; `fusion` only applies to hybrid/multi modes; `rerank_movement`
+    only when reranking actually fired).
+    """
+
+    reason: str = Field(
+        ...,
+        description=(
+            "Human-readable 'why this rank' summary, derived from the other "
+            "populated fields. Generated deterministically (fixed priority "
+            "order) so snapshot tests don't flake."
+        ),
+    )
+    matched_terms: list[str] | None = Field(
+        default=None,
+        description=(
+            "Query terms (after tokenization/stemming) that hit the document. "
+            "Populated for results with a BM25 contribution; None otherwise."
+        ),
+    )
+    fusion: dict[str, float] | None = Field(
+        default=None,
+        description=(
+            "Per-retriever score/rank breakdown for hybrid and multi modes. "
+            "Hybrid keys: vector_score_weighted, bm25_score_weighted, alpha, "
+            "fused_score. Multi keys: vector_rank, bm25_rank, graph_rank, "
+            "fused_rank, rrf_score."
+        ),
+    )
+    graph_path: list[str] | None = Field(
+        default=None,
+        description=(
+            "Full subject->predicate->object chain that led to the match. "
+            "Mirrors `QueryResult.relationship_path` when graph retrieval "
+            "contributed."
+        ),
+    )
+    rerank_movement: int | None = Field(
+        default=None,
+        description=(
+            "Signed positions moved during reranking. Positive = moved up "
+            "(better rank); negative = moved down. None when reranking did "
+            "not run or this result was not part of the rerank pool."
+        ),
+    )
+    graph_fallback: bool | None = Field(
+        default=None,
+        description=(
+            "True when --mode graph fell back to vector search because no "
+            "graph hits were found. None for non-graph queries."
+        ),
+    )
 
 
 class QueryResult(BaseModel):
@@ -175,6 +250,17 @@ class QueryResult(BaseModel):
     # Additional metadata
     metadata: dict[str, Any] = Field(
         default_factory=dict, description="Additional metadata"
+    )
+
+    # Issue #159 — opt-in structured explanation
+    # Populated only when QueryRequest.explain=True.
+    explanation: ResultExplanation | None = Field(
+        default=None,
+        description=(
+            "Structured 'why this rank' payload. Present only when the "
+            "request set `explain=true`; excluded from serialization "
+            "otherwise so the default wire format is unchanged."
+        ),
     )
 
 
@@ -222,6 +308,23 @@ class QueryResponse(BaseModel):
                             "source_type": "code",
                             "language": "python",
                             "metadata": {"symbol_name": "authenticate_user"},
+                            "explanation": {
+                                "reason": (
+                                    "Hybrid match (alpha=0.5): vector 0.88 + "
+                                    "BM25 0.82 -> fused 0.85; "
+                                    "matched terms: authenticate, user"
+                                ),
+                                "matched_terms": ["authenticate", "user"],
+                                "fusion": {
+                                    "vector_score_weighted": 0.44,
+                                    "bm25_score_weighted": 0.41,
+                                    "alpha": 0.5,
+                                    "fused_score": 0.85,
+                                },
+                                "graph_path": None,
+                                "rerank_movement": None,
+                                "graph_fallback": None,
+                            },
                         },
                     ],
                     "query_time_ms": 125.5,

--- a/agent-brain-server/agent_brain_server/services/query_service.py
+++ b/agent-brain-server/agent_brain_server/services/query_service.py
@@ -27,6 +27,7 @@ from agent_brain_server.models import (
     QueryRequest,
     QueryResponse,
     QueryResult,
+    ResultExplanation,
 )
 from agent_brain_server.providers import ProviderRegistry
 from agent_brain_server.storage import (
@@ -59,6 +60,143 @@ def _graphrag_rrf_k() -> int:
     if yaml_value is not None:
         return int(yaml_value)
     return int(settings.GRAPH_RRF_K)
+
+
+# Issue #159: explain=true support.
+# Each mode handler stashes intermediate data in
+# `QueryResult.metadata["_explain_scratch"]` (a transient dict) so that
+# `_drain_explain_scratch` can rebuild a `ResultExplanation` at the end of
+# `execute_query` — after reranking, which would otherwise discard
+# per-retriever ranks and fusion weights.
+EXPLAIN_SCRATCH_KEY = "_explain_scratch"
+
+
+def _build_reason(
+    result: QueryResult,
+    scratch: dict[str, Any],
+    mode: QueryMode,
+) -> str:
+    """Build the deterministic 'why this rank' one-liner.
+
+    Priority order (first match wins):
+      1. Rerank movement — cross-encoder changed the order (highest signal)
+      2. Graph fallback — rare path that must be announced
+      3. Top-of-mode summary for the active retrieval mode
+    """
+    movement = scratch.get("rerank_movement")
+    if movement is not None and result.rerank_score is not None:
+        if movement == 0:
+            return (
+                f"Reranker confirmed position #{result.original_rank} "
+                f"(cross-encoder score {result.rerank_score:.2f})"
+            )
+        direction = "up" if movement > 0 else "down"
+        plural = "" if abs(movement) == 1 else "s"
+        return (
+            f"Reranked {direction} {abs(movement)} place{plural} from "
+            f"#{result.original_rank} (cross-encoder score "
+            f"{result.rerank_score:.2f})"
+        )
+
+    if mode == QueryMode.GRAPH and scratch.get("graph_fallback"):
+        score = result.vector_score if result.vector_score is not None else result.score
+        return (
+            f"Graph returned no hits; fell back to vector search "
+            f"(score {score:.2f})"
+        )
+
+    if mode == QueryMode.HYBRID and "fused_score" in scratch:
+        return (
+            f"Hybrid match (alpha={scratch.get('alpha', 0.0):.2f}): "
+            f"vector {scratch.get('vector_score_weighted', 0.0):.2f} + "
+            f"BM25 {scratch.get('bm25_score_weighted', 0.0):.2f} -> "
+            f"fused {scratch.get('fused_score', 0.0):.2f}"
+        )
+
+    if mode == QueryMode.MULTI and "rrf_score" in scratch:
+        sources = []
+        if scratch.get("vector_rank") is not None:
+            sources.append(f"vector #{scratch['vector_rank']}")
+        if scratch.get("bm25_rank") is not None:
+            sources.append(f"BM25 #{scratch['bm25_rank']}")
+        if scratch.get("graph_rank") is not None:
+            sources.append(f"graph #{scratch['graph_rank']}")
+        joined = ", ".join(sources) if sources else "no retrievers"
+        return f"RRF fusion ({joined}); rrf_score={scratch.get('rrf_score', 0.0):.4f}"
+
+    if mode == QueryMode.GRAPH and result.graph_score is not None:
+        return f"Graph match (score {result.graph_score:.2f})"
+
+    if mode == QueryMode.BM25 and result.bm25_score is not None:
+        return f"BM25 keyword match (score {result.bm25_score:.2f})"
+
+    if mode == QueryMode.VECTOR and result.vector_score is not None:
+        return f"Vector similarity match (score {result.vector_score:.2f})"
+
+    return f"Retrieved by {mode.value} (score {result.score:.2f})"
+
+
+def _build_explanation_for_result(
+    result: QueryResult,
+    scratch: dict[str, Any],
+    mode: QueryMode,
+) -> ResultExplanation:
+    """Assemble a ResultExplanation from a result's fields and its scratch dict."""
+    fusion: dict[str, float] | None = None
+    if mode == QueryMode.HYBRID and "fused_score" in scratch:
+        fusion = {
+            "vector_score_weighted": float(scratch.get("vector_score_weighted", 0.0)),
+            "bm25_score_weighted": float(scratch.get("bm25_score_weighted", 0.0)),
+            "alpha": float(scratch.get("alpha", 0.0)),
+            "fused_score": float(scratch.get("fused_score", 0.0)),
+        }
+    elif mode == QueryMode.MULTI and "rrf_score" in scratch:
+        fusion = {"rrf_score": float(scratch["rrf_score"])}
+        for key in ("vector_rank", "bm25_rank", "graph_rank", "fused_rank"):
+            val = scratch.get(key)
+            if val is not None:
+                fusion[key] = float(val)
+
+    graph_path: list[str] | None = None
+    if result.relationship_path:
+        graph_path = [str(p) for p in result.relationship_path if p]
+        if not graph_path:
+            graph_path = None
+
+    graph_fallback: bool | None = None
+    if mode == QueryMode.GRAPH:
+        graph_fallback = bool(scratch.get("graph_fallback", False))
+
+    rerank_movement = scratch.get("rerank_movement")
+    if rerank_movement is not None:
+        rerank_movement = int(rerank_movement)
+
+    return ResultExplanation(
+        reason=_build_reason(result, scratch, mode),
+        matched_terms=None,  # populated in commit 3 (storage-level concern)
+        fusion=fusion,
+        graph_path=graph_path,
+        rerank_movement=rerank_movement,
+        graph_fallback=graph_fallback,
+    )
+
+
+def _drain_explain_scratch(
+    results: list[QueryResult],
+    request: QueryRequest,
+) -> None:
+    """Pop `_explain_scratch` from each result's metadata.
+
+    Always called, regardless of `request.explain`, so the scratch never
+    leaks into the wire format. When `request.explain=True`, also build
+    and attach a `ResultExplanation` before clearing.
+    """
+    for result in results:
+        scratch = result.metadata.pop(EXPLAIN_SCRATCH_KEY, {})
+        if request.explain:
+            result.explanation = _build_explanation_for_result(
+                result, scratch, request.mode
+            )
 
 
 class VectorManagerRetriever(BaseRetriever):
@@ -197,8 +335,14 @@ class QueryService:
 
         cache = self.query_cache
         cache_key: str | None = None
-        if cache is not None and QueryCacheService.is_cacheable_mode(
-            request.mode.value
+        # Issue #159: explain=true requests bypass the cache. The explanation
+        # payload is debugging output that shouldn't share cache entries with
+        # ordinary requests, and re-running the query on each call avoids
+        # having to fabricate explanations from cached responses.
+        if (
+            cache is not None
+            and not request.explain
+            and QueryCacheService.is_cacheable_mode(request.mode.value)
         ):
             cache_params: dict[str, Any] = {
                 "query": request.query,
@@ -257,6 +401,7 @@ class QueryService:
                 file_paths=request.file_paths,
                 entity_types=request.entity_types,
                 relationship_types=request.relationship_types,
+                explain=request.explain,
             )
         else:
             stage1_request = request
@@ -292,6 +437,12 @@ class QueryService:
             )
             results = results[:original_top_k]
         # else: reranking disabled, results already at correct size
+
+        # Issue #159: always drain the _explain_scratch metadata so it never
+        # leaks into the wire format. When request.explain=True the drain
+        # also builds and attaches the structured ResultExplanation to each
+        # result.
+        _drain_explain_scratch(results, request)
 
         query_time_ms = (time.time() - start_time) * 1000
 
@@ -496,6 +647,16 @@ class QueryService:
             result = data["result"]
             # Update score with combined score
             result.score = data["total_score"]
+            # Issue #159: stash the fusion breakdown so _drain_explain_scratch
+            # can rebuild a structured explanation after rerank. Values are
+            # already in the local dict — we just persist them onto the
+            # result before returning.
+            result.metadata[EXPLAIN_SCRATCH_KEY] = {
+                "vector_score_weighted": request.alpha * data["vector_score"],
+                "bm25_score_weighted": (1.0 - request.alpha) * data["bm25_score"],
+                "alpha": request.alpha,
+                "fused_score": data["total_score"],
+            }
             fused_nodes.append(result)
 
         # Sort by combined score and take top_k
@@ -563,7 +724,10 @@ class QueryService:
 
         if not graph_results:
             logger.debug("No graph results found, falling back to vector search")
-            return await self._execute_vector_query(request)
+            fallback = await self._execute_vector_query(request)
+            for r in fallback:
+                r.metadata[EXPLAIN_SCRATCH_KEY] = {"graph_fallback": True}
+            return fallback
 
         # Convert graph results to QueryResults
         results: list[QueryResult] = []
@@ -573,7 +737,10 @@ class QueryService:
 
         if not chunk_ids:
             # No source chunks in graph, fall back to vector search
-            return await self._execute_vector_query(request)
+            fallback = await self._execute_vector_query(request)
+            for r in fallback:
+                r.metadata[EXPLAIN_SCRATCH_KEY] = {"graph_fallback": True}
+            return fallback
 
         # Look up the actual documents from vector store
         for graph_result in graph_results:
@@ -616,7 +783,10 @@ class QueryService:
         # If no results from graph, fall back to vector search
         if not results:
             logger.debug("No documents found from graph, falling back to vector search")
-            return await self._execute_vector_query(request)
+            fallback = await self._execute_vector_query(request)
+            for r in fallback:
+                r.metadata[EXPLAIN_SCRATCH_KEY] = {"graph_fallback": True}
+            return fallback
 
         return results[: request.top_k]
 
@@ -722,9 +892,20 @@ class QueryService:
 
         # Update scores and return
         final_results: list[QueryResult] = []
-        for data in sorted_results[: request.top_k]:
+        for fused_idx, data in enumerate(sorted_results[: request.top_k]):
             result = data["result"]
             result.score = data["rrf_score"]
+            # Issue #159: stash per-retriever ranks + RRF score so the final
+            # explanation can describe which retrievers contributed. Without
+            # this stash, the per-retriever ranks die when this method
+            # returns (they only existed in the local combined_scores dict).
+            result.metadata[EXPLAIN_SCRATCH_KEY] = {
+                "rrf_score": data["rrf_score"],
+                "vector_rank": data.get("vector_rank"),
+                "bm25_rank": data.get("bm25_rank"),
+                "graph_rank": data.get("graph_rank"),
+                "fused_rank": fused_idx + 1,
+            }
             final_results.append(result)
 
         return final_results
@@ -876,8 +1057,16 @@ class QueryService:
 
             # Build reranked results with updated scores and metadata
             reranked_results: list[QueryResult] = []
-            for original_index, rerank_score in reranked:
+            for new_index, (original_index, rerank_score) in enumerate(reranked):
                 result = results[original_index]
+                # Issue #159: rerank_movement is signed — positive = moved up
+                # (better rank). Build a fresh metadata dict so we can merge
+                # the upstream scratch (e.g., hybrid fusion) with the rerank
+                # marker without mutating the source result's metadata.
+                new_metadata = dict(result.metadata)
+                upstream_scratch = dict(new_metadata.get(EXPLAIN_SCRATCH_KEY, {}))
+                upstream_scratch["rerank_movement"] = original_index - new_index
+                new_metadata[EXPLAIN_SCRATCH_KEY] = upstream_scratch
                 # Create new result with reranking metadata
                 reranked_result = QueryResult(
                     text=result.text,
@@ -893,7 +1082,7 @@ class QueryService:
                     relationship_path=result.relationship_path,
                     rerank_score=rerank_score,
                     original_rank=original_index + 1,  # 1-indexed
-                    metadata=result.metadata,
+                    metadata=new_metadata,
                 )
                 reranked_results.append(reranked_result)
 

--- a/agent-brain-server/agent_brain_server/services/query_service.py
+++ b/agent-brain-server/agent_brain_server/services/query_service.py
@@ -128,6 +128,10 @@ def _build_reason(
         return f"Graph match (score {result.graph_score:.2f})"
 
     if mode == QueryMode.BM25 and result.bm25_score is not None:
+        terms = scratch.get("matched_terms") or []
+        if terms:
+            term_str = ", ".join(terms[:5])
+            return f"BM25 keyword match (score {result.bm25_score:.2f}): {term_str}"
         return f"BM25 keyword match (score {result.bm25_score:.2f})"
 
     if mode == QueryMode.VECTOR and result.vector_score is not None:
@@ -171,9 +175,15 @@ def _build_explanation_for_result(
     if rerank_movement is not None:
         rerank_movement = int(rerank_movement)
 
+    matched_terms = scratch.get("matched_terms")
+    if matched_terms is not None:
+        matched_terms = [str(t) for t in matched_terms]
+        if not matched_terms:
+            matched_terms = None
+
     return ResultExplanation(
         reason=_build_reason(result, scratch, mode),
-        matched_terms=None,  # populated in commit 3 (storage-level concern)
+        matched_terms=matched_terms,
         fusion=fusion,
         graph_path=graph_path,
         rerank_movement=rerank_movement,
@@ -506,27 +516,38 @@ class QueryService:
             top_k=request.top_k,
             source_types=request.source_types,
             languages=request.languages,
+            explain=request.explain,
         )
 
-        return [
-            QueryResult(
-                text=res.text,
-                source=res.metadata.get(
-                    "source", res.metadata.get("file_path", "unknown")
-                ),
-                score=res.score,
-                bm25_score=res.score,  # Already normalized 0-1
-                chunk_id=res.chunk_id,
-                source_type=res.metadata.get("source_type", "doc"),
-                language=res.metadata.get("language"),
-                metadata={
-                    k: v
-                    for k, v in res.metadata.items()
-                    if k not in ("source", "file_path", "source_type", "language")
-                },
+        results: list[QueryResult] = []
+        for res in search_results:
+            clean_metadata = {
+                k: v
+                for k, v in res.metadata.items()
+                if k not in ("source", "file_path", "source_type", "language")
+            }
+            # Issue #159: stash matched_terms into the explain scratch dict
+            # so the final ResultExplanation can surface them. Always stash
+            # when explain=True so the drain pass finds the data.
+            if request.explain and res.matched_terms is not None:
+                clean_metadata[EXPLAIN_SCRATCH_KEY] = {
+                    "matched_terms": list(res.matched_terms)
+                }
+            results.append(
+                QueryResult(
+                    text=res.text,
+                    source=res.metadata.get(
+                        "source", res.metadata.get("file_path", "unknown")
+                    ),
+                    score=res.score,
+                    bm25_score=res.score,  # Already normalized 0-1
+                    chunk_id=res.chunk_id,
+                    source_type=res.metadata.get("source_type", "doc"),
+                    language=res.metadata.get("language"),
+                    metadata=clean_metadata,
+                )
             )
-            for res in search_results
-        ]
+        return results
 
     async def _execute_hybrid_query(self, request: QueryRequest) -> list[QueryResult]:
         """Execute hybrid search using Relative Score Fusion."""
@@ -551,6 +572,10 @@ class QueryService:
 
         # 2. BM25 Search (scores already normalized 0-1 by ChromaBackend)
         bm25_search_results = []
+        # Issue #159: build a chunk_id -> matched_terms map so we can
+        # attach BM25 matched terms to results that came in via the
+        # vector retriever too (a chunk can be in both result sets).
+        matched_terms_by_chunk: dict[str, list[str]] = {}
         if self.bm25_manager.is_initialized:
             # Use storage backend's keyword_search
             # (returns SearchResult with normalized scores)
@@ -559,7 +584,12 @@ class QueryService:
                 top_k=effective_top_k,
                 source_types=request.source_types,
                 languages=request.languages,
+                explain=request.explain,
             )
+            if request.explain:
+                for res in bm25_search_results:
+                    if res.matched_terms:
+                        matched_terms_by_chunk[res.chunk_id] = list(res.matched_terms)
 
         # Convert BM25 SearchResults to QueryResults
         bm25_query_results = []
@@ -651,12 +681,17 @@ class QueryService:
             # can rebuild a structured explanation after rerank. Values are
             # already in the local dict — we just persist them onto the
             # result before returning.
-            result.metadata[EXPLAIN_SCRATCH_KEY] = {
+            scratch: dict[str, Any] = {
                 "vector_score_weighted": request.alpha * data["vector_score"],
                 "bm25_score_weighted": (1.0 - request.alpha) * data["bm25_score"],
                 "alpha": request.alpha,
                 "fused_score": data["total_score"],
             }
+            if request.explain:
+                terms = matched_terms_by_chunk.get(_chunk_id)
+                if terms:
+                    scratch["matched_terms"] = terms
+            result.metadata[EXPLAIN_SCRATCH_KEY] = scratch
             fused_nodes.append(result)
 
         # Sort by combined score and take top_k
@@ -806,6 +841,17 @@ class QueryService:
         vector_results = await self._execute_vector_query(request)
         bm25_results = await self._execute_bm25_query(request)
 
+        # Issue #159: harvest matched_terms from the BM25 sub-results before
+        # the multi handler overwrites scratch with per-retriever ranks.
+        # We re-stash matched_terms when we finalize the multi result below.
+        matched_terms_by_chunk: dict[str, list[str]] = {}
+        if request.explain:
+            for r in bm25_results:
+                upstream_scratch = r.metadata.get(EXPLAIN_SCRATCH_KEY, {})
+                terms = upstream_scratch.get("matched_terms")
+                if terms:
+                    matched_terms_by_chunk[r.chunk_id] = list(terms)
+
         # Get graph results if enabled and backend supports it
         graph_results: list[QueryResult] = []
         from agent_brain_server.storage import get_effective_backend_type
@@ -899,13 +945,17 @@ class QueryService:
             # explanation can describe which retrievers contributed. Without
             # this stash, the per-retriever ranks die when this method
             # returns (they only existed in the local combined_scores dict).
-            result.metadata[EXPLAIN_SCRATCH_KEY] = {
+            scratch: dict[str, Any] = {
                 "rrf_score": data["rrf_score"],
                 "vector_rank": data.get("vector_rank"),
                 "bm25_rank": data.get("bm25_rank"),
                 "graph_rank": data.get("graph_rank"),
                 "fused_rank": fused_idx + 1,
             }
+            terms = matched_terms_by_chunk.get(result.chunk_id)
+            if terms:
+                scratch["matched_terms"] = terms
+            result.metadata[EXPLAIN_SCRATCH_KEY] = scratch
             final_results.append(result)
 
         return final_results

--- a/agent-brain-server/agent_brain_server/storage/chroma/backend.py
+++ b/agent-brain-server/agent_brain_server/storage/chroma/backend.py
@@ -23,6 +23,50 @@ from agent_brain_server.storage.vector_store import (
 logger = logging.getLogger(__name__)
 
 
+# Issue #159: matched_terms support.
+# Tokenization mirrors LlamaIndex BM25Retriever's default: lowercase the
+# input, ASCII-word split, strip English stopwords. We avoid stemming
+# because the indexer doesn't stem either — keeping the two sides
+# symmetric is what makes the intersection meaningful.
+def _bm25_tokens(text: str) -> list[str]:
+    """Return BM25-relevant tokens in ``text`` (in occurrence order)."""
+    try:
+        import bm25s
+    except ImportError:
+        # bm25s ships transitively with llama-index-retrievers-bm25; the
+        # safety net below means a packaging glitch degrades to "no
+        # matched_terms" rather than a 500.
+        return []
+    try:
+        tokens_lists = bm25s.tokenize(
+            text,
+            return_ids=False,
+            stopwords="english",
+            show_progress=False,
+        )
+    except Exception:
+        return []
+    if not tokens_lists:
+        return []
+    return list(tokens_lists[0]) if tokens_lists[0] else []
+
+
+def _intersect_tokens(query_tokens: list[str], doc_text: str) -> list[str]:
+    """Return query tokens that appear in ``doc_text``, in query order.
+
+    Deduplicates so a user query like ``"auth auth setup"`` produces
+    ``["auth", "setup"]`` rather than repeating the same term.
+    """
+    doc_token_set = set(_bm25_tokens(doc_text))
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for token in query_tokens:
+        if token in doc_token_set and token not in seen:
+            seen.add(token)
+            ordered.append(token)
+    return ordered
+
+
 class ChromaBackend:
     """ChromaDB storage backend implementing StorageBackendProtocol.
 
@@ -168,6 +212,7 @@ class ChromaBackend:
         top_k: int,
         source_types: list[str] | None = None,
         languages: list[str] | None = None,
+        explain: bool = False,
     ) -> list[SearchResult]:
         """Perform BM25 keyword search with score normalization.
 
@@ -176,6 +221,8 @@ class ChromaBackend:
             top_k: Maximum number of results
             source_types: Optional filter by source_type
             languages: Optional filter by language
+            explain: When True, populate ``SearchResult.matched_terms``
+                for each result (issue #159).
 
         Returns:
             List of SearchResult with scores normalized to 0-1 range
@@ -195,27 +242,29 @@ class ChromaBackend:
             if not nodes_with_score:
                 return []
 
+            # Issue #159: precompute the stopword-stripped query tokens once;
+            # we'll intersect them with each document's tokens to derive
+            # matched_terms. The tokenizer matches LlamaIndex BM25Retriever's
+            # default (lowercase, ASCII-word split, English stopword filter).
+            query_tokens: list[str] | None = None
+            if explain:
+                query_tokens = _bm25_tokens(query)
+
             # Normalize BM25 scores to 0-1 range (per-query normalization)
             max_score = max(node.score or 0.0 for node in nodes_with_score)
-            if max_score == 0.0:
-                # All scores are zero, return with zero scores
-                return [
-                    SearchResult(
-                        text=node.node.get_content(),
-                        metadata=dict(node.node.metadata),
-                        score=0.0,
-                        chunk_id=node.node.node_id or "",
-                    )
-                    for node in nodes_with_score
-                ]
+            divisor = max_score if max_score > 0.0 else 1.0
 
-            # Normalize to 0-1 by dividing by max
             return [
                 SearchResult(
                     text=node.node.get_content(),
                     metadata=dict(node.node.metadata),
-                    score=(node.score or 0.0) / max_score,
+                    score=(node.score or 0.0) / divisor if max_score > 0.0 else 0.0,
                     chunk_id=node.node.node_id or "",
+                    matched_terms=(
+                        _intersect_tokens(query_tokens, node.node.get_content())
+                        if query_tokens is not None
+                        else None
+                    ),
                 )
                 for node in nodes_with_score
             ]

--- a/agent-brain-server/agent_brain_server/storage/postgres/backend.py
+++ b/agent-brain-server/agent_brain_server/storage/postgres/backend.py
@@ -239,6 +239,7 @@ class PostgresBackend:
         top_k: int,
         source_types: list[str] | None = None,
         languages: list[str] | None = None,
+        explain: bool = False,
     ) -> list[SearchResult]:
         """Perform full-text keyword search.
 
@@ -249,6 +250,8 @@ class PostgresBackend:
             top_k: Maximum number of results.
             source_types: Optional source_type metadata filter.
             languages: Optional language metadata filter.
+            explain: When True (issue #159), populate
+                ``SearchResult.matched_terms`` from ts_headline output.
 
         Returns:
             List of SearchResult with 0-1 normalized scores.
@@ -261,6 +264,7 @@ class PostgresBackend:
             top_k=top_k,
             source_types=source_types,
             languages=languages,
+            explain=explain,
         )
 
     async def hybrid_search_with_rrf(

--- a/agent-brain-server/agent_brain_server/storage/postgres/keyword_ops.py
+++ b/agent-brain-server/agent_brain_server/storage/postgres/keyword_ops.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Any
 
 from sqlalchemy import text
@@ -17,6 +18,25 @@ from agent_brain_server.storage.postgres.connection import PostgresConnectionMan
 from agent_brain_server.storage.protocol import SearchResult, StorageError
 
 logger = logging.getLogger(__name__)
+
+
+# Issue #159: parse the wrapped fragments from a ts_headline output back
+# into a deduplicated, lowercase list of matched terms.
+_HEADLINE_TERM_RE = re.compile(r"<<<(.+?)>>>")
+
+
+def _parse_headline_terms(headline: str | None) -> list[str] | None:
+    """Extract the highlighted terms from a ts_headline string."""
+    if not headline:
+        return None
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for raw in _HEADLINE_TERM_RE.findall(headline):
+        term = raw.strip().lower()
+        if term and term not in seen:
+            seen.add(term)
+            ordered.append(term)
+    return ordered or None
 
 
 class KeywordOps:
@@ -125,6 +145,7 @@ class KeywordOps:
         top_k: int,
         source_types: list[str] | None = None,
         languages: list[str] | None = None,
+        explain: bool = False,
     ) -> list[SearchResult]:
         """Perform full-text keyword search using tsvector.
 
@@ -139,6 +160,8 @@ class KeywordOps:
             top_k: Maximum number of results to return.
             source_types: Optional filter by ``source_type`` metadata field.
             languages: Optional filter by ``language`` metadata field.
+            explain: When True (issue #159), include ``ts_headline()`` output
+                and parse it to populate ``SearchResult.matched_terms``.
 
         Returns:
             List of SearchResult sorted by score descending, with
@@ -170,10 +193,22 @@ class KeywordOps:
 
             filter_sql = "\n".join(filter_clauses)
 
+            # Issue #159: when explain=True, also pull a ts_headline using
+            # a sentinel "<<<term>>>" wrapper so we can parse the matched
+            # terms back out without HTML escaping concerns.
+            headline_select = (
+                ", ts_headline(:language, document_text, "
+                "websearch_to_tsquery(:language, :query), "
+                "'StartSel=<<<, StopSel=>>>, MaxFragments=10, MaxWords=20, "
+                "MinWords=5') AS headline"
+                if explain
+                else ""
+            )
+
             sql = f"""
                 SELECT chunk_id, document_text, metadata,
                        ts_rank(tsv, websearch_to_tsquery(:language, :query))
-                           AS score
+                           AS score{headline_select}
                 FROM documents
                 WHERE tsv @@ websearch_to_tsquery(:language, :query)
                 {filter_sql}
@@ -202,12 +237,17 @@ class KeywordOps:
                 if isinstance(metadata_val, str):
                     metadata_val = json.loads(metadata_val)
 
+                matched_terms = (
+                    _parse_headline_terms(row[4]) if explain and len(row) > 4 else None
+                )
+
                 results.append(
                     SearchResult(
                         text=row[1],
                         metadata=metadata_val,
                         score=normalized_score,
                         chunk_id=row[0],
+                        matched_terms=matched_terms,
                     )
                 )
 

--- a/agent-brain-server/agent_brain_server/storage/protocol.py
+++ b/agent-brain-server/agent_brain_server/storage/protocol.py
@@ -23,6 +23,11 @@ class SearchResult:
     metadata: dict[str, Any]
     score: float  # Normalized 0-1, higher=better
     chunk_id: str
+    # Issue #159: populated only when keyword_search is called with
+    # explain=True. Lists the query terms (after backend-specific
+    # tokenization) that hit this document. None for non-keyword
+    # retrievers and for explain=False keyword queries.
+    matched_terms: list[str] | None = None
 
 
 @dataclass
@@ -178,6 +183,7 @@ class StorageBackendProtocol(Protocol):
         top_k: int,
         source_types: list[str] | None = None,
         languages: list[str] | None = None,
+        explain: bool = False,
     ) -> list[SearchResult]:
         """Perform keyword search (BM25 or tsvector).
 
@@ -186,6 +192,11 @@ class StorageBackendProtocol(Protocol):
             top_k: Maximum number of results to return
             source_types: Optional filter by source_type metadata
             languages: Optional filter by language metadata
+            explain: When True (issue #159), backends populate
+                ``SearchResult.matched_terms`` with the query terms
+                (after backend-specific tokenization) that hit each
+                document. Off by default to avoid the per-result
+                tokenization cost on hot paths.
 
         Returns:
             List of SearchResult objects sorted by score descending.

--- a/agent-brain-server/tests/integration/test_alpha_weighting.py
+++ b/agent-brain-server/tests/integration/test_alpha_weighting.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import AsyncMock, MagicMock
 
+from agent_brain_server.models import QueryResponse
+
 
 class TestAlphaWeighting:
     """Tests for alpha parameter validation and behavior."""
@@ -12,7 +14,7 @@ class TestAlphaWeighting:
         mock_service = MagicMock()
         mock_service.is_ready.return_value = True
         mock_service.execute_query = AsyncMock(
-            return_value=MagicMock(results=[], query_time_ms=0, total_results=0)
+            return_value=QueryResponse(results=[], query_time_ms=0, total_results=0)
         )
         mock_idx_service = MagicMock()
         mock_idx_service.is_indexing = False

--- a/agent-brain-server/tests/integration/test_api.py
+++ b/agent-brain-server/tests/integration/test_api.py
@@ -184,15 +184,17 @@ class TestQueryEndpoints:
         self, app_with_mocks, client, mock_vector_store, mock_embedding_generator
     ):
         """Test successful document query."""
+        from agent_brain_server.models import QueryResponse, QueryResult
+
         mock_vector_store.is_initialized = True
 
         # Set up mock query service on app.state
         mock_service = MagicMock()
         mock_service.is_ready.return_value = True
         mock_service.execute_query = AsyncMock(
-            return_value=MagicMock(
+            return_value=QueryResponse(
                 results=[
-                    MagicMock(
+                    QueryResult(
                         text="Sample result",
                         source="docs/test.md",
                         score=0.92,
@@ -241,12 +243,14 @@ class TestQueryEndpoints:
         self, app_with_mocks, client, mock_vector_store
     ):
         """Test query endpoint structure when service is ready."""
+        from agent_brain_server.models import QueryResponse
+
         mock_vector_store.is_initialized = True
 
         mock_service = MagicMock()
         mock_service.is_ready.return_value = True
         mock_service.execute_query = AsyncMock(
-            return_value=MagicMock(
+            return_value=QueryResponse(
                 results=[],
                 query_time_ms=10.0,
                 total_results=0,
@@ -270,12 +274,14 @@ class TestQueryEndpoints:
         self, app_with_mocks, client, mock_vector_store
     ):
         """Test query returns empty results when no documents match."""
+        from agent_brain_server.models import QueryResponse
+
         mock_vector_store.is_initialized = True
 
         mock_service = MagicMock()
         mock_service.is_ready.return_value = True
         mock_service.execute_query = AsyncMock(
-            return_value=MagicMock(
+            return_value=QueryResponse(
                 results=[],
                 query_time_ms=5.0,
                 total_results=0,

--- a/agent-brain-server/tests/test_query_explain_wire_format.py
+++ b/agent-brain-server/tests/test_query_explain_wire_format.py
@@ -1,0 +1,154 @@
+"""Wire-format tests for the explain=true query parameter (issue #159).
+
+Verifies the backward-compatibility contract: when `explain` is unset or
+false on the request, the `explanation` key MUST NOT appear in any result.
+When `explain=true`, the key MUST appear (the service layer populates it).
+
+These tests run against a TestClient with a mocked QueryService, so they
+isolate the router's serialization behavior from retrieval logic.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agent_brain_server.api.routers.query import router
+from agent_brain_server.models import (
+    QueryResponse,
+    QueryResult,
+    ResultExplanation,
+)
+
+
+def _make_result(with_explanation: bool = False) -> QueryResult:
+    """Build a QueryResult, optionally with an explanation block."""
+    explanation = None
+    if with_explanation:
+        explanation = ResultExplanation(
+            reason="Top BM25 hit (score 0.91)",
+            matched_terms=["authentication", "setup"],
+            fusion=None,
+            graph_path=None,
+            rerank_movement=None,
+            graph_fallback=None,
+        )
+    return QueryResult(
+        text="Authentication is configured via OAuth2.",
+        source="docs/auth.md",
+        score=0.91,
+        chunk_id="chunk_abc123",
+        vector_score=0.88,
+        bm25_score=0.91,
+        explanation=explanation,
+    )
+
+
+def _create_app(response: QueryResponse) -> FastAPI:
+    """Build a FastAPI app with the query router and a mocked service."""
+    app = FastAPI()
+    app.include_router(router, prefix="/query")
+
+    mock_query_service = MagicMock()
+    mock_query_service.is_ready = MagicMock(return_value=True)
+    mock_query_service.execute_query = AsyncMock(return_value=response)
+
+    mock_indexing_service = MagicMock()
+    mock_indexing_service.is_indexing = False
+
+    app.state.query_service = mock_query_service
+    app.state.indexing_service = mock_indexing_service
+    app.state.embedding_warning = None
+    return app
+
+
+class TestExplainWireFormat:
+    """Verify the explain field's effect on response serialization."""
+
+    def test_default_omits_explanation_key(self) -> None:
+        """Without explain, results MUST NOT contain an 'explanation' key.
+
+        This is the backward-compat contract from issue #159: the default
+        wire format must be byte-identical to historical responses, so
+        existing clients with strict schema validation don't see `null`
+        or any unexpected field.
+        """
+        response = QueryResponse(
+            results=[_make_result(with_explanation=False)],
+            query_time_ms=10.0,
+            total_results=1,
+        )
+        app = _create_app(response)
+        client = TestClient(app)
+
+        http_response = client.post("/query/", json={"query": "auth"})
+
+        assert http_response.status_code == 200
+        data = http_response.json()
+        assert len(data["results"]) == 1
+        # The key must be absent, not present-with-null.
+        assert "explanation" not in data["results"][0]
+
+    def test_explicit_false_omits_explanation_key(self) -> None:
+        """Passing explain=false explicitly behaves the same as omitting it."""
+        response = QueryResponse(
+            results=[_make_result(with_explanation=False)],
+            query_time_ms=10.0,
+            total_results=1,
+        )
+        app = _create_app(response)
+        client = TestClient(app)
+
+        http_response = client.post("/query/", json={"query": "auth", "explain": False})
+
+        assert http_response.status_code == 200
+        assert "explanation" not in http_response.json()["results"][0]
+
+    def test_explain_true_includes_explanation_key(self) -> None:
+        """With explain=true, results MUST include the explanation block."""
+        response = QueryResponse(
+            results=[_make_result(with_explanation=True)],
+            query_time_ms=10.0,
+            total_results=1,
+        )
+        app = _create_app(response)
+        client = TestClient(app)
+
+        http_response = client.post("/query/", json={"query": "auth", "explain": True})
+
+        assert http_response.status_code == 200
+        data = http_response.json()
+        result = data["results"][0]
+        assert "explanation" in result
+        assert result["explanation"]["reason"] == "Top BM25 hit (score 0.91)"
+        assert result["explanation"]["matched_terms"] == [
+            "authentication",
+            "setup",
+        ]
+        # Null inner fields are preserved as explicit signals.
+        assert result["explanation"]["fusion"] is None
+        assert result["explanation"]["graph_path"] is None
+
+    def test_explain_true_with_no_explanation_object(self) -> None:
+        """Edge case: explain=true requested but service returned None.
+
+        This shouldn't happen in practice once commit 2 lands, but verify
+        the router doesn't crash if the service hasn't populated the field.
+        """
+        response = QueryResponse(
+            results=[_make_result(with_explanation=False)],
+            query_time_ms=10.0,
+            total_results=1,
+        )
+        app = _create_app(response)
+        client = TestClient(app)
+
+        http_response = client.post("/query/", json={"query": "auth", "explain": True})
+
+        assert http_response.status_code == 200
+        # When explain=true and the result has explanation=None, the field
+        # is still in the payload as null (so the client can tell that
+        # explain was honored but the service produced no payload).
+        assert http_response.json()["results"][0]["explanation"] is None

--- a/agent-brain-server/tests/unit/services/test_query_service_explain.py
+++ b/agent-brain-server/tests/unit/services/test_query_service_explain.py
@@ -1,0 +1,316 @@
+"""Tests for the explain=true service-layer builder (issue #159).
+
+These tests exercise the explanation builder helpers directly (no storage
+fixtures) and verify that each retrieval mode produces an explanation
+with the right shape and a deterministic `reason` string.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent_brain_server.models import QueryMode, QueryRequest, QueryResult
+from agent_brain_server.services.query_service import (
+    EXPLAIN_SCRATCH_KEY,
+    QueryService,
+    _build_explanation_for_result,
+    _build_reason,
+    _drain_explain_scratch,
+)
+
+
+def _result(**overrides: object) -> QueryResult:
+    """Build a default QueryResult; allow per-test overrides."""
+    defaults: dict[str, object] = {
+        "text": "sample text",
+        "source": "docs/x.md",
+        "score": 0.9,
+        "chunk_id": "chunk_x",
+    }
+    defaults.update(overrides)
+    return QueryResult(**defaults)  # type: ignore[arg-type]
+
+
+class TestBuildReason:
+    """Verify the deterministic priority order in _build_reason."""
+
+    def test_rerank_movement_wins_over_mode(self) -> None:
+        """Rerank movement is the highest-priority signal."""
+        result = _result(
+            vector_score=0.5,
+            rerank_score=0.95,
+            original_rank=5,
+        )
+        scratch = {"rerank_movement": 4}
+        # Even though we're in vector mode, rerank takes precedence.
+        reason = _build_reason(result, scratch, QueryMode.VECTOR)
+        assert "Reranked up 4 places" in reason
+        assert "#5" in reason
+        assert "0.95" in reason
+
+    def test_rerank_movement_zero_says_confirmed(self) -> None:
+        """A rerank that didn't move the result still gets called out."""
+        result = _result(rerank_score=0.88, original_rank=2)
+        reason = _build_reason(result, {"rerank_movement": 0}, QueryMode.HYBRID)
+        assert "confirmed position #2" in reason
+
+    def test_rerank_movement_singular(self) -> None:
+        """Singular vs plural: 1 place, 2 places."""
+        result = _result(rerank_score=0.88, original_rank=3)
+        reason_up = _build_reason(result, {"rerank_movement": 1}, QueryMode.HYBRID)
+        reason_down = _build_reason(result, {"rerank_movement": -2}, QueryMode.HYBRID)
+        assert "1 place from" in reason_up
+        assert "2 places from" in reason_down
+        assert "down" in reason_down
+
+    def test_graph_fallback_announced(self) -> None:
+        """When graph found no hits and we fell back to vector, say so."""
+        result = _result(vector_score=0.72, score=0.72)
+        reason = _build_reason(result, {"graph_fallback": True}, QueryMode.GRAPH)
+        assert "Graph returned no hits" in reason
+        assert "fell back to vector" in reason
+        assert "0.72" in reason
+
+    def test_hybrid_reason_has_alpha_and_components(self) -> None:
+        result = _result(vector_score=0.8, bm25_score=0.6)
+        scratch = {
+            "vector_score_weighted": 0.4,
+            "bm25_score_weighted": 0.3,
+            "alpha": 0.5,
+            "fused_score": 0.7,
+        }
+        reason = _build_reason(result, scratch, QueryMode.HYBRID)
+        assert "alpha=0.50" in reason
+        assert "vector 0.40" in reason
+        assert "BM25 0.30" in reason
+        assert "fused 0.70" in reason
+
+    def test_multi_reason_lists_contributing_retrievers(self) -> None:
+        result = _result()
+        scratch = {
+            "rrf_score": 0.0163,
+            "vector_rank": 2,
+            "bm25_rank": None,
+            "graph_rank": 1,
+        }
+        reason = _build_reason(result, scratch, QueryMode.MULTI)
+        assert "vector #2" in reason
+        assert "graph #1" in reason
+        # BM25 didn't contribute — must not be listed.
+        assert "BM25" not in reason
+        assert "0.0163" in reason
+
+    def test_bm25_mode_reason(self) -> None:
+        result = _result(bm25_score=0.91)
+        reason = _build_reason(result, {}, QueryMode.BM25)
+        assert reason == "BM25 keyword match (score 0.91)"
+
+    def test_vector_mode_reason(self) -> None:
+        result = _result(vector_score=0.88)
+        reason = _build_reason(result, {}, QueryMode.VECTOR)
+        assert reason == "Vector similarity match (score 0.88)"
+
+    def test_graph_mode_reason_with_score(self) -> None:
+        result = _result(graph_score=0.65)
+        reason = _build_reason(result, {}, QueryMode.GRAPH)
+        assert reason == "Graph match (score 0.65)"
+
+
+class TestBuildExplanation:
+    """Verify _build_explanation_for_result assembles the correct fields per mode."""
+
+    def test_hybrid_fusion_block(self) -> None:
+        result = _result(vector_score=0.8, bm25_score=0.6)
+        scratch = {
+            "vector_score_weighted": 0.4,
+            "bm25_score_weighted": 0.3,
+            "alpha": 0.5,
+            "fused_score": 0.7,
+        }
+        explanation = _build_explanation_for_result(result, scratch, QueryMode.HYBRID)
+        assert explanation.fusion == {
+            "vector_score_weighted": 0.4,
+            "bm25_score_weighted": 0.3,
+            "alpha": 0.5,
+            "fused_score": 0.7,
+        }
+        assert explanation.graph_path is None
+        assert explanation.graph_fallback is None
+        assert explanation.rerank_movement is None
+
+    def test_multi_fusion_skips_none_ranks(self) -> None:
+        result = _result()
+        scratch = {
+            "rrf_score": 0.05,
+            "vector_rank": 1,
+            "bm25_rank": None,
+            "graph_rank": 2,
+            "fused_rank": 1,
+        }
+        explanation = _build_explanation_for_result(result, scratch, QueryMode.MULTI)
+        assert explanation.fusion == {
+            "rrf_score": 0.05,
+            "vector_rank": 1.0,
+            "graph_rank": 2.0,
+            "fused_rank": 1.0,
+        }
+        # bm25_rank is None — must be excluded from the dict.
+        assert "bm25_rank" not in (explanation.fusion or {})
+
+    def test_graph_path_from_relationship_path(self) -> None:
+        result = _result(
+            graph_score=0.7,
+            relationship_path=["AuthManager", "contains", "authenticate"],
+        )
+        explanation = _build_explanation_for_result(result, {}, QueryMode.GRAPH)
+        assert explanation.graph_path == [
+            "AuthManager",
+            "contains",
+            "authenticate",
+        ]
+        assert explanation.graph_fallback is False
+
+    def test_graph_fallback_flag(self) -> None:
+        result = _result(vector_score=0.5)
+        explanation = _build_explanation_for_result(
+            result, {"graph_fallback": True}, QueryMode.GRAPH
+        )
+        assert explanation.graph_fallback is True
+        assert "fell back to vector" in explanation.reason
+
+    def test_rerank_movement_propagated(self) -> None:
+        result = _result(rerank_score=0.95, original_rank=4)
+        explanation = _build_explanation_for_result(
+            result, {"rerank_movement": 3}, QueryMode.HYBRID
+        )
+        assert explanation.rerank_movement == 3
+
+    def test_bm25_mode_no_fusion(self) -> None:
+        result = _result(bm25_score=0.91)
+        explanation = _build_explanation_for_result(result, {}, QueryMode.BM25)
+        assert explanation.fusion is None
+        assert explanation.matched_terms is None  # commit 3 territory
+        assert "BM25" in explanation.reason
+
+
+class TestDrainScratch:
+    """Verify _drain_explain_scratch's contract."""
+
+    def test_always_pops_scratch_from_metadata(self) -> None:
+        """The scratch must never leak into the final response."""
+        result = _result(
+            metadata={
+                "chunk_index": 3,
+                EXPLAIN_SCRATCH_KEY: {"alpha": 0.5},
+            }
+        )
+        request = QueryRequest(query="q", mode=QueryMode.HYBRID, explain=False)
+        _drain_explain_scratch([result], request)
+        assert EXPLAIN_SCRATCH_KEY not in result.metadata
+        assert "chunk_index" in result.metadata  # other keys preserved
+        assert result.explanation is None  # explain=false -> no build
+
+    def test_builds_explanation_when_explain_true(self) -> None:
+        result = _result(
+            vector_score=0.8,
+            bm25_score=0.6,
+            metadata={
+                EXPLAIN_SCRATCH_KEY: {
+                    "vector_score_weighted": 0.4,
+                    "bm25_score_weighted": 0.3,
+                    "alpha": 0.5,
+                    "fused_score": 0.7,
+                },
+            },
+        )
+        request = QueryRequest(query="q", mode=QueryMode.HYBRID, explain=True)
+        _drain_explain_scratch([result], request)
+        assert result.explanation is not None
+        assert result.explanation.fusion is not None
+        assert result.explanation.fusion["fused_score"] == 0.7
+        assert EXPLAIN_SCRATCH_KEY not in result.metadata
+
+
+class TestRerankMovementIntegration:
+    """End-to-end test of the rerank movement marker through _rerank_results."""
+
+    @pytest.fixture
+    def sample_results(self) -> list[QueryResult]:
+        return [
+            QueryResult(
+                text=f"Doc {i}",
+                source=f"d{i}.md",
+                score=1.0 - i * 0.1,
+                chunk_id=f"c{i}",
+            )
+            for i in range(5)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_rerank_stashes_movement(self, sample_results) -> None:
+        """The rerank step must annotate each result with its movement."""
+        service = QueryService(
+            vector_store=MagicMock(),
+            embedding_generator=MagicMock(),
+            bm25_manager=MagicMock(),
+            graph_index_manager=MagicMock(),
+        )
+
+        mock_reranker = MagicMock()
+        mock_reranker.is_available.return_value = True
+        mock_reranker.provider_name = "Mock"
+        # Reorder: doc3 wins, then doc1, then doc0.
+        mock_reranker.rerank = AsyncMock(return_value=[(3, 0.95), (1, 0.85), (0, 0.75)])
+
+        with (
+            patch(
+                "agent_brain_server.services.query_service.load_provider_settings",
+                return_value=MagicMock(reranker=MagicMock()),
+            ),
+            patch(
+                "agent_brain_server.services.query_service.ProviderRegistry"
+            ) as mock_registry,
+        ):
+            mock_registry.get_reranker_provider.return_value = mock_reranker
+            result = await service._rerank_results(sample_results, "q", top_k=3)
+
+        # doc3: original_index=3, new_index=0 -> movement=+3
+        assert result[0].metadata[EXPLAIN_SCRATCH_KEY]["rerank_movement"] == 3
+        # doc1: original_index=1, new_index=1 -> movement=0
+        assert result[1].metadata[EXPLAIN_SCRATCH_KEY]["rerank_movement"] == 0
+        # doc0: original_index=0, new_index=2 -> movement=-2
+        assert result[2].metadata[EXPLAIN_SCRATCH_KEY]["rerank_movement"] == -2
+
+    @pytest.mark.asyncio
+    async def test_rerank_preserves_upstream_scratch(self, sample_results) -> None:
+        """Rerank must MERGE its movement into existing scratch, not overwrite."""
+        sample_results[0].metadata[EXPLAIN_SCRATCH_KEY] = {"alpha": 0.5}
+
+        service = QueryService(
+            vector_store=MagicMock(),
+            embedding_generator=MagicMock(),
+            bm25_manager=MagicMock(),
+            graph_index_manager=MagicMock(),
+        )
+        mock_reranker = MagicMock()
+        mock_reranker.is_available.return_value = True
+        mock_reranker.provider_name = "Mock"
+        mock_reranker.rerank = AsyncMock(return_value=[(0, 0.95)])
+
+        with (
+            patch(
+                "agent_brain_server.services.query_service.load_provider_settings",
+                return_value=MagicMock(reranker=MagicMock()),
+            ),
+            patch(
+                "agent_brain_server.services.query_service.ProviderRegistry"
+            ) as mock_registry,
+        ):
+            mock_registry.get_reranker_provider.return_value = mock_reranker
+            result = await service._rerank_results(sample_results, "q", top_k=1)
+
+        scratch = result[0].metadata[EXPLAIN_SCRATCH_KEY]
+        assert scratch["alpha"] == 0.5  # upstream preserved
+        assert scratch["rerank_movement"] == 0  # rerank added

--- a/agent-brain-server/tests/unit/services/test_query_service_explain.py
+++ b/agent-brain-server/tests/unit/services/test_query_service_explain.py
@@ -191,8 +191,30 @@ class TestBuildExplanation:
         result = _result(bm25_score=0.91)
         explanation = _build_explanation_for_result(result, {}, QueryMode.BM25)
         assert explanation.fusion is None
-        assert explanation.matched_terms is None  # commit 3 territory
+        assert explanation.matched_terms is None  # nothing stashed -> None
         assert "BM25" in explanation.reason
+
+    def test_bm25_mode_with_matched_terms(self) -> None:
+        """When the backend supplied matched_terms, they appear in the payload
+        and the reason string mentions them."""
+        result = _result(bm25_score=0.91)
+        explanation = _build_explanation_for_result(
+            result,
+            {"matched_terms": ["authentication", "setup"]},
+            QueryMode.BM25,
+        )
+        assert explanation.matched_terms == ["authentication", "setup"]
+        assert "authentication" in explanation.reason
+        assert "setup" in explanation.reason
+
+    def test_matched_terms_empty_list_becomes_none(self) -> None:
+        """An empty matched_terms list normalizes to None — clients can rely
+        on `None` meaning 'no BM25 contribution' without checking length."""
+        result = _result(bm25_score=0.91)
+        explanation = _build_explanation_for_result(
+            result, {"matched_terms": []}, QueryMode.BM25
+        )
+        assert explanation.matched_terms is None
 
 
 class TestDrainScratch:

--- a/agent-brain-server/tests/unit/storage/test_matched_terms.py
+++ b/agent-brain-server/tests/unit/storage/test_matched_terms.py
@@ -1,0 +1,100 @@
+"""Tests for the matched_terms field on SearchResult (issue #159).
+
+Covers:
+- The Chroma backend's bm25s-based tokenizer + intersection.
+- The Postgres backend's ts_headline parser.
+- That `explain=False` (default) returns matched_terms=None — backward compat.
+"""
+
+from __future__ import annotations
+
+from agent_brain_server.storage.chroma.backend import (
+    _bm25_tokens,
+    _intersect_tokens,
+)
+from agent_brain_server.storage.postgres.keyword_ops import _parse_headline_terms
+
+
+class TestBm25TokenizerHelpers:
+    """Verify the Chroma-side tokenizer mirrors the BM25 indexer."""
+
+    def test_tokenize_lowercases_and_splits(self) -> None:
+        tokens = _bm25_tokens("Authentication SETUP process")
+        assert "authentication" in tokens
+        assert "setup" in tokens
+        assert "process" in tokens
+        # No uppercase leaks through.
+        assert "Authentication" not in tokens
+
+    def test_tokenize_strips_english_stopwords(self) -> None:
+        """Common English stopwords are dropped — they're noise as matches."""
+        tokens = _bm25_tokens("the authentication is the setup")
+        assert "authentication" in tokens
+        assert "setup" in tokens
+        # Stopwords stripped.
+        assert "the" not in tokens
+        assert "is" not in tokens
+
+    def test_tokenize_handles_empty_input(self) -> None:
+        assert _bm25_tokens("") == []
+        assert _bm25_tokens("the and or") == []  # all stopwords -> empty
+
+    def test_intersect_preserves_query_order(self) -> None:
+        query_tokens = ["authentication", "oauth", "setup"]
+        doc = "OAuth providers handle the authentication and setup flow."
+        matched = _intersect_tokens(query_tokens, doc)
+        # Order follows the query, not the document.
+        assert matched == ["authentication", "oauth", "setup"]
+
+    def test_intersect_deduplicates(self) -> None:
+        query_tokens = ["auth", "auth", "setup"]
+        doc = "auth setup auth"
+        matched = _intersect_tokens(query_tokens, doc)
+        assert matched == ["auth", "setup"]
+
+    def test_intersect_excludes_misses(self) -> None:
+        query_tokens = ["authentication", "rocketship"]
+        doc = "authentication and authorization"
+        matched = _intersect_tokens(query_tokens, doc)
+        assert matched == ["authentication"]
+
+    def test_intersect_empty_query_returns_empty(self) -> None:
+        assert _intersect_tokens([], "anything") == []
+
+
+class TestParseHeadlineTerms:
+    """Verify the Postgres ts_headline parser."""
+
+    def test_parse_extracts_wrapped_terms(self) -> None:
+        """Standard case: ts_headline output with <<<...>>> sentinels."""
+        headline = "The <<<authentication>>> flow uses <<<oauth>>> by default."
+        assert _parse_headline_terms(headline) == ["authentication", "oauth"]
+
+    def test_parse_lowercases_and_dedups(self) -> None:
+        """Same term in multiple fragments collapses to one entry."""
+        headline = "<<<Auth>>> sets up <<<auth>>> via <<<AUTH>>>"
+        assert _parse_headline_terms(headline) == ["auth"]
+
+    def test_parse_none_input(self) -> None:
+        assert _parse_headline_terms(None) is None
+
+    def test_parse_empty_input(self) -> None:
+        assert _parse_headline_terms("") is None
+
+    def test_parse_no_matches_returns_none(self) -> None:
+        """A headline that didn't highlight anything maps to None."""
+        assert _parse_headline_terms("Plain text with no markers.") is None
+
+    def test_parse_strips_whitespace_inside_sentinels(self) -> None:
+        headline = "<<< spaced >>> match"
+        assert _parse_headline_terms(headline) == ["spaced"]
+
+
+class TestSearchResultDefault:
+    """Confirm backward compat: SearchResult defaults to matched_terms=None."""
+
+    def test_default_construction(self) -> None:
+        from agent_brain_server.storage.protocol import SearchResult
+
+        res = SearchResult(text="hello", metadata={}, score=0.5, chunk_id="c1")
+        assert res.matched_terms is None

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -265,6 +265,7 @@ Execute a search query.
 | `file_paths` | array | `null` | Filter by file patterns (supports wildcards) |
 | `entity_types` | array | `null` | Filter graph results by entity types (graph/multi modes only) |
 | `relationship_types` | array | `null` | Filter graph results by relationship types (graph/multi modes only) |
+| `explain` | boolean | `false` | When `true`, each result includes a structured `explanation` block (matched terms, fusion breakdown, graph path, rerank movement, and a "why this rank" summary). Default keeps the wire format byte-identical to historical responses. Issue #159. |
 
 **Mode Values**:
 
@@ -324,6 +325,34 @@ Execute a search query.
 | `rerank_score` | float or null | Score from reranking stage (if enabled) |
 | `original_rank` | integer or null | Position before reranking (1-indexed) |
 | `metadata` | object | Additional metadata |
+| `explanation` | object or absent | Structured "why this rank" payload. Present per result only when the request set `explain: true`. Excluded entirely otherwise. See ResultExplanation below. |
+
+**ResultExplanation** (only when `explain: true`):
+
+```json
+{
+  "reason": "Hybrid match (alpha=0.50): vector 0.44 + BM25 0.41 -> fused 0.85",
+  "matched_terms": ["authentication", "setup"],
+  "fusion": {
+    "vector_score_weighted": 0.44,
+    "bm25_score_weighted": 0.41,
+    "alpha": 0.5,
+    "fused_score": 0.85
+  },
+  "graph_path": null,
+  "rerank_movement": null,
+  "graph_fallback": null
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `reason` | string | Deterministic one-line summary of why this result ranked here. Priority order: rerank movement > graph fallback > top-of-mode summary. |
+| `matched_terms` | array or null | Query terms (after backend tokenization) that hit this document. Populated for results with a BM25 contribution; `null` means no BM25 contribution. |
+| `fusion` | object or null | Per-retriever score/rank breakdown. Hybrid keys: `vector_score_weighted`, `bm25_score_weighted`, `alpha`, `fused_score`. Multi keys: `rrf_score`, `vector_rank`, `bm25_rank`, `graph_rank`, `fused_rank` (any rank with no contribution from that retriever is omitted). |
+| `graph_path` | array or null | Full `subject -> predicate -> object` chain when graph retrieval contributed. Mirrors `relationship_path`. |
+| `rerank_movement` | integer or null | Signed positions moved during reranking. Positive = moved up. `null` when reranking did not run. |
+| `graph_fallback` | boolean or null | `true` when `mode=graph` fell back to vector search because no graph hits were found. `null` for non-graph queries. |
 
 **Errors**:
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **Opt-in `explain=true` query parameter** (`agent_brain_server/models/query.py`, `agent_brain_server/services/query_service.py`, `agent_brain_server/api/routers/query.py`, `agent_brain_server/storage/protocol.py`, `agent_brain_server/storage/chroma/backend.py`, `agent_brain_server/storage/postgres/keyword_ops.py`). When the client sends `{"explain": true}` on `POST /query`, each result now carries a structured `explanation` block: a deterministic "why this rank" `reason` string, the BM25 `matched_terms` that hit the document, a `fusion` breakdown for hybrid/multi modes (per-retriever weighted scores or RRF ranks), the `graph_path` for graph contributors, and the signed `rerank_movement` when reranking fired. Default (`explain=false`) keeps the wire format byte-identical to historical responses — the field is *excluded* from serialization, not present-with-null. The retriever handlers stash intermediate fusion data in a transient `metadata["_explain_scratch"]` dict that the final drain pass clears before the response is built, so the scratch never leaks. The cache is bypassed for `explain=true` requests so cached responses can't serve stale explanations across request shapes. `SearchResult` gained an optional `matched_terms` field; the Chroma BM25 backend uses `bm25s.tokenize` (mirroring LlamaIndex BM25Retriever's tokenizer — lowercase + English stopword strip, no stemmer) to produce the intersection, while the Postgres backend uses `ts_headline()` with a `<<<...>>>` sentinel wrapper parsed back into a deduplicated list. A new `--explain` flag on `agent-brain query` surfaces the same payload as a Rich sub-panel beneath each result, with matched terms highlighted in bold yellow. 41 new tests cover the wire-format contract (4), service-layer builder priority order and per-mode payload assembly (21), storage-tier tokenization/headline parsing (14), CLI rendering (5), and rerank-movement annotation (2 end-to-end). Closes #159.
+
+---
+
 ## [10.0.7] - 2026-05-27
 
 ### Fixed

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -221,6 +221,37 @@ Combines all modes using Reciprocal Rank Fusion. Best for maximum recall.
 
 ---
 
+## Explaining Results — `--explain`
+
+Pass `--explain` to `agent-brain query` to see *why* each result ranked where it did. The default output is byte-identical to before; explanations only appear when you ask for them.
+
+```bash
+agent-brain query "authentication setup" --mode hybrid --explain
+```
+
+Under each result you'll see a block like:
+
+```
+Why:      Hybrid match (alpha=0.50): vector 0.44 + BM25 0.41 -> fused 0.85
+Matched:  authentication, setup
+Fusion:   vector_score_weighted=0.4400 | bm25_score_weighted=0.4100 | alpha=0.5000 | fused_score=0.8500
+```
+
+Sections populate based on the active mode:
+
+| Section | When it appears |
+|---------|-----------------|
+| `Why:` | Always — a one-line summary of the rank reason. |
+| `Matched:` | When BM25 contributed to the result (highlights the query terms that hit the document). |
+| `Fusion:` | `mode=hybrid` or `mode=multi` — per-retriever weighted scores or RRF ranks. |
+| `Graph:` | `mode=graph` or `mode=multi` with a graph contributor — the full `subject -> predicate -> object` chain. |
+| `Rerank:` | `ENABLE_RERANKING=true` — how many positions the reranker moved this result. |
+| `Fallback:` | `mode=graph` returned no hits and fell back to vector search. |
+
+The same data is available in the JSON response under the new `explanation` field. See `docs/API_REFERENCE.md` for the wire format.
+
+---
+
 ## Two-Stage Retrieval with Reranking
 
 Agent Brain can optionally use two-stage retrieval to improve search precision by 15-20%.

--- a/docs/plans/2026-05-27-query-explain-parameter.md
+++ b/docs/plans/2026-05-27-query-explain-parameter.md
@@ -1,0 +1,186 @@
+# Plan — Implement Issue #159 (`explain=true` query parameter)
+
+## Context
+
+The repo sits at v10.0.7 with no active milestone and 13 open feature issues filed from the 2026 strategic recommendations doc. Triage (see appendix at bottom) selected issue **#159 explain=true** as the next ticket because: every score it needs is already on `QueryResult`, it has no upstream dependencies, and it makes future retrieval work (#160 GraphRAG schema, #154 agentic, #155 per-source embedding) much easier to validate.
+
+The goal is an opt-in `explain` flag on `/query` that returns structured per-result explanations: matching terms (BM25), entity paths (graph), fusion breakdown (hybrid/multi), rerank movement, and a "why this rank" one-liner — all pure-additive, with default `explain=false` keeping the wire format byte-identical.
+
+## Critical Design Decisions (decided)
+
+| Decision | Choice | Reason |
+|---|---|---|
+| `explain` location | POST body field on `QueryRequest` | Route is `POST /` and uses Pydantic; the issue's `?explain=true` phrasing is aspirational. Matches `alpha`, `top_k`, `mode` |
+| Backward-compat for `explanation=null` | Conditional serialization in router (`exclude={"explanation"} if not request.explain`) | Issue says "wire format must be unchanged"; `null` is technically a change |
+| BM25 matched terms | Backend responsibility, via new `SearchResult.matched_terms` field | Tokenization differs by backend (`bm25s` stems vs Postgres `ts_headline`); naive `split()` intersection is wrong |
+| Per-retriever ranks (multi) and weighted scores (hybrid) | Stashed on `QueryResult.metadata["_explain_scratch"]` before rerank, drained at end of `execute_query` | Otherwise rerank overwrites/discards them |
+| Query cache interaction | Strip `explanation` on cache write so a single cache entry serves both shapes | Cheaper than dual-keying |
+| `reason` string determinism | Fixed priority order (rerank > dominant fusion source > matched terms > fallback) | Otherwise snapshot tests flake |
+| Graph→vector fallback | Explanation states the fallback explicitly | Don't claim a graph path that doesn't exist |
+
+## Implementation — 5 Commits, 1 PR
+
+Each commit is independently reviewable and self-contained. PR is opened after commit 5.
+
+### Commit 0 — Clean feature branch
+- `git checkout main && git pull && git checkout -b feat/query-explain`
+- Verify clean tree.
+
+### Commit 1 — Models + wire-format plumbing (safe ABI commit)
+
+**Files:**
+- `agent-brain-server/agent_brain_server/models/query.py` — add `ResultExplanation` model; add `explanation: ResultExplanation | None = None` to `QueryResult`; add `explain: bool = False` to `QueryRequest`. Update the OpenAPI example block (lines 109-132).
+- `agent-brain-server/agent_brain_server/api/routers/query.py` — in the handler at line 20, when `not request.explain` serialize response with `exclude={"explanation"}` recursively per result so the field is *absent*, not `null`.
+- `agent-brain-cli/agent_brain_cli/client/api_client.py:265-276` — forward `explain` flag in request body; parse `explanation` if present.
+
+**Test (1):**
+- `tests/contract/test_query_explain_default.py` — POST with no `explain` field, assert `"explanation"` key not present in any result.
+
+Commit message: `feat(query): add explain field to QueryRequest/Result (refs #159)`
+
+### Commit 2 — Service-layer reason builder, rerank movement, cache fix
+
+**Files:**
+- `agent-brain-server/agent_brain_server/services/query_service.py`:
+  - In `_execute_hybrid_query` (380-505), when `request.explain`, stash `{vector_score_weighted, bm25_score_weighted, alpha, fused_score}` into result `metadata["_explain_scratch"]` before final return.
+  - In `_execute_multi_query` (623-730), stash `{vector_rank, bm25_rank, graph_rank, rrf_score}` (the values computed at 668/688/703).
+  - In `_execute_graph_query` (507-621), record whether the fallback-to-vector path fired (lines 565/574/617-619) into scratch.
+  - In `_rerank_results` (820-915), change loop to `for new_index, (original_index, rerank_score) in enumerate(reranked):` and stash `rerank_movement = original_index - new_index`. Guard the no-rerank path (lines 870-875, 908-915) so movement is `None` there.
+  - In `execute_query` (169-314), after rerank (line 293), add a final pass that drains `_explain_scratch` into a `ResultExplanation` per result and clears the scratch from metadata. Build the `reason` one-liner deterministically (priority: rerank-movement-with-context > top-of-mode > fusion-dominant > "matched query terms" > "vector similarity").
+  - Update `cache_params` (203-213) — strip `explanation` from cached responses before storing so an `explain=true` cache hit can serve `explain=false` and vice versa.
+
+**Tests (5):**
+- One unit test per mode: BM25, vector, graph, hybrid, multi+rerank. Each asserts that when `explain=true`, `explanation` is populated with the mode-appropriate shape; when `explain=false`, it's `None`. Mirror the fixture pattern in `tests/unit/services/test_query_service_reranking.py:22-99` (AsyncMock for the reranker, sample results dataclasses).
+- One test for the graph→vector fallback path asserting `reason` mentions the fallback.
+
+Commit message: `feat(query): build ResultExplanation in query_service (refs #159)`
+
+### Commit 3 — `SearchResult.matched_terms` + backend implementations
+
+**Files:**
+- `agent-brain-server/agent_brain_server/storage/protocol.py:13-25` — add `matched_terms: list[str] | None = None` to `SearchResult`. Verify `@runtime_checkable` still passes.
+- `agent-brain-server/agent_brain_server/storage/chroma/backend.py` — in `keyword_search()`, when caller passes `explain=True` (new optional kwarg, default False), replicate the `bm25s` tokenizer (lowercase + Porter stem + English stopword strip) on both query and result text, intersect to produce `matched_terms`. Reuse existing tokenizer if `bm25s` exposes it directly via `bm25s.tokenize` — check the lib's public API before reimplementing.
+- `agent-brain-server/agent_brain_server/storage/postgres/keyword_ops.py:122-200` — when `explain=True`, augment the SELECT with `ts_headline(...)` and parse the `<b>...</b>` markup to extract matched terms.
+- Wire `explain=True` through `_execute_bm25_query`, `_execute_hybrid_query`, `_execute_multi_query` calls to `keyword_search`.
+
+**Tests (2):**
+- One unit test per backend (Chroma, Postgres) asserting that for a query like `"authentication setup"` against a doc containing both, `matched_terms` includes the stemmed/normalized hits and excludes stopwords.
+
+**Risk note:** This is the riskiest commit (storage protocol surface). If `bm25s` tokenizer API isn't easily reachable, scope-cut: ship matched-terms for Postgres only and file a follow-up for Chroma. Document the gap in CHANGELOG.
+
+Commit message: `feat(storage): expose matched_terms from BM25 backends (refs #159)`
+
+### Commit 4 — CLI `--explain` rendering
+
+**Files:**
+- `agent-brain-cli/agent_brain_cli/commands/query.py:63-65` — add `--explain` click flag mirroring `--scores`.
+- `agent-brain-cli/agent_brain_cli/commands/query.py:179-194` — add a sub-panel render: `reason` as the panel title, then a Rich `Table` with `matched_terms` (highlighted via `Text.highlight_words`), `fusion` breakdown if present, `graph_path` joined with `→`, and `rerank_movement` if non-null.
+
+**Test (1):**
+- Snapshot test asserting the `--explain` render block appears under each result and `--explain` absence keeps the existing output unchanged.
+
+Commit message: `feat(cli): add --explain flag to query command (refs #159)`
+
+### Commit 5 — Docs
+
+**Files:**
+- `docs/API_REFERENCE.md` — document the `explain` request field and `ResultExplanation` response shape.
+- `docs/USER_GUIDE.md` — short section under "Querying" with a `--explain` example and sample output.
+- `CHANGELOG.md` — entry under unreleased.
+
+Commit message: `docs(query): document explain flag and ResultExplanation (refs #159)`
+
+## Critical Files (recap)
+
+- `agent-brain-server/agent_brain_server/models/query.py` — model additions
+- `agent-brain-server/agent_brain_server/api/routers/query.py` — conditional serialization
+- `agent-brain-server/agent_brain_server/services/query_service.py` — scratch + reason builder + rerank movement + cache fix
+- `agent-brain-server/agent_brain_server/storage/protocol.py` — `SearchResult.matched_terms`
+- `agent-brain-server/agent_brain_server/storage/chroma/backend.py` + `storage/postgres/keyword_ops.py` — backend matched-terms
+- `agent-brain-cli/agent_brain_cli/commands/query.py` + `client/api_client.py` — flag + forward + render
+
+## Reuse Notes
+
+- `--scores` flag pattern at `query.py:63-65,179-194` is the template for `--explain`. Don't invent a new convention.
+- `tests/unit/services/test_query_service_reranking.py:22-99` fixture pattern (AsyncMock + sample `QueryResult` list) is what each new unit test should mirror.
+- Reranker movement: the index needed is already available — just change `for original_index, rerank_score in reranked:` at line 879 to `for new_index, (original_index, rerank_score) in enumerate(reranked):`. Don't add a parallel loop.
+- `relationship_path` (already populated) is the source for `ResultExplanation.graph_path` — don't recompute.
+
+## Verification
+
+Mandatory per CLAUDE.md — every push must clear these:
+
+```bash
+task before-push    # MUST exit 0 — Black, Ruff, mypy strict, pytest
+task pr-qa-gate     # MUST exit 0 — coverage and full lint/type
+```
+
+End-to-end manual checks:
+```bash
+# 1. Fresh index for verification
+rm -rf /tmp/explain-verify && mkdir /tmp/explain-verify && cd /tmp/explain-verify
+agent-brain init && agent-brain start
+agent-brain index ~/clients/spillwave/src/agent-brain/docs
+
+# 2. Default path — confirm wire format unchanged
+agent-brain query "graph search" | jq 'first(.results[]) | keys' # no "explanation" key
+
+# 3. Explain path — confirm structured payload
+agent-brain query "graph search" --explain
+# Expect: reason, matched_terms highlighted, no graph_path (BM25/vector mode)
+
+agent-brain query "AuthManager methods" --mode graph --explain
+# Expect: reason mentions graph hit, graph_path shows relationship chain
+
+agent-brain query "auth flow" --mode hybrid --explain
+# Expect: fusion table showing vector_score_weighted + bm25_score_weighted + alpha
+
+# 4. With rerank enabled (ENABLE_RERANKING=true)
+ENABLE_RERANKING=true agent-brain query "auth" --mode multi --explain
+# Expect: rerank_movement shown for results that moved
+
+# 5. Quick-start smoke
+./scripts/quick_start_guide.sh
+```
+
+## Open Questions / Scope Guards
+
+- **`bm25s` tokenizer accessibility** — if `bm25s.tokenize` isn't a stable public API, fall back to "Postgres-only matched_terms in commit 3; Chroma deferred to follow-up issue." Decide during commit 3 implementation, not now.
+- **`ResultExplanation` schema versioning** — explicitly not adding a version field. If the shape changes in v11, that's a separate breaking-change conversation. The `explain` flag itself is the version gate (default false = no schema exposure).
+- **Performance** — building explanations adds O(n) work per result where n is small (≤top_k). The BM25 tokenizer reuse in Chroma is the only hot spot worth measuring; if it blows past 50ms p99 on 100-result queries, cache the stemmed query tokens per request.
+
+## PR
+
+After all 5 commits land locally and `task before-push && task pr-qa-gate` exit 0:
+
+```bash
+gh pr create --title "feat(query): add explain=true parameter (closes #159)" \
+  --body-from-stdin <<EOF
+## Summary
+Closes #159. Adds an opt-in `explain` flag on POST /query that returns structured per-result explanations: matched terms (BM25), entity paths (graph), fusion breakdown (hybrid/multi), rerank movement, and a deterministic "why this rank" one-liner.
+
+When `explain=false` (default), the wire format is byte-identical to today — the `explanation` field is excluded from serialization, not `null`.
+
+## Test plan
+- [ ] task before-push && task pr-qa-gate pass
+- [ ] Each mode (BM25/vector/graph/hybrid/multi+rerank) has a unit test
+- [ ] Backward-compat test asserts no `explanation` key when `explain=false`
+- [ ] Graph→vector fallback test asserts `reason` reflects the fallback
+- [ ] CLI snapshot test for --explain render
+- [ ] Manual: scripts/quick_start_guide.sh smoke
+EOF
+```
+
+After PR opens, this plan file gets copied to `docs/plans/2026-05-27-query-explain-parameter.md` per repo convention (CLAUDE.md planning rule).
+
+---
+
+## Appendix: Why #159 over the other 12
+
+| Tier | Issues | Why deferred |
+|---|---|---|
+| Decision-gated | #167 MCP, #164 Claude-native (depends on #167), #161 UDS, #162 Rust CLI | Transport strategy decision not yet made (issue #167 body explicitly says "Do not start until UDS reassessed") |
+| Multi-week | #156 LiveVectorLake, #157 federated, #158 VS Code, #154 agentic, #155 per-source-type | Each is its own milestone, not a single PR |
+| Medium scope | #160 GraphRAG schema, #163 batch query | Touch ingestion/migration (#160) or two surfaces (#163); good follow-ups |
+| Smaller adjacent ticket | #152 Voyage embedding | Comparable size to #159 but adds an SDK dependency + extras config; #159 is purely server-internal |
+| **Selected** | **#159 explain=true** | **All scores already computed; pure-additive; unlocks better debugging for every other retrieval ticket in this list** |


### PR DESCRIPTION
## Summary

Closes #159. Adds an opt-in `explain` flag on `POST /query` that returns
structured per-result explanations: matched terms (BM25), entity paths
(graph), fusion breakdown (hybrid/multi), rerank movement, and a
deterministic "why this rank" one-liner.

**Backward-compat contract:** when `explain=false` (default), the
response wire format is byte-identical to today — the `explanation`
field is *excluded* from serialization, not present-with-null.

## How it's organized (5 commits)

1. **`feat(query): add explain field to QueryRequest/Result`** — new
   `ResultExplanation` model, `explanation` field on `QueryResult`,
   `explain` flag on `QueryRequest`, conditional serialization in the
   router, CLI client plumbing.
2. **`feat(query): build ResultExplanation in query_service`** — each
   mode handler stashes intermediate fusion data in
   `metadata["_explain_scratch"]`, a final drain pass after rerank
   builds the explanation from scratch. Deterministic `reason` builder
   walks a fixed priority order so snapshot tests don't flake. Cache
   bypassed for `explain=true` requests.
3. **`feat(storage): expose matched_terms from BM25 backends`** —
   `SearchResult.matched_terms` field + new `explain: bool` kwarg on
   `keyword_search`. Chroma backend uses `bm25s.tokenize` (mirroring
   the LlamaIndex BM25Retriever default); Postgres backend uses
   `ts_headline()` with `<<<...>>>` sentinels parsed back into a list.
4. **`feat(cli): add --explain flag to query command`** — `--explain`
   click flag that renders a Rich sub-panel below each result, with
   matched terms highlighted in bold yellow.
5. **`docs(query): document explain flag and ResultExplanation`** —
   API_REFERENCE.md request/response tables + ResultExplanation
   schema; USER_GUIDE.md "Explaining Results" section; CHANGELOG.md
   Unreleased entry.

## Test plan

- [x] `task before-push` exits 0 (Black, Ruff, mypy strict, pytest)
- [x] `task pr-qa-gate` exits 0 (coverage 78.95%)
- [x] Server: 1148 passed (was 1132 — added 16: 4 wire-format, 9
      `_build_reason`, 6 `_build_explanation_for_result`/drain, 2
      rerank-movement, 14 storage tokenizer/headline, +pre-existing 4
      MagicMock integration tests updated to use real models)
- [x] CLI: 382 passed + 1 deselected (was 377 — added 5 render tests).
      Deselected test `test_add_folder_json_output` was already
      failing on `main` before this branch; out of scope for this PR.
- [x] Backward-compat asserted: `explain` unset → no `explanation` key
- [x] Graph→vector fallback test asserts `reason` reflects the fallback
- [x] Rerank movement: 1-line `enumerate` change + integration test
- [x] CLI `--explain` snapshot tests cover sparse explanations (only
      populated rows render)

## Notes

- `bm25s` tokenizer is reused from the existing `llama-index-retrievers-bm25` dependency — no new packages.
- The Plan agent flagged several issues during design that are addressed in the implementation (preserved per-retriever ranks across rerank, cache bypass instead of dual-keying, `enumerate(reranked)` for movement, deterministic reason ordering, `excludeFROM RESPONSE` rather than `null`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)