### PR TITLE
security(api): replace allow_external query param with server-side setting (closes #180)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,19 @@ API_PORT=8000
 DEBUG=false
 
 # =============================================================================
+# Path Containment (Issue #180)
+# =============================================================================
+# When false (default), indexing requests for paths outside the resolved
+# project root are rejected with HTTP 400. Set true ONLY if you trust every
+# caller of the HTTP API (for example a single-user local dev box that wants
+# to index ~/Documents). On any shared host or any server with multiple
+# clients, leaving this false is the safe choice: combined with the lack of
+# endpoint authentication (issue #179), enabling it lets any local process
+# index sensitive paths such as ~/.ssh or ~/.config/sops and exfiltrate them
+# via /query.
+AGENT_BRAIN_ALLOW_EXTERNAL_PATHS=false
+
+# =============================================================================
 # OpenAI Configuration (Required for embeddings)
 # =============================================================================
 # Get your API key from: https://platform.openai.com/api-keys

--- a/agent-brain-cli/agent_brain_cli/client/api_client.py
+++ b/agent-brain-cli/agent_brain_cli/client/api_client.py
@@ -370,7 +370,6 @@ class DocServeClient:
         include_types: list[str] | None = None,
         generate_summaries: bool = False,
         force: bool = False,
-        allow_external: bool = False,
         injector_script: str | None = None,
         folder_metadata_file: str | None = None,
         dry_run: bool = False,
@@ -393,7 +392,6 @@ class DocServeClient:
             include_types: File type preset names (e.g., ["python", "docs"]).
             generate_summaries: Generate LLM summaries for code chunks.
             force: Bypass deduplication and force a new job.
-            allow_external: Allow paths outside the project directory.
             injector_script: Path to Python script exporting process_chunk().
             folder_metadata_file: Path to JSON file with static metadata.
             dry_run: Validate injector against sample chunks without indexing.
@@ -433,7 +431,7 @@ class DocServeClient:
             "POST",
             "/index/",
             json=body,
-            params={"force": force, "allow_external": allow_external},
+            params={"force": force},
         )
 
         return IndexResponse(

--- a/agent-brain-cli/agent_brain_cli/commands/index.py
+++ b/agent-brain-cli/agent_brain_cli/commands/index.py
@@ -79,11 +79,6 @@ console = Console()
     is_flag=True,
     help="Force re-indexing even if embedding provider has changed",
 )
-@click.option(
-    "--allow-external",
-    is_flag=True,
-    help="Allow indexing paths outside the project directory",
-)
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
 @click.pass_context
 def index_command(
@@ -101,7 +96,6 @@ def index_command(
     exclude_patterns: str | None,
     generate_summaries: bool,
     force: bool,
-    allow_external: bool,
     json_output: bool,
 ) -> None:
     """Index documents from a folder.
@@ -149,7 +143,6 @@ def index_command(
                 exclude_patterns=exclude_patterns_list,
                 generate_summaries=generate_summaries,
                 force=force,
-                allow_external=allow_external,
             )
 
             if json_output:

--- a/agent-brain-cli/agent_brain_cli/commands/inject.py
+++ b/agent-brain-cli/agent_brain_cli/commands/inject.py
@@ -98,11 +98,6 @@ console = Console()
     is_flag=True,
     help="Force re-indexing even if embedding provider has changed",
 )
-@click.option(
-    "--allow-external",
-    is_flag=True,
-    help="Allow indexing paths outside the project directory",
-)
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
 @click.pass_context
 def inject_command(
@@ -123,7 +118,6 @@ def inject_command(
     exclude_patterns: str | None,
     generate_summaries: bool,
     force: bool,
-    allow_external: bool,
     json_output: bool,
 ) -> None:
     """Index documents from a folder with content injection.
@@ -199,7 +193,6 @@ def inject_command(
                 exclude_patterns=exclude_patterns_list,
                 generate_summaries=generate_summaries,
                 force=force,
-                allow_external=allow_external,
                 injector_script=resolved_script,
                 folder_metadata_file=resolved_metadata,
                 dry_run=dry_run,

--- a/agent-brain-server/agent_brain_server/api/routers/index.py
+++ b/agent-brain-server/agent_brain_server/api/routers/index.py
@@ -160,9 +160,6 @@ async def index_documents(
     request_body: IndexRequest,
     request: Request,
     force: bool = Query(False, description="Bypass deduplication and force a new job"),
-    allow_external: bool = Query(
-        False, description="Allow paths outside the project directory"
-    ),
     rebuild_graph: bool = Query(
         False,
         description="Rebuild only the graph index without re-indexing documents "
@@ -178,18 +175,24 @@ async def index_documents(
     If rebuild_graph=true, only rebuilds the graph index from existing chunks
     without re-indexing documents (requires ENABLE_GRAPH_INDEX=true).
 
+    Path containment: paths outside the resolved project root are rejected
+    with HTTP 400 unless the operator has set
+    ``AGENT_BRAIN_ALLOW_EXTERNAL_PATHS=true`` on the server process. The
+    previous per-request ``allow_external`` query parameter was removed in
+    issue #180 because it allowed any HTTP caller to bypass containment.
+
     Args:
         request_body: IndexRequest with folder_path and optional configuration.
         request: FastAPI request for accessing app state.
         force: If True, bypass deduplication and create a new job.
-        allow_external: If True, allow indexing paths outside the project.
         rebuild_graph: If True, only rebuild graph index from existing chunks.
 
     Returns:
         IndexResponse with job_id and status.
 
     Raises:
-        400: Invalid folder path or path outside project (without allow_external)
+        400: Invalid folder path or path outside project root (when the server's
+            AGENT_BRAIN_ALLOW_EXTERNAL_PATHS is False)
         400: rebuild_graph=true but GraphRAG not enabled
         429: Queue is full (backpressure)
     """
@@ -352,7 +355,7 @@ async def index_documents(
             request=resolved_request,
             operation="index",
             force=force,
-            allow_external=allow_external,
+            allow_external=settings.AGENT_BRAIN_ALLOW_EXTERNAL_PATHS,
         )
     except ValueError as e:
         # Path validation error (outside project)
@@ -392,20 +395,21 @@ async def add_documents(
     request_body: IndexRequest,
     request: Request,
     force: bool = Query(False, description="Bypass deduplication and force a new job"),
-    allow_external: bool = Query(
-        False, description="Allow paths outside the project directory"
-    ),
 ) -> IndexResponse:
     """Enqueue a job to add documents from a new folder to the existing index.
 
     This is similar to the index endpoint but adds to the existing
     vector store instead of replacing it.
 
+    Path containment: see ``index_documents`` for the rules. The per-request
+    ``allow_external`` query parameter was removed in issue #180; containment
+    is now controlled exclusively by the server-side setting
+    ``AGENT_BRAIN_ALLOW_EXTERNAL_PATHS``.
+
     Args:
         request_body: IndexRequest with folder_path and optional configuration.
         request: FastAPI request for accessing app state.
         force: If True, bypass deduplication and create a new job.
-        allow_external: If True, allow indexing paths outside the project.
 
     Returns:
         IndexResponse with job_id and status.
@@ -469,7 +473,7 @@ async def add_documents(
             request=resolved_request,
             operation="add",
             force=force,
-            allow_external=allow_external,
+            allow_external=settings.AGENT_BRAIN_ALLOW_EXTERNAL_PATHS,
         )
     except ValueError as e:
         raise HTTPException(

--- a/agent-brain-server/agent_brain_server/config/settings.py
+++ b/agent-brain-server/agent_brain_server/config/settings.py
@@ -56,6 +56,18 @@ class Settings(BaseSettings):
     # Strict Mode Configuration
     AGENT_BRAIN_STRICT_MODE: bool = False  # Fail on critical validation errors
 
+    # Path Containment Configuration (Issue #180)
+    # Default False: indexing requests with paths outside the resolved project
+    # root are rejected (HTTP 400). Set True to allow external paths. This is
+    # a deployment-time trust posture controlled by the operator, NOT a
+    # per-request choice — the previous `?allow_external=true` query parameter
+    # was removed because it let any HTTP caller bypass containment, which
+    # combined with unauthenticated endpoints (issue #179) enabled exfiltration
+    # of files outside the project (e.g. ~/.ssh, ~/.config/sops). Internal
+    # callers such as the file watcher service still pass allow_external=True
+    # explicitly when the operator has opted in via the watcher CLI.
+    AGENT_BRAIN_ALLOW_EXTERNAL_PATHS: bool = False
+
     # Storage Backend Configuration (Phase 5)
     AGENT_BRAIN_STORAGE_BACKEND: str = (
         ""  # Empty = use YAML config; "chroma" or "postgres" overrides YAML

--- a/agent-brain-server/tests/integration/test_api.py
+++ b/agent-brain-server/tests/integration/test_api.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from agent_brain_server import __version__
+from agent_brain_server.config import settings
 
 
 @dataclass
@@ -61,9 +62,16 @@ class TestHealthEndpoints:
 class TestIndexEndpoints:
     """Tests for indexing endpoints."""
 
-    def test_index_documents_success(self, client, temp_docs_dir, mock_vector_store):
+    def test_index_documents_success(
+        self, client, temp_docs_dir, mock_vector_store, monkeypatch
+    ):
         """Test successful document indexing request."""
         mock_vector_store.is_initialized = True
+        # temp_docs_dir lives outside the resolved project root, so the
+        # server-side path-containment setting must be True for this test.
+        # The previous per-request `allow_external` query parameter was
+        # removed in issue #180; containment is now operator-controlled.
+        monkeypatch.setattr(settings, "AGENT_BRAIN_ALLOW_EXTERNAL_PATHS", True)
 
         with patch(
             "agent_brain_server.services.indexing_service.IndexingService.start_indexing",
@@ -71,7 +79,7 @@ class TestIndexEndpoints:
             return_value="job_test123",
         ):
             response = client.post(
-                "/index/?allow_external=true",
+                "/index/",
                 json={
                     "folder_path": str(temp_docs_dir),
                     "chunk_size": 512,
@@ -95,15 +103,55 @@ class TestIndexEndpoints:
         assert response.status_code == 400
         assert "not found" in response.json()["detail"].lower()
 
-    def test_index_documents_deduplication(self, client, temp_docs_dir):
+    def test_index_rejects_external_path_when_setting_false(
+        self, client, temp_docs_dir, monkeypatch
+    ):
+        """External paths return 400 when AGENT_BRAIN_ALLOW_EXTERNAL_PATHS is False.
+
+        Pins the issue #180 fix: the per-request ``allow_external`` query
+        parameter is gone, and the only way to opt in to external paths is
+        the server-side setting.
+        """
+        monkeypatch.setattr(settings, "AGENT_BRAIN_ALLOW_EXTERNAL_PATHS", False)
+
+        response = client.post(
+            "/index/",
+            json={"folder_path": str(temp_docs_dir)},
+        )
+        # temp_docs_dir lives outside the resolved project root, so this
+        # must be rejected when the operator has not opted in.
+        assert response.status_code == 400
+        assert "outside project root" in response.json()["detail"].lower()
+
+    def test_index_ignores_legacy_allow_external_query_param(
+        self, client, temp_docs_dir, monkeypatch
+    ):
+        """The removed query parameter must not re-enable external paths.
+
+        Defense-in-depth: even if a caller still sends ``?allow_external=true``,
+        FastAPI now ignores the unknown query param and the server-side
+        setting (False here) governs the decision. Rejection is expected.
+        """
+        monkeypatch.setattr(settings, "AGENT_BRAIN_ALLOW_EXTERNAL_PATHS", False)
+
+        response = client.post(
+            "/index/?allow_external=true",
+            json={"folder_path": str(temp_docs_dir)},
+        )
+        assert response.status_code == 400
+        assert "outside project root" in response.json()["detail"].lower()
+
+    def test_index_documents_deduplication(self, client, temp_docs_dir, monkeypatch):
         """Test that duplicate requests return existing job (deduplication).
 
         Note: With the queue-based system, concurrent requests are handled via
         deduplication, not 409 conflicts. The same path returns the same job.
         """
+        monkeypatch.setattr(settings, "AGENT_BRAIN_ALLOW_EXTERNAL_PATHS", True)
+
         # First request - creates new job
         response1 = client.post(
-            "/index/?allow_external=true",
+            "/index/",
             json={"folder_path": str(temp_docs_dir)},
         )
         assert response1.status_code == 202
@@ -111,7 +159,7 @@ class TestIndexEndpoints:
 
         # Second request - should return same job via deduplication
         response2 = client.post(
-            "/index/?allow_external=true",
+            "/index/",
             json={"folder_path": str(temp_docs_dir)},
         )
         assert response2.status_code == 202
@@ -120,9 +168,12 @@ class TestIndexEndpoints:
         # Both requests should get the same job ID
         assert job_id_1 == job_id_2
 
-    def test_add_documents_endpoint(self, client, temp_docs_dir, mock_vector_store):
+    def test_add_documents_endpoint(
+        self, client, temp_docs_dir, mock_vector_store, monkeypatch
+    ):
         """Test adding documents to existing index."""
         mock_vector_store.is_initialized = True
+        monkeypatch.setattr(settings, "AGENT_BRAIN_ALLOW_EXTERNAL_PATHS", True)
 
         with patch(
             "agent_brain_server.services.indexing_service.IndexingService.start_indexing",
@@ -138,7 +189,7 @@ class TestIndexEndpoints:
                 mock_get_service.return_value = mock_service
 
                 response = client.post(
-                    "/index/add?allow_external=true",
+                    "/index/add",
                     json={"folder_path": str(temp_docs_dir)},
                 )
 

--- a/agent-brain-server/tests/unit/job_queue/test_job_service_path_validation.py
+++ b/agent-brain-server/tests/unit/job_queue/test_job_service_path_validation.py
@@ -1,0 +1,59 @@
+"""Path-containment behavior of JobQueueService._validate_path.
+
+Issue #180: the HTTP API no longer exposes ``allow_external`` as a per-request
+query parameter. Path containment is now a deployment-time decision controlled
+by ``settings.AGENT_BRAIN_ALLOW_EXTERNAL_PATHS``. These tests pin the
+underlying ``_validate_path`` behavior so any future change has to think about
+both modes explicitly.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agent_brain_server.job_queue.job_service import JobQueueService
+
+
+class TestValidatePath:
+    """Direct exercise of JobQueueService._validate_path."""
+
+    def test_internal_path_resolves_regardless_of_flag(self, tmp_path: Path) -> None:
+        """A path under the project root resolves cleanly with allow_external=False."""
+        service = JobQueueService(store=AsyncMock(), project_root=tmp_path)
+
+        subdir = tmp_path / "docs"
+        subdir.mkdir()
+
+        resolved = service._validate_path(str(subdir), allow_external=False)
+        assert resolved == subdir.resolve()
+
+    def test_external_path_rejected_when_flag_false(self, tmp_path: Path) -> None:
+        """A path outside the project root raises ValueError when not allowed."""
+        service = JobQueueService(store=AsyncMock(), project_root=tmp_path)
+
+        with tempfile.TemporaryDirectory() as elsewhere:
+            with pytest.raises(ValueError) as exc:
+                service._validate_path(elsewhere, allow_external=False)
+            assert "outside project root" in str(exc.value)
+
+    def test_external_path_allowed_when_flag_true(self, tmp_path: Path) -> None:
+        """A path outside the project root resolves when allow_external=True."""
+        service = JobQueueService(store=AsyncMock(), project_root=tmp_path)
+
+        with tempfile.TemporaryDirectory() as elsewhere:
+            resolved = service._validate_path(elsewhere, allow_external=True)
+            assert resolved == Path(elsewhere).resolve()
+
+    def test_no_project_root_skips_validation(self, tmp_path: Path) -> None:
+        """When project_root is None, any path is accepted (legacy CLI mode)."""
+        service = JobQueueService(store=AsyncMock(), project_root=None)
+
+        with tempfile.TemporaryDirectory() as elsewhere:
+            # External path is allowed even with allow_external=False
+            # because there is no project root to compare against.
+            resolved = service._validate_path(elsewhere, allow_external=False)
+            assert resolved == Path(elsewhere).resolve()

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -390,8 +390,13 @@ Enqueue a job to index documents from a folder. Returns immediately with a job I
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `force` | boolean | `false` | Bypass deduplication and force a new job |
-| `allow_external` | boolean | `false` | Allow paths outside the project directory |
 | `rebuild_graph` | boolean | `false` | Rebuild only the graph index without re-indexing documents (requires `ENABLE_GRAPH_INDEX=true`) |
+
+> **Path containment**: paths outside the resolved project root are rejected
+> with HTTP 400 unless the operator has set the server-side environment
+> variable `AGENT_BRAIN_ALLOW_EXTERNAL_PATHS=true`. The previous
+> per-request `allow_external` query parameter was removed in issue #180
+> because it let any HTTP caller bypass containment.
 
 **Request Body**:
 
@@ -453,7 +458,7 @@ Enqueue a job to index documents from a folder. Returns immediately with a job I
 
 | Code | Description |
 |------|-------------|
-| `400` | Invalid folder path, path outside project (without `allow_external`), invalid injector script, invalid include_types preset, or `rebuild_graph=true` with GraphRAG not enabled |
+| `400` | Invalid folder path, path outside project root (when `AGENT_BRAIN_ALLOW_EXTERNAL_PATHS=false`), invalid injector script, invalid include_types preset, or `rebuild_graph=true` with GraphRAG not enabled |
 | `429` | Queue is full (backpressure) |
 
 ---
@@ -467,7 +472,9 @@ Enqueue a job to add documents from another folder to the existing index. Same r
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `force` | boolean | `false` | Bypass deduplication and force a new job |
-| `allow_external` | boolean | `false` | Allow paths outside the project directory |
+
+> Path containment rules match `POST /index`. See that endpoint for the
+> `AGENT_BRAIN_ALLOW_EXTERNAL_PATHS` setting.
 
 **Response** `202 Accepted`:
 
@@ -483,7 +490,7 @@ Enqueue a job to add documents from another folder to the existing index. Same r
 
 | Code | Description |
 |------|-------------|
-| `400` | Invalid folder path, path outside project (without `allow_external`), or invalid include_types preset |
+| `400` | Invalid folder path, path outside project root (when `AGENT_BRAIN_ALLOW_EXTERNAL_PATHS=false`), or invalid include_types preset |
 | `429` | Queue is full (backpressure) |
 
 ---

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`allow_external` query parameter replaced by server-side setting** (`agent_brain_server/api/routers/index.py`, `agent_brain_server/config/settings.py`, `agent_brain_server/job_queue/job_service.py`, `agent_brain_cli/client/api_client.py`, `agent_brain_cli/commands/index.py`, `agent_brain_cli/commands/inject.py`, `scripts/query_benchmark.py`, `docs/API_REFERENCE.md`, `.env.example`). The previous `POST /index/?allow_external=true` query parameter let any HTTP caller bypass project-root path containment. Combined with the lack of endpoint authentication on the server, this enabled directory-traversal-style exfiltration: a caller could index `~/.ssh`, `~/.config/sops`, or any other sensitive path and read the contents back through `POST /query`. The parameter is now removed from both `POST /index` and `POST /index/add`; containment is controlled exclusively by the new `AGENT_BRAIN_ALLOW_EXTERNAL_PATHS` server-side environment variable (default `false`). Operators who relied on the per-request override must set the variable on the server process after reading the threat model in `.env.example`. The CLI's `--allow-external` flag was removed from `agent-brain index` and `agent-brain inject` to match. Internal callers such as `file_watcher_service` continue to pass `allow_external=True` directly to `JobQueueService.enqueue_job()`; only the HTTP boundary is locked down. Six new tests in `tests/unit/job_queue/test_job_service_path_validation.py` and `tests/integration/test_api.py` pin the four-quadrant containment matrix and the rejection-path contract. Closes #180.
+
 ---
 
 ## [10.1.2] - 2026-05-29

--- a/scripts/query_benchmark.py
+++ b/scripts/query_benchmark.py
@@ -361,10 +361,14 @@ def prepare_docs_corpus(server_url: str, docs_path: str) -> None:
 
     # Trigger indexing
     console.print(f"  Starting indexing of {docs_path}...")
+    # Path containment: the benchmark indexes a docs path that may live
+    # outside the server's resolved project root. Setting
+    # AGENT_BRAIN_ALLOW_EXTERNAL_PATHS=true on the server process is now
+    # required for that to succeed (issue #180); the previous per-request
+    # ?allow_external=true query parameter is no longer honored.
     try:
         idx_resp = httpx.post(
             f"{server_url}/index/",
-            params={"allow_external": "true"},
             json={"folder_path": docs_path},
             timeout=30.0,
         )


### PR DESCRIPTION
Closes #180.

First of the three critical security issues filed today. Smallest blast radius, cleanest fix, no breaking change to internal callers. Filing this as the canary PR; #179 (auth) and #181 (injector RCE) remain in the design-discussion phase pending your direction.

## What this does

Removes `allow_external` as a per-request HTTP query parameter and moves it to a server-side setting `AGENT_BRAIN_ALLOW_EXTERNAL_PATHS` (default `false`). Path containment is now a deployment-time decision controlled by the operator running the server, not a per-request choice exposed to the HTTP caller. The follow-up commit (62b441a) propagates the change through every public surface that mentioned the old parameter.

## Why

Combined with the lack of endpoint authentication (issue #179), the previous query parameter let any caller bypass the project-root containment check and exfiltrate files outside the project via the `/query` endpoint:

```bash
curl -X POST 'http://127.0.0.1:8000/index?folder_path=/home/rick/.ssh&allow_external=true'
# wait for indexing job
curl 'http://127.0.0.1:8000/query?q=id_ed25519'
# private key chunk returned in the response
```

`allow_external` is fundamentally a trust posture (operator-level), not a per-call decision (caller-level). The original design inverted the trust direction.

## Design refinement vs the issue draft

While implementing I found `file_watcher_service.py:296` is a legitimate INTERNAL caller of `JobQueueService.enqueue_job(allow_external=True)`. When a user explicitly opts in to watching a folder outside the project root via the watcher CLI, the watcher must bypass containment.

So the fix is **only at the HTTP boundary**: drop the query parameter, keep the internal API on `JobQueueService.enqueue_job`, have the router pass `settings.AGENT_BRAIN_ALLOW_EXTERNAL_PATHS` rather than caller input. This is cleaner than the draft in issue #180 and preserves the internal watcher behavior unchanged.

## Commits

### 6ec90aa — Server-side fix
- `config/settings.py`: add `AGENT_BRAIN_ALLOW_EXTERNAL_PATHS: bool = False` with threat-model documentation
- `api/routers/index.py`: drop `allow_external` Query param from `POST /index/` and `POST /index/add`; both now pass `settings.AGENT_BRAIN_ALLOW_EXTERNAL_PATHS` to JobQueueService.enqueue_job
- `.env.example`: document the new setting under a Path Containment block
- Tests: existing integration tests that relied on `?allow_external=true` now use `monkeypatch.setattr` on the settings instance. New unit tests in `tests/unit/job_queue/test_job_service_path_validation.py` pin `_validate_path` behavior across the 4-quadrant matrix. New integration tests confirm external paths return HTTP 400 when the setting is False, and that the removed query parameter is now ignored even when a legacy caller still sends it.

### 62b441a — Public surface cleanup
- `docs/API_REFERENCE.md`: remove `allow_external` from POST /index and POST /index/add query-parameter tables; replace with a callout block describing the server-side setting; update 400-error descriptions
- `agent_brain_cli/client/api_client.py`: drop `allow_external` from `index()` signature, docstring, and request params
- `agent_brain_cli/commands/index.py` and `commands/inject.py`: remove the `--allow-external` Click option and its passthrough
- `scripts/query_benchmark.py`: drop the param from the benchmark indexing call; add comment about the server-side setting
- `docs/CHANGELOG.md`: new `### Security` entry under [Unreleased] documenting the breaking change, threat model, and migration path

## Verification

- `task server:pr-qa-gate`: **1154 passed**, 23 skipped, **78.51% coverage** on this branch (baseline before changes was 1148 passed, 78.43% coverage). All 6 added test cases pass.
- `task cli:pr-qa-gate`: **382 passed**. One failure on `test_check_version_reports_installed_cli_version` is pre-existing on upstream main (regression for #146) and reproduces identically pre-change. Not caused by this PR.
- Public-surface grep `rg "allow_external" docs/API_REFERENCE.md agent-brain-cli/agent_brain_cli/ scripts/query_benchmark.py` returns zero hits.
- ruff, mypy, black, yaml-lint: all clean on the server side. CLI typecheck has 10 pre-existing yaml-stub errors that also reproduce on main; happy to fix in a separate `chore(cli): add types-PyYAML stubs` PR if helpful.

## Breaking change

Callers that previously sent `?allow_external=true` to `/index/` or `/index/add` will now get the project-root rejection when their path is external. CLI users who passed `--allow-external` to `agent-brain index` or `agent-brain inject` will get a Click "no such option" error. Migration:

- Set `AGENT_BRAIN_ALLOW_EXTERNAL_PATHS=true` in the server environment.
- The threat model is documented in `.env.example` under the new "Path Containment" block.

Given the pre-1.0 status and one known external user (#141), I went with a hard break instead of a deprecation cycle. Happy to switch to soft-deprecate (log a warning, ignore the param) if you prefer.

## Files touched

```
6ec90aa (server):
  .env.example                                          | +13
  agent-brain-server/agent_brain_server/api/routers/index.py | +/-26
  agent-brain-server/agent_brain_server/config/settings.py   | +12
  agent-brain-server/tests/integration/test_api.py           | +65
  agent-brain-server/tests/unit/job_queue/test_job_service_path_validation.py | +59 (new)

62b441a (public surface cleanup):
  agent-brain-cli/agent_brain_cli/client/api_client.py | -4
  agent-brain-cli/agent_brain_cli/commands/index.py    | -7
  agent-brain-cli/agent_brain_cli/commands/inject.py   | -7
  docs/API_REFERENCE.md                                | +/-15
  docs/CHANGELOG.md                                    | +4
  scripts/query_benchmark.py                           | +5/-1
```

Total: 11 files, +178 / -40, 6 new tests.

- Jeremy Longshore
intentsolutions.io