### PR TITLE
docs(mcp): add standalone MCP user guide

### DIFF
--- a/agent-brain-mcp/README.md
+++ b/agent-brain-mcp/README.md
@@ -2,9 +2,9 @@
 
 Model Context Protocol server for [Agent Brain](https://github.com/SpillwaveSolutions/agent-brain).
 
-Exposes the running Agent Brain instance as an MCP server consumable by Claude Desktop, Claude Code, OpenCode, Gemini CLI, and any other MCP-aware client.
+Exposes the running Agent Brain instance as an MCP server consumable by Claude Desktop, Cursor, Windsurf, Claude Agent SDK, LangChain DeepAgents, and any other MCP-aware client.
 
-## v1 surface (Phase 4)
+## v1 surface
 
 - **7 Tools**: `search_documents`, `query_count`, `index_folder`, `get_job`, `list_jobs`, `cancel_job`, `server_health`
 - **5 Resources** (read-only): `corpus://config`, `corpus://status`, `corpus://health`, `corpus://providers`, `corpus://folders`
@@ -12,12 +12,17 @@ Exposes the running Agent Brain instance as an MCP server consumable by Claude D
 - **Transport**: stdio
 - **Backend**: UDS (preferred) or HTTP, selectable via `--backend {auto,uds,http}`
 
-## Status
+Shipped in Agent Brain 10.1.0 (May 2026); see [`CHANGELOG.md`](../docs/CHANGELOG.md). v2 (subscriptions + streamable HTTP), v3 (CLI-via-MCP + framework adapters), and v4 (OAuth) are tracked under [`docs/roadmaps/mcp/`](../docs/roadmaps/mcp/).
 
-Phase 0 scaffold (10.0.7) — public surface lands in Phase 4.
-See [`docs/plans/2026-05-28-mcp-uds-transport-design.md`](../docs/plans/2026-05-28-mcp-uds-transport-design.md).
+## Install
 
-## Claude Desktop / Code config (when Phase 4 ships)
+```bash
+pip install agent-brain-ag-mcp
+```
+
+The PyPI distribution is `agent-brain-ag-mcp`; the installed console script is `agent-brain-mcp`.
+
+## Quick config
 
 ```json
 {
@@ -30,6 +35,12 @@ See [`docs/plans/2026-05-28-mcp-uds-transport-design.md`](../docs/plans/2026-05-
   }
 }
 ```
+
+## Full guide
+
+For per-host configuration (Claude Desktop, Cursor / Windsurf, Claude Agent SDK, LangChain DeepAgents), the full tool/resource/prompt reference with schemas, worked end-to-end examples, error mapping, and troubleshooting, see **[`docs/MCP_USER_GUIDE.md`](../docs/MCP_USER_GUIDE.md)**.
+
+For internal design (UDS bind strategy, package layering, deferred work), see [`docs/plans/2026-05-28-mcp-uds-transport-design.md`](../docs/plans/2026-05-28-mcp-uds-transport-design.md).
 
 ## License
 

--- a/docs/MCP_USER_GUIDE.md
+++ b/docs/MCP_USER_GUIDE.md
@@ -1,0 +1,680 @@
+---
+last_validated: 2026-05-30
+---
+
+# Agent Brain MCP Server Guide
+
+Complete reference for `agent-brain-mcp` — the Model Context Protocol server that exposes your indexed Agent Brain corpus to MCP-aware clients (Claude Desktop, Cursor, Windsurf, Claude Agent SDK, LangChain DeepAgents, and any other MCP host).
+
+## Table of Contents
+
+- [What it is](#what-it-is)
+- [MCP server vs. plugin — which should I use?](#mcp-server-vs-plugin--which-should-i-use)
+- [Features at a glance](#features-at-a-glance)
+- [Installation](#installation)
+- [Configuration](#configuration)
+  - [Universal stdio config](#universal-stdio-config)
+  - [Claude Desktop](#claude-desktop)
+  - [Cursor / Windsurf / generic MCP IDE](#cursor--windsurf--generic-mcp-ide)
+  - [Claude Agent SDK (Python)](#claude-agent-sdk-python)
+  - [LangChain DeepAgents (and other LangGraph agents)](#langchain-deepagents-and-other-langgraph-agents)
+  - [Other agent frameworks (preview)](#other-agent-frameworks-preview)
+- [CLI flags and environment variables](#cli-flags-and-environment-variables)
+- [Tool reference (7 tools)](#tool-reference-7-tools)
+- [Resource reference (5 resources)](#resource-reference-5-resources)
+- [Prompt reference (6 prompts)](#prompt-reference-6-prompts)
+- [End-to-end worked examples](#end-to-end-worked-examples)
+- [Error handling](#error-handling)
+- [Cancellation](#cancellation)
+- [Troubleshooting](#troubleshooting)
+- [What's not in v1, and what's coming](#whats-not-in-v1-and-whats-coming)
+- [Related docs](#related-docs)
+
+---
+
+## What it is
+
+`agent-brain-mcp` is a small Python process that speaks the [Model Context Protocol](https://modelcontextprotocol.io/) over stdio to an LLM client and talks to your local Agent Brain backend (the FastAPI server shipped by `agent-brain-rag`) over a Unix Domain Socket or HTTP. It is **a thin protocol adapter**, not a re-implementation — every tool call maps to a single REST endpoint on the backend.
+
+- **PyPI distribution:** `agent-brain-ag-mcp`
+- **Console script:** `agent-brain-mcp`
+- **Transport (to the LLM client):** stdio (JSON-RPC 2.0)
+- **Transport (to the backend):** UDS (preferred) or HTTP, selectable with `--backend {auto|uds|http}`
+- **v1 surface:** 7 tools, 5 read-only resources, 6 prompts
+
+If you want slash commands inside Claude Code, OpenCode, Gemini CLI, or Codex, use the [plugin](./PLUGIN_GUIDE.md) instead. If your LLM client speaks MCP natively (Claude Desktop, Cursor, an agent SDK), use this server.
+
+---
+
+## MCP server vs. plugin — which should I use?
+
+You can run both at the same time against the same backend — they don't conflict. Use whichever matches your host.
+
+| Question | Plugin | MCP server |
+|---|---|---|
+| Where does it run? | Inside Claude Code / OpenCode / Gemini CLI / Codex | Inside Claude Desktop, Cursor, Windsurf, an agent SDK process |
+| How does the user call it? | `/agent-brain-search "…"` slash commands (30 of them) | The host model picks tools, reads resources, or expands prompts as part of normal tool use |
+| What's installed? | Markdown files + a few shell commands; shells out to the `agent-brain` CLI | A Python process started by the host as a subprocess |
+| Best for | Interactive sessions where humans drive search via slash commands | Agentic / autonomous workflows where the model itself orchestrates retrieval |
+| Backend required? | Yes (`agent-brain start`) | Yes (`agent-brain start`) |
+| Multi-runtime? | Yes — Claude Code, OpenCode, Gemini CLI, Codex, generic skill runtime | Yes — any MCP-aware host |
+
+**Rule of thumb:** if your client has a `mcpServers` config block, use the MCP server. If it has a `plugins` config block and you're a Claude Code / OpenCode / Gemini user, use the plugin.
+
+---
+
+## Features at a glance
+
+- **All 5 retrieval modes** — `semantic`, `bm25`, `hybrid`, `graph`, `multi` — selected by the `mode` parameter on a single `search_documents` tool. No mode-specific tools to remember.
+- **Structured tool output** — every tool advertises an `outputSchema` and returns a typed `structuredContent` block alongside the human-readable summary, so model clients that consume MCP structured output get typed data.
+- **Corpus state as resources** — read backend config, status, health, providers, and indexed folders via `corpus://...` URIs without a tool call (i.e. without an LLM round-trip).
+- **Opinionated multi-step prompts** — six parameterized templates (`find-callers`, `find-implementation`, `explain-architecture`, `compare-search-modes`, `onboard-to-codebase`, `audit-indexed-folders`) that chain tool calls into useful end-to-end flows.
+- **UDS-or-HTTP backend transport** — `--backend auto` prefers UDS for lower latency and falls back to HTTP transparently.
+- **Version-compat startup check** — the server calls `GET /health/` once at startup and refuses to start if the backend reports a version below the pinned `MIN_BACKEND_VERSION`. Prevents wire drift.
+- **Structured JSON-RPC errors** — HTTP failures map to MCP error codes including custom `-32000…-32003` codes for `BackendConflict`, `BackendUnavailable`, `ServiceIndexing`, and `BackendTimeout`. Every error carries `data.httpStatus` and `data.cause`.
+- **Responsive cancellation** — `notifications/cancelled` unblocks the MCP-side handler within ~1 second even while a slow backend request is in flight.
+
+---
+
+## Installation
+
+The MCP server is published as `agent-brain-ag-mcp` on PyPI. The PyPI distribution name is unusual (the original `agent-brain-mcp` name was taken on PyPI), but the installed **console script** is `agent-brain-mcp`.
+
+```bash
+pip install agent-brain-ag-mcp
+# verify
+agent-brain-mcp --help
+```
+
+You also need a running Agent Brain backend. The MCP server is a proxy — it does not index anything itself.
+
+```bash
+# install the backend + CLI
+pip install agent-brain-rag agent-brain-cli
+
+# in your project root
+agent-brain init                  # creates .agent-brain/
+agent-brain start                 # starts the FastAPI server
+agent-brain index ./docs          # index something
+```
+
+For multi-instance / shared deployments, see [`docs/USER_GUIDE.md`](./USER_GUIDE.md#multi-project-support).
+
+---
+
+## Configuration
+
+### Universal stdio config
+
+Every MCP host launches the server the same way — a subprocess with a `command`, optional `args`, and an `env` dictionary. The hosts only differ in *where* you put that object.
+
+```json
+{
+  "command": "agent-brain-mcp",
+  "args": ["--backend", "auto"],
+  "env": {
+    "AGENT_BRAIN_STATE_DIR": "/abs/path/to/your-project/.agent-brain"
+  }
+}
+```
+
+- `command` must resolve on the host's `PATH`. If the host can't find it, use the absolute path printed by `which agent-brain-mcp`.
+- `args` accept any flag from [CLI flags](#cli-flags-and-environment-variables).
+- `env` should usually pin `AGENT_BRAIN_STATE_DIR` to the project's `.agent-brain` directory so the MCP server can locate the running backend's UDS socket and `runtime.json`. Without it, the server falls back to `$CWD/.agent-brain`, which the host's CWD may not match.
+
+### Claude Desktop
+
+Add to `claude_desktop_config.json` (location varies by OS — `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS, `%APPDATA%\Claude\claude_desktop_config.json` on Windows):
+
+```json
+{
+  "mcpServers": {
+    "agent-brain": {
+      "command": "agent-brain-mcp",
+      "args": ["--backend", "auto"],
+      "env": {
+        "AGENT_BRAIN_STATE_DIR": "/Users/me/work/myproject/.agent-brain"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The 7 tools, 5 resources, and 6 prompts will appear in the tool/resource pickers.
+
+### Cursor / Windsurf / generic MCP IDE
+
+Most MCP-aware IDEs accept the same `mcpServers` shape — Cursor uses `~/.cursor/mcp.json`, Windsurf uses its in-app settings, others vary. Drop the universal stdio object in:
+
+```json
+{
+  "mcpServers": {
+    "agent-brain": {
+      "command": "agent-brain-mcp",
+      "args": ["--backend", "auto"],
+      "env": {
+        "AGENT_BRAIN_STATE_DIR": "/abs/path/to/.agent-brain"
+      }
+    }
+  }
+}
+```
+
+If your IDE asks for a "name" or "label", use `agent-brain` — tools and resources are namespaced by it in the host (e.g. `mcp__agent-brain__search_documents` in some hosts).
+
+### Claude Agent SDK (Python)
+
+The [`claude-agent-sdk-python`](https://github.com/anthropics/claude-agent-sdk-python) registers external MCP servers through `ClaudeAgentOptions.mcp_servers`:
+
+```python
+from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
+
+options = ClaudeAgentOptions(
+    mcp_servers={
+        "agent-brain": {
+            "type": "stdio",
+            "command": "agent-brain-mcp",
+            "args": ["--backend", "auto"],
+            "env": {
+                "AGENT_BRAIN_STATE_DIR": "/abs/path/to/.agent-brain",
+            },
+        },
+    },
+    # Pre-approve Agent Brain tools so the SDK does not prompt
+    # for permission on each call. Names are namespaced by server.
+    allowed_tools=[
+        "mcp__agent-brain__search_documents",
+        "mcp__agent-brain__query_count",
+        "mcp__agent-brain__server_health",
+    ],
+)
+
+async with ClaudeSDKClient(options=options) as client:
+    await client.query("Find every caller of `compute_embeddings`.")
+    async for msg in client.receive_response():
+        print(msg)
+```
+
+Tool names in `allowed_tools` follow the SDK's `mcp__<server-name>__<tool-name>` namespacing convention. Omit destructive tools (`cancel_job`) from `allowed_tools` if you want the SDK to ask for permission each time.
+
+### LangChain DeepAgents (and other LangGraph agents)
+
+DeepAgents builds on LangGraph, and the canonical way to load MCP tools into a LangGraph agent is the official [`langchain-mcp-adapters`](https://github.com/langchain-ai/langchain-mcp-adapters) package. The same pattern works for any LangChain agent that accepts a `tools=` list.
+
+```bash
+pip install deepagents langchain-mcp-adapters
+```
+
+```python
+from deepagents import create_deep_agent
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+client = MultiServerMCPClient(
+    {
+        "agent-brain": {
+            "command": "agent-brain-mcp",
+            "args": ["--backend", "auto"],
+            "transport": "stdio",
+            "env": {
+                "AGENT_BRAIN_STATE_DIR": "/abs/path/to/.agent-brain",
+            },
+        },
+    }
+)
+
+tools = await client.get_tools()
+agent = create_deep_agent(tools=tools, model="anthropic:claude-opus-4-7")
+
+result = await agent.ainvoke(
+    {"messages": [("user", "Where is `IndexingService.process_folder` implemented?")]}
+)
+```
+
+The `MultiServerMCPClient` starts `agent-brain-mcp` as a stdio subprocess and exposes each MCP tool as a LangChain `Tool`. `client.get_tools()` returns the full set — pass them through to `create_deep_agent`, `create_agent`, `create_react_agent`, or your own LangGraph node.
+
+If you'd rather use DeepAgents' built-in MCP loader (the `.mcp.json` file under your project root), put the universal stdio object there with `"type": "stdio"` and DeepAgents will pick it up at launch.
+
+### Other agent frameworks (preview)
+
+First-party adapters for OpenAI Agents SDK, LlamaIndex, Pydantic AI, Mastra, Vercel AI SDK, and Autogen are tracked in [v3 of the MCP roadmap](./roadmaps/mcp/v3-cli-via-mcp-and-frameworks.md). In the meantime, any framework that can spawn an MCP stdio subprocess (i.e. anyone using the official `mcp` Python or TypeScript SDK as a client) can connect today — the universal stdio config above is all you need.
+
+---
+
+## CLI flags and environment variables
+
+`agent-brain-mcp` only takes three flags. Everything else is configured through the backend.
+
+| Flag | Env var | Default | Description |
+|---|---|---|---|
+| `--backend {auto,uds,http}` | `AGENT_BRAIN_MCP_BACKEND` | `auto` | Backend transport. `auto` tries UDS first and falls back to HTTP. |
+| `--backend-url <url>` | `AGENT_BRAIN_MCP_BACKEND_URL` then `AGENT_BRAIN_URL` | `http://127.0.0.1:8000` | Explicit HTTP base URL. Only consulted when transport resolves to HTTP. |
+| `--state-dir <path>` | `AGENT_BRAIN_STATE_DIR` | `$CWD/.agent-brain` if it exists | Locates the UDS socket and `runtime.json` for the running backend. |
+
+**Resolution precedence** (top wins):
+
+- Transport: `--backend` → `AGENT_BRAIN_MCP_BACKEND` → `"auto"`.
+- HTTP URL: `--backend-url` → `AGENT_BRAIN_MCP_BACKEND_URL` → `AGENT_BRAIN_URL` → `<state-dir>/runtime.json::base_url` → `http://127.0.0.1:8000`.
+- UDS path: `AGENT_BRAIN_UDS_PATH` → `<state-dir>/runtime.json::socket_path` → backend's conventional path under `<state-dir>/`.
+
+**Tip:** when running multiple Agent Brain projects from the same workstation, give each MCP entry its own `AGENT_BRAIN_STATE_DIR` and use a distinct host label (`agent-brain-app`, `agent-brain-docs`, …) so the model can address them separately.
+
+---
+
+## Tool reference (7 tools)
+
+Every tool returns both a human-readable `content` block and a typed `structuredContent` payload validated against its `outputSchema`. REST endpoint columns refer to the FastAPI backend the MCP server proxies to — see [`API_REFERENCE.md`](./API_REFERENCE.md) for full backend schemas.
+
+### `search_documents` (readOnly, openWorld)
+
+Search indexed documents using semantic, BM25, hybrid, graph, or multi-stage retrieval. **The single entry point for all retrieval modes.**
+
+**Wraps:** `POST /query/`
+
+**Input:**
+
+| Field | Type | Default | Constraints |
+|---|---|---|---|
+| `query` | string | — | required |
+| `mode` | enum | `"hybrid"` | one of `semantic`, `bm25`, `hybrid`, `graph`, `multi` |
+| `top_k` | int | `10` | 1–100 |
+| `similarity_threshold` | float | `0.0` | 0.0–1.0 (score floor) |
+| `alpha` | float | `0.5` | 0.0–1.0 (hybrid mix: 0 = pure BM25, 1 = pure semantic) |
+| `source_types` | string[] | null | filter by source type |
+| `languages` | string[] | null | filter by language |
+| `file_paths` | string[] | null | restrict to file-path globs |
+| `explain` | bool | `false` | include per-result explanation block |
+
+**Output:** `{query, mode, total_results, query_time_ms, results: [{text, source, score, chunk_id, metadata}]}`
+
+**Use when:** you need the model to find chunks. Default `mode: hybrid` for general questions; `bm25` for exact symbols; `graph` for relationships ("who calls X?"); `multi` for the "throw the kitchen sink at it" question.
+
+**Example call (MCP JSON-RPC):**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "search_documents",
+    "arguments": {
+      "query": "session timeout handling",
+      "mode": "hybrid",
+      "top_k": 5,
+      "alpha": 0.6,
+      "explain": true
+    }
+  }
+}
+```
+
+### `query_count` (readOnly)
+
+Return total documents and chunks currently indexed.
+
+**Wraps:** `GET /query/count`
+
+**Input:** none.
+
+**Output:** `{total_documents: int, total_chunks: int}`
+
+**Use when:** the model is sanity-checking that the corpus is non-empty before searching.
+
+### `index_folder` (openWorld)
+
+Queue a folder for indexing. Returns a `job_id` the caller polls with `get_job`.
+
+**Wraps:** `POST /index/?force=&allow_external=`
+
+**Input:**
+
+| Field | Type | Default | Constraints |
+|---|---|---|---|
+| `folder_path` | string | — | absolute or project-relative |
+| `force` | bool | `false` | re-index even if unchanged |
+| `allow_external` | bool | `false` | allow paths outside the project root |
+| `include_code` | bool | `true` | apply AST-aware code ingestion |
+| `chunk_size` | int? | null | optional override (≥ 1) |
+| `chunk_overlap` | int? | null | optional override (≥ 0) |
+
+**Output:** `{job_id, status, message?, folder_path, progress_percent?}`
+
+**Use when:** the model needs to add new content to the corpus mid-conversation. Indexing is async; pair with `get_job`.
+
+### `get_job` (readOnly)
+
+Look up the current state of an indexing job.
+
+**Wraps:** `GET /index/jobs/{job_id}`
+
+**Input:** `{job_id: string}`
+
+**Output:** `{job_id, status, progress_percent?, message?, started_at?, completed_at?}`
+
+**Use when:** polling a job to completion. (v2 will add `wait_for_job` with server-side progress notifications — see roadmap.)
+
+### `list_jobs` (readOnly)
+
+List jobs in the queue with cursor-based pagination.
+
+**Wraps:** `GET /index/jobs/?limit=&offset=`
+
+**Input:**
+
+| Field | Type | Default | Constraints |
+|---|---|---|---|
+| `limit` | int | `20` | 1–100 |
+| `cursor` | string? | null | opaque base64-encoded offset from previous response |
+
+**Output:** `{jobs: [JobSummary], next_cursor?}`
+
+**Use when:** the model needs to enumerate background work — e.g. "find any stuck indexing jobs from yesterday".
+
+### `cancel_job` (destructive)
+
+Cancel an indexing job. **Requires a `confirm: true` argument as a destructive-operation guard** (enforced by the JSON Schema — calls without it fail validation).
+
+**Wraps:** `DELETE /index/jobs/{job_id}`
+
+**Input:** `{job_id: string, confirm: true}`
+
+**Output:** `{job_id, cancelled: bool, message?}`
+
+**Use when:** stopping a runaway re-index. Host clients typically prompt the user before allowing destructive tools — keep this tool out of any `allowed_tools` auto-approve list unless you trust the caller.
+
+### `server_health` (readOnly)
+
+Return Agent Brain server health, version, and mode.
+
+**Wraps:** `GET /health/`
+
+**Input:** none.
+
+**Output:** `{status, version, message?, mode?, instance_id?}`
+
+**Use when:** the model wants a quick liveness check (also called at MCP startup for the version-compat gate).
+
+---
+
+## Resource reference (5 resources)
+
+Resources are *read-on-demand only* in v1 — `resources/subscribe` lands in v2. All resources return JSON (`mime_type: application/json`) and mirror a backend `/health/*` or `/index/*` endpoint.
+
+| URI | Mirrors | What's inside |
+|---|---|---|
+| `corpus://config` | `GET /health/config` | Storage backend, enabled stores (vector/BM25/graph), embedding model, reranker config, file-watcher status. |
+| `corpus://status` | `GET /health/status` | Indexed document counts, in-progress jobs, queue depth, graph-index size, embedding + query cache hit rates. |
+| `corpus://health` | `GET /health/` | Server status, message, version, mode (project/shared), instance_id, project_id. |
+| `corpus://providers` | `GET /health/providers` | Active embedding / summarization / reranker provider per type with healthy / degraded / unavailable state and validation errors. |
+| `corpus://folders` | `GET /index/folders/` | Array of indexed folders with `chunk_count`, `last_indexed`, `watch_mode`, and `watch_debounce_seconds`. |
+
+**Use resources when** the model needs corpus *state* (what's indexed, what mode is configured, is the watcher running) rather than corpus *content*. Resource reads are an HTTP `GET` against the backend with no LLM round-trip — cheaper than calling a tool to fetch the same info.
+
+**Example read (MCP JSON-RPC):**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "method": "resources/read",
+  "params": { "uri": "corpus://folders" }
+}
+```
+
+Response (truncated):
+
+```json
+{
+  "contents": [
+    {
+      "uri": "corpus://folders",
+      "mimeType": "application/json",
+      "text": "{\"folders\":[{\"folder_path\":\"/Users/me/app/docs\",\"chunk_count\":1284,\"last_indexed\":\"2026-05-29T10:14:32Z\",\"watch_mode\":\"poll\",\"watch_debounce_seconds\":2}]}"
+    }
+  ]
+}
+```
+
+---
+
+## Prompt reference (6 prompts)
+
+Prompts are parameterized message sequences the MCP server returns from `prompts/get`. The host model then executes the implied tool plan. They are pure templates — no backend call happens inside `prompts/get` itself; the model still issues the tool calls.
+
+### `find-callers`
+
+Find every function that calls a given symbol (graph-walk).
+
+| Argument | Required | Description |
+|---|---|---|
+| `symbol` | yes | The function or method name to find callers of. |
+| `language` | no | Optional language restriction (`python`, `ts`, …). |
+
+**Implied tool plan:** `search_documents(mode=graph, relationship_types=["calls"], query=<symbol>)`, group results by file.
+
+**Use when:** the user asks "where is `X` called from?" and you want a callsite-by-file report.
+
+### `find-implementation`
+
+Two-step BM25 + graph walk to surface a feature's primary implementation site and its tests.
+
+| Argument | Required | Description |
+|---|---|---|
+| `feature` | yes | The feature, concept, or symbol to locate. |
+
+**Implied tool plan:**
+1. `search_documents(mode=bm25, query=<feature>)` for exact symbol matches.
+2. `search_documents(mode=graph, …)` on the top match to walk to tests + helpers.
+
+**Use when:** "show me where the X feature lives, plus its tests".
+
+### `explain-architecture`
+
+Multi-stage retrieval restricted to a folder, then a graph walk to produce an architectural summary.
+
+| Argument | Required | Description |
+|---|---|---|
+| `folder` | yes | Folder (relative to project root) to explain. |
+| `depth` | no (default `2`) | Graph walk depth. |
+
+**Implied tool plan:**
+1. `search_documents(mode=multi, file_paths=[<folder>/**])` to pull READMEs, entrypoints, high-level docs.
+2. `search_documents(mode=graph)` on the top entrypoint symbols at `depth=<depth>`.
+
+**Use when:** onboarding to or reviewing a specific subdirectory.
+
+### `compare-search-modes`
+
+Run the same query under BM25, hybrid, and multi modes and present the three result sets side-by-side.
+
+| Argument | Required | Description |
+|---|---|---|
+| `query` | yes | The query to compare. |
+
+**Implied tool plan:** three `search_documents` calls with different `mode` values; side-by-side report.
+
+**Use when:** tuning retrieval — figuring out which mode answers a given question best.
+
+### `onboard-to-codebase`
+
+Build a "where to start" briefing by reading config + folders resources and surfacing top entrypoints.
+
+| Argument | Required | Description |
+|---|---|---|
+| `area` | no | Optional folder or topic to scope the briefing. |
+
+**Implied tool plan:**
+1. `resources/read corpus://config` for backend setup.
+2. `resources/read corpus://status` for index size and state.
+3. `resources/read corpus://folders` for what's indexed.
+4. `search_documents(mode=multi, …)` for top entrypoints.
+
+**Use when:** new contributors arrive and you want a one-shot "read these files, in this order" briefing.
+
+### `audit-indexed-folders`
+
+Read `corpus://folders`, identify stale (>7 days) and unwatched folders, and suggest `index_folder` calls.
+
+| Argument | Required | Description |
+|---|---|---|
+| (none) | — | — |
+
+**Implied tool plan:** `resources/read corpus://folders`; categorize; suggest re-index commands.
+
+**Use when:** doing periodic corpus hygiene.
+
+---
+
+## End-to-end worked examples
+
+### 1. Index a folder and poll the job to completion
+
+```jsonc
+// 1. Queue the index
+→ {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{
+    "name":"index_folder",
+    "arguments":{"folder_path":"./docs","include_code":false}
+  }}
+
+← {"jsonrpc":"2.0","id":1,"result":{
+    "content":[{"type":"text","text":"Queued indexing of ./docs (job_id=ix-abc123)"}],
+    "structuredContent":{
+      "job_id":"ix-abc123","status":"queued",
+      "folder_path":"./docs","progress_percent":0.0
+    }
+  }}
+
+// 2. Poll until completed (host loops, e.g. every 2-5s)
+→ {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{
+    "name":"get_job","arguments":{"job_id":"ix-abc123"}
+  }}
+
+← {"jsonrpc":"2.0","id":2,"result":{
+    "structuredContent":{
+      "job_id":"ix-abc123","status":"completed",
+      "progress_percent":100.0,
+      "started_at":"2026-05-30T10:00:01Z",
+      "completed_at":"2026-05-30T10:01:47Z"
+    }
+  }}
+```
+
+v1 has no `wait_for_job` — the host (or model) drives the poll loop. v2 will add server-side progress notifications.
+
+### 2. Search and interpret results using a resource
+
+```jsonc
+// 1. Run a hybrid search with explanations on
+→ tools/call search_documents { "query":"jwt refresh", "mode":"hybrid", "alpha":0.6, "explain":true }
+
+// 2. Read corpus://config to understand what model + reranker produced those scores
+→ resources/read corpus://config
+← { "contents":[{"text":"{\"embedding_model\":\"text-embedding-3-large\",\"reranker\":{\"enabled\":true,\"model\":\"cohere-rerank-3\"},\"storage_backend\":\"chroma\"}"}] }
+```
+
+Reading `corpus://config` after a search lets the model contextualize the result list ("scores look low because reranker is disabled", "BM25 ignored because the bm25 store is off") without an extra tool call.
+
+### 3. Onboard to a new codebase with the `onboard-to-codebase` prompt
+
+```jsonc
+// 1. Host asks the server to expand the prompt with arguments
+→ {"jsonrpc":"2.0","id":1,"method":"prompts/get","params":{
+    "name":"onboard-to-codebase","arguments":{"area":"auth"}
+  }}
+
+← {"jsonrpc":"2.0","id":1,"result":{
+    "messages":[{"role":"user","content":{"type":"text","text":"Produce an onboarding briefing for this codebase focused on `auth`. Plan: 1. Read corpus://config ... 2. Read corpus://status ... 3. Read corpus://folders ... 4. Call search_documents (mode=multi) for the top entrypoints in `auth` ..."}}]
+  }}
+
+// 2. Host feeds those messages to the model, which then issues the
+//    implied resources/read + tools/call sequence on its own.
+```
+
+The prompt itself doesn't call tools — it returns the script the model should execute. This is the MCP equivalent of a runbook.
+
+---
+
+## Error handling
+
+HTTP backend errors are mapped to MCP JSON-RPC error codes per a fixed table. Every error carries `data.httpStatus` and `data.cause` so clients can distinguish transport-level failures from backend-rejected requests.
+
+| HTTP | MCP code | Name | Notes |
+|---|---|---|---|
+| 400 / 404 / 422 | `-32602` | `InvalidParams` | Pydantic validation detail echoed in `data.cause`. |
+| 409 | `-32000` | `BackendConflict` | Custom Agent Brain code. |
+| 500 | `-32603` | `InternalError` | Standard JSON-RPC. |
+| 502 | `-32001` | `BackendUnavailable` | Custom — UDS missing or HTTP unreachable. |
+| 503 | `-32002` | `ServiceIndexing` | Custom — indexing in progress, retry later. |
+| 504 | `-32003` | `BackendTimeout` | Custom — wraps `httpx.TimeoutException`. |
+
+Transport-level errors (connection refused, read timeout) surface as the same custom codes (`-32001`, `-32003`), so MCP clients can tell "backend down" from "backend rejected my request" with one check.
+
+**Version-compat startup check.** The server calls `GET /health/` once at startup and refuses to start if the backend reports a `version` below the pinned floor (`MIN_BACKEND_VERSION` in `agent_brain_mcp/server.py`). If this fires, upgrade the backend (`pip install -U agent-brain-rag agent-brain-cli`) and restart it. The pin is intentional — it prevents the MCP wire from drifting from the server it talks to.
+
+---
+
+## Cancellation
+
+MCP `notifications/cancelled` propagates. Every tool and resource handler runs in `asyncio.to_thread` so the asyncio event loop stays responsive while a sync `httpx` call is in flight. Cancelling a tool call returns control to the MCP client within ~1 second; the underlying OS-level request may still complete in the background (Python can't portably kill threads), but the MCP-side handler unblocks cleanly. v1 has no long-running tools (no `wait_for_job` — that's v2), so this is a fast-path guarantee.
+
+---
+
+## Troubleshooting
+
+**"Server fails to start with version-floor error."** The backend is older than `MIN_BACKEND_VERSION`. Upgrade both:
+
+```bash
+pip install -U agent-brain-rag agent-brain-cli agent-brain-ag-mcp
+agent-brain stop && agent-brain start
+```
+
+**"Connection refused" / "Backend Unavailable (-32001)".** The backend isn't running, or the MCP server resolved the wrong state directory. Check:
+
+```bash
+agent-brain status                       # is the backend up?
+agent-brain-mcp --backend http --backend-url http://127.0.0.1:8000   # bypass UDS to isolate
+echo $AGENT_BRAIN_STATE_DIR              # does it match the project that ran `agent-brain start`?
+```
+
+**"Backend Timeout (-32003)" on long indexing jobs.** Expected for large folders — `index_folder` is async and returns immediately, but `get_job` calls use the backend's default timeout. Poll less aggressively or raise the backend timeout. (v2's `wait_for_job` will push progress notifications.)
+
+**"Tool not found" or tools missing in the host.** The host probably hasn't picked up the new `mcpServers` entry. Restart Claude Desktop / your IDE after editing the config. In Claude Agent SDK, confirm `allowed_tools` uses the `mcp__<server-name>__<tool-name>` shape (e.g. `mcp__agent-brain__search_documents`).
+
+**"agent-brain-mcp: command not found"** in the host. The host launches the subprocess with its own PATH, which may not include your user `bin`. Use the absolute path:
+
+```bash
+which agent-brain-mcp   # paste the result into "command"
+```
+
+**Multiple projects bleeding into each other.** Each MCP host entry must pin its own `AGENT_BRAIN_STATE_DIR` env var. Don't rely on `$CWD/.agent-brain` — the host's CWD is rarely your project root.
+
+---
+
+## What's not in v1, and what's coming
+
+**Not in v1:**
+
+- Resource subscriptions (`resources/subscribe`) — v2.
+- Streamable HTTP MCP transport — v2 (stdio only in v1).
+- `chunk://<id>` and `graph-entity://<type>/<id>` resource schemes — v2 (need new backend endpoints).
+- 9 deferred tools: `explain_result`, `add_documents`, `inject_documents`, `wait_for_job`, `list_folders`, `remove_folder`, `cache_status`, `clear_cache`, `list_file_types` — v2.
+- CLI-via-MCP (`agent-brain --transport mcp`) and the agent-framework adapter matrix — v3.
+- OAuth 2.1 for remote Agent Brain instances — v4.
+
+See [`docs/roadmaps/mcp/`](./roadmaps/mcp/) for per-version scope:
+
+- [v2 — subscriptions and resources](./roadmaps/mcp/v2-subscriptions-and-resources.md)
+- [v3 — CLI-via-MCP and frameworks](./roadmaps/mcp/v3-cli-via-mcp-and-frameworks.md)
+- [v4 — OAuth for remote](./roadmaps/mcp/v4-oauth-for-remote.md)
+
+---
+
+## Related docs
+
+- [Plugin Guide](./PLUGIN_GUIDE.md) — the slash-command companion for Claude Code / OpenCode / Gemini CLI / Codex.
+- [User Guide](./USER_GUIDE.md) — backend setup, indexing, retrieval modes, multi-instance architecture.
+- [API Reference](./API_REFERENCE.md) — FastAPI backend schemas (every MCP tool wraps one of these).
+- [Configuration](./CONFIGURATION.md) — provider configuration (embedding, summarization, reranker).
+- [GraphRAG Guide](./GRAPHRAG_GUIDE.md) — context for `mode: graph` searches.
+- [MCP + UDS design doc](./plans/2026-05-28-mcp-uds-transport-design.md) — internal design (UDS bind strategy, package layering, future work).
+- [MCP meta-roadmap](./roadmaps/mcp/) — v1 shipped, v2/v3/v4 planned scope.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1020,9 +1020,7 @@ The dual-bind path runs two `uvicorn.Server` instances on the shared asyncio loo
 
 ## Using Agent Brain via MCP
 
-Agent Brain ships an MCP (Model Context Protocol) server — `agent-brain-mcp` — that exposes the indexed corpus as **7 tools, 5 read-only resources, and 6 prompts** over stdio. LLM clients that speak MCP (Claude Desktop, Claude Code's MCP support, Cline, Continue.dev, Cursor, Goose) can call Agent Brain directly without shelling out to the CLI.
-
-### Claude Desktop / Code config
+Agent Brain ships an MCP (Model Context Protocol) server — `agent-brain-mcp` — that exposes the indexed corpus as **7 tools, 5 read-only resources, and 6 prompts** over stdio. Any MCP-aware host (Claude Desktop, Cursor, Windsurf, Claude Agent SDK, LangChain DeepAgents, …) can call Agent Brain directly without shelling out to the CLI.
 
 ```json
 {
@@ -1036,76 +1034,9 @@ Agent Brain ships an MCP (Model Context Protocol) server — `agent-brain-mcp` �
 }
 ```
 
-`--backend auto` tries UDS first and falls back to HTTP. Set `--backend uds` or `--backend http` to force one. Override the backend URL with `--backend-url http://127.0.0.1:9100` or `AGENT_BRAIN_MCP_BACKEND_URL`.
+For per-host configuration (Claude Desktop, Cursor / Windsurf, Claude Agent SDK, LangChain DeepAgents), the full tool/resource/prompt reference with schemas, end-to-end worked examples, error-mapping table, troubleshooting, and the v2–v4 roadmap, see **[MCP User Guide](./MCP_USER_GUIDE.md)**.
 
-The MCP server runs a one-time version-compat check at startup: it calls `GET /health/` and refuses to start when the backend reports a `version` below the pinned floor (`MIN_BACKEND_VERSION` in `agent_brain_mcp/server.py`). This prevents the MCP wire from drifting from the server it talks to.
-
-### The 7 tools
-
-| Tool | What it does |
-|---|---|
-| `search_documents` | All 5 retrieval modes (`semantic`, `bm25`, `hybrid`, `graph`, `multi`) via `mode` param. Returns ranked chunks with paths and scores. |
-| `query_count` | Total documents + total chunks currently indexed. |
-| `index_folder` | Queue a folder for indexing. Returns `{job_id, status}`. Honors `include_code`, `chunk_size`, `chunk_overlap`, `force`, `allow_external`. |
-| `get_job` | Poll a specific indexing job. |
-| `list_jobs` | List queue with cursor pagination (opaque base64 offset). |
-| `cancel_job` | Cancel a job. Requires `confirm: true` in input as a destructive-op gate (JSON-Schema-enforced). |
-| `server_health` | Server health, version, mode. |
-
-Each response includes both a `content` block (human-readable summary) and a `structuredContent` payload with declared `outputSchema` — so models that consume MCP structured output get typed data, not just text.
-
-### The 5 resources (read-only)
-
-| URI | Mirrors | What the model sees |
-|---|---|---|
-| `corpus://config` | `GET /health/config` | Storage backend, vector/BM25/graph enable flags, embedding + rerank model names, graph extractor, watcher state |
-| `corpus://status` | `GET /health/status` | `total_chunks`, `total_documents`, indexing in progress, current job, queue depth, cache hit rates |
-| `corpus://health` | `GET /health/` | Status, version, mode, instance_id, project_id |
-| `corpus://providers` | `GET /health/providers` | Active embedding/summarization/reranker provider, model name, healthy/degraded/unavailable |
-| `corpus://folders` | `GET /index/folders/` | Indexed folders with chunk counts, last-indexed timestamps, watch mode |
-
-`resources.subscribe` is **not** advertised in v1 — clients fetch with `resources/read` on demand. Subscriptions land in v2 (see Roadmap in CHANGELOG `[10.1.0]`).
-
-### The 6 prompts
-
-| Prompt | Arguments | What it does |
-|---|---|---|
-| `find-callers` | `symbol` (required), `language` (optional) | Graph-mode search for callers of `symbol`, returns ranked source paths. |
-| `find-implementation` | `feature` (required) | Two-step: BM25 for exact match, then graph walk to tests + related code. |
-| `explain-architecture` | `folder` (required), `depth` (default 2) | Multi-mode search restricted to `folder`, pulls READMEs + entrypoints + graph at depth. |
-| `compare-search-modes` | `query` (required) | Runs same query under BM25/hybrid/multi and shows the three result sets side by side. |
-| `onboard-to-codebase` | `area` (optional) | Reads config + folders resources, runs search for top entrypoints in `area`, produces a "where to start" briefing. |
-| `audit-indexed-folders` | (none) | Reads `corpus://folders`, identifies stale (>7 days) and unwatched folders, suggests `index_folder` calls. |
-
-### Error handling
-
-HTTP backend errors are mapped to MCP JSON-RPC error codes per a fixed table — every error carries `data.httpStatus` and `data.cause`:
-
-| HTTP | MCP code | Notes |
-|---|---|---|
-| 400 / 404 / 422 | `-32602 InvalidParams` | Pydantic validation detail echoed |
-| 409 | `-32000 InvalidRequest` | Conflict (custom code) |
-| 500 | `-32603 InternalError` | |
-| 502 | `-32001 BackendUnavailable` | UDS gone / HTTP unreachable (custom) |
-| 503 | `-32002 ServiceIndexing` | Indexing-in-progress (custom) |
-| 504 | `-32003 BackendTimeout` | Wrapped httpx timeout (custom) |
-
-Transport-level errors (connect refused, read timeout) map to the same custom codes (`-32001`, `-32003`) so MCP clients can distinguish "backend down" from "backend rejected my request".
-
-### Cancellation
-
-MCP `notifications/cancelled` propagates: every tool/resource handler runs in `asyncio.to_thread` so the asyncio event loop stays responsive while a sync `httpx` call is in flight. Cancelling a tool call returns control to the MCP client within ~1 second; the underlying OS-level request may still complete in the background (Python can't portably kill threads), but the MCP-side handler unblocks cleanly. v1 has no long-running tools (no `wait_for_job` — that's v2), so this is a fast-path guarantee.
-
-### What's not in v1
-
-- Resource **subscriptions** (`resources/subscribe`) — v2
-- Streamable HTTP MCP transport — v2 (stdio only in v1)
-- `chunk://<id>` and `graph-entity://<type>/<id>` resource schemes — v2 (need new server endpoints)
-- 9 deferred tools: `explain_result`, `add_documents`, `inject_documents`, `wait_for_job`, `list_folders`, `remove_folder`, `cache_status`, `clear_cache`, `list_file_types` — v2
-- CLI-via-MCP (`agent-brain --transport mcp`) and framework adapter matrix — v3
-- OAuth 2.1 for remote Agent Brain — v4
-
-See `docs/roadmaps/mcp/` for the per-version roadmap bodies.
+For the slash-command companion that runs inside Claude Code / OpenCode / Gemini CLI / Codex, see **[Plugin Guide](./PLUGIN_GUIDE.md)**.
 
 ---
 

--- a/docs/plans/2026-05-30-mcp-user-guide.md
+++ b/docs/plans/2026-05-30-mcp-user-guide.md
@@ -1,0 +1,97 @@
+# Plan: Agent Brain MCP Server User Guide
+
+## Context
+
+The MCP server (`agent-brain-mcp`, PyPI distribution `agent-brain-ag-mcp`) shipped in v10.1.0 (Phase 4 of the MCP/UDS rollout) and currently has only ~90 lines of user-facing documentation embedded in `docs/USER_GUIDE.md` (lines 1021–1110) plus a 37-line `agent-brain-mcp/README.md`. The MCP roadmap meta-doc (`docs/roadmaps/mcp/README.md`) and the design doc (`docs/plans/2026-05-28-mcp-uds-transport-design.md`) are internal-facing.
+
+A symmetric `docs/PLUGIN_GUIDE.md` already exists for the slash-command plugin. The MCP server has no equivalent dedicated user guide — users arriving via PyPI, Claude Desktop, Cursor, or an MCP-capable agent framework have no single doc that answers "what is this, how do I configure it, what verbs does it expose, when do I use it instead of the plugin?".
+
+This plan creates `docs/MCP_USER_GUIDE.md` as a comprehensive standalone guide, then trims the existing USER_GUIDE.md MCP section to a short cross-link so we don't fork content. The package README gets a minor pointer update.
+
+The guide must answer (from the user's request):
+1. What verbs (tools) are available
+2. How to configure (per client)
+3. When to use MCP vs the plugin
+4. How to use the MCP server end-to-end
+5. What features it provides
+
+## Approach
+
+Single canonical user guide at `docs/MCP_USER_GUIDE.md`, modeled on the structure of `docs/PLUGIN_GUIDE.md`, with reference tables drawn from the existing USER_GUIDE.md MCP section as the spine. Worked examples and the MCP-vs-plugin decision matrix are new material. No source code changes — documentation only.
+
+### Outline of `docs/MCP_USER_GUIDE.md`
+
+1. **What is the MCP server?** — One-paragraph definition: thin MCP/stdio adapter over the existing FastAPI backend; 7 tools + 5 resources + 6 prompts; ships as PyPI package `agent-brain-ag-mcp`; console script `agent-brain-mcp`.
+2. **MCP vs the plugin — when to use which** — Decision matrix. Plugin = Claude Code/OpenCode/Gemini CLI slash-commands (CLI-shell pattern). MCP = Claude Desktop, Cursor, Windsurf, Claude Agent SDK, LangChain DeepAgents, and any MCP-aware agent framework. Both target the same backend; you can run both side-by-side.
+3. **Features at a glance** — Bullet list: 5 retrieval modes via `mode` param, structured-output tool responses (`outputSchema`-typed), corpus state resources (no LLM call needed to read config/status/folders/health/providers), opinionated multi-step prompts, UDS-or-HTTP backend transport, version-compat startup check, JSON-RPC error mapping with custom `-32000..-32003` codes.
+4. **Installation** — `pip install agent-brain-ag-mcp` (resolves console script `agent-brain-mcp`). Note: requires a running `agent-brain-server` (install with `pip install agent-brain-rag agent-brain-cli`, then `agent-brain init && agent-brain start`).
+5. **Configuration** — One subsection per client, each showing the stdio config and explaining the env vars:
+   - **Claude Desktop** — `claude_desktop_config.json` snippet with `command`, `args`, `env` (location varies by OS).
+   - **Cursor / Windsurf / generic IDE** — Generic stdio JSON snippet usable in any MCP-aware editor.
+   - **Claude Agent SDK** — Anthropic's `claude-agent-sdk` Python/TS snippet: register `agent-brain-mcp` as an `mcpServers` entry when constructing an Agent, call tools through the SDK's tool-use interface.
+   - **LangChain DeepAgents** — Snippet using LangChain's MCP client adapter (`langchain-mcp-adapters` or DeepAgent's MCP loader) to load tools from the `agent-brain-mcp` stdio process and pass them to a DeepAgent.
+   - **(Preview)** — One short paragraph: v3 roadmap covers first-party adapters for OpenAI Agents SDK, LlamaIndex, Pydantic AI, Mastra, Vercel AI SDK, Autogen. Link to `docs/roadmaps/mcp/v3-cli-via-mcp-and-frameworks.md`.
+6. **CLI flags + environment variables** — Table of all flags from `agent_brain_mcp/cli.py` (`--backend`, `--backend-url`, `--state-dir`) and env vars from `agent_brain_mcp/config.py` (`AGENT_BRAIN_MCP_BACKEND`, `AGENT_BRAIN_MCP_BACKEND_URL`, `AGENT_BRAIN_URL`, `AGENT_BRAIN_UDS_PATH`, `AGENT_BRAIN_STATE_DIR`), with precedence rules.
+7. **Tool reference (7 tools)** — Expand the existing 7-row table from USER_GUIDE.md into one subsection per tool. For each: purpose, input schema (full field list with types, defaults, constraints — pulled from `agent_brain_mcp/schemas.py`), output schema, REST endpoint it wraps, MCP annotations (readOnly / destructive / openWorld), example call (inline-rendered as MCP JSON-RPC), and a one-line "use when" hint.
+8. **Resource reference (5 resources)** — One row per `corpus://` URI: what's inside, when to read it, JSON shape (link to mirrored REST endpoint for full schema), and a worked example showing the MCP `resources/read` request and a representative response payload.
+9. **Prompt reference (6 prompts)** — One subsection per prompt: arguments, the tool/resource sequence the prompt orchestrates, a worked example showing the rendered prompt messages and what the model is asked to do, and a "use when" hint.
+10. **End-to-end worked examples** — Three short narratives, each ~15-20 lines, with tool-call JSON:
+    - **Index a folder and poll the job** — `index_folder` → loop on `get_job` until `status: completed`.
+    - **Search and explain results** — `search_documents` with `mode: hybrid`, `explain: true`, then read `corpus://config` to interpret the scoring.
+    - **Onboard to a new codebase** — Invoke the `onboard-to-codebase` prompt; show how it reads `corpus://config`, `corpus://folders`, and runs a multi-mode search under the hood.
+11. **Error handling** — Reuse the existing HTTP→MCP error mapping table; add a paragraph on the version-compat startup check (server refuses to start if backend `version` is below `MIN_BACKEND_VERSION`) and what to do when that fires.
+12. **Cancellation** — Reuse the existing cancellation paragraph (one paragraph: `notifications/cancelled` propagates, handlers wake within ~1s).
+13. **Troubleshooting** — Specific failure modes:
+    - "Server fails to start with version-floor error" → upgrade `agent-brain-rag`/`agent-brain-server` to match `MIN_BACKEND_VERSION`.
+    - "Connection refused" → backend not running; run `agent-brain start`.
+    - "Backend Unavailable (-32001)" → UDS socket missing or backend died; switch to `--backend http` to bypass UDS.
+    - "Backend Timeout (-32003)" on long indexing jobs → expected for big folders; use `get_job` to poll (v2 will add `wait_for_job`).
+    - "Tool not found" in client → confirm the client picked up the new `mcpServers` entry (restart the client after config change).
+14. **What's not in v1, what's coming** — Reuse the existing "deferred" list from USER_GUIDE.md and link `docs/roadmaps/mcp/v2-…`, `v3-…`, `v4-…` for the per-version scope.
+15. **Related docs** — Cross-links to `PLUGIN_GUIDE.md`, `USER_GUIDE.md`, `API_REFERENCE.md`, `CONFIGURATION.md`, and the design/roadmap docs.
+
+### Files to modify
+
+| File | Change |
+|---|---|
+| `docs/MCP_USER_GUIDE.md` | **Create** new file (the outline above; estimated 600–800 lines including JSON examples). |
+| `docs/USER_GUIDE.md` (lines 1021–1110) | **Replace** the existing "Using Agent Brain via MCP" section with a ~15-line summary that links to `MCP_USER_GUIDE.md`. Keep the Claude Desktop snippet inline so casual readers still see one config example without leaving the page. |
+| `agent-brain-mcp/README.md` | **Minor edit**: update the "Status" line (which still says "Phase 0 scaffold (10.0.7)" even though v1 shipped in 10.1.0) and add a "Full guide" pointer to `docs/MCP_USER_GUIDE.md`. Keep the quick config snippet for PyPI/GitHub package-page viewers. |
+| `docs/plans/2026-05-30-mcp-user-guide.md` | **Create** a copy of this plan in the repo's plans directory (per `CLAUDE.md`: "after any planning step, save the plan to `docs/plans/<name>.md` before doing work"). |
+
+### Sources to draw from (existing material to reuse, not re-derive)
+
+- **Tool/resource/prompt tables** — Already correct in `docs/USER_GUIDE.md` lines 1043–1078; expand with schema detail.
+- **Error mapping table** — `docs/USER_GUIDE.md` lines 1082–1093 (verbatim).
+- **Cancellation paragraph** — `docs/USER_GUIDE.md` line 1097 (verbatim).
+- **Input/output schemas** — Read from `agent-brain-mcp/agent_brain_mcp/schemas.py` lines 35–158 (every model is annotated; copy field-by-field).
+- **CLI flags** — `agent-brain-mcp/agent_brain_mcp/cli.py` lines 1–56.
+- **Env-var resolution chain** — `agent-brain-mcp/agent_brain_mcp/config.py` lines 1–155.
+- **Tool→REST mapping** — `agent-brain-mcp/agent_brain_mcp/client.py` lines 1–125 (one method per tool).
+- **Prompt orchestration logic** — `agent-brain-mcp/agent_brain_mcp/prompts/*.py` (each file is one prompt and is self-contained; the tool sequence it asks the model to follow is in the messages it returns).
+- **Plugin install + commands** (for the "MCP vs plugin" section) — `agent-brain-plugin/README.md` and `agent-brain-cli/agent_brain_cli/commands/`.
+- **v2/v3/v4 deferred items** — `docs/roadmaps/mcp/v{2,3,4}-*.md`.
+
+### Sources to fetch fresh (not in training data)
+
+- **Claude Agent SDK MCP server registration** — Use `ctx7` to resolve and pull docs for `claude-agent-sdk` (Anthropic's Python/TS SDK). The exact `mcpServers` API on Agent construction may have changed.
+- **LangChain DeepAgents MCP loader** — Use `ctx7` to resolve `deepagents` (or `langchain-mcp-adapters`) and pull the current MCP-tool-loading snippet.
+
+The fetched snippets go straight into §5 (Configuration). Don't paraphrase APIs from memory.
+
+## Verification
+
+Documentation-only change, no code execution needed for correctness. Verify by:
+
+1. **Render check** — Preview `docs/MCP_USER_GUIDE.md` in a Markdown viewer (or `gh` web view after push) and confirm every code block, table, and cross-link renders cleanly.
+2. **Link check** — All internal cross-links (`./PLUGIN_GUIDE.md`, `./USER_GUIDE.md`, `./API_REFERENCE.md`, `./roadmaps/mcp/*.md`, `../agent-brain-mcp/agent_brain_mcp/*.py`) resolve to real files. Run `grep -oE '\]\([^)]+\)' docs/MCP_USER_GUIDE.md | sort -u` and spot-check each path with `ls`.
+3. **Tool/resource/prompt parity** — Diff the new tool table against the registry in `agent-brain-mcp/agent_brain_mcp/tools/__init__.py` lines 76–150, resources against `resources/corpus.py` lines 62–108, and prompts against `prompts/__init__.py` lines 20–27. Counts must match (7 / 5 / 6) and names must be byte-exact.
+4. **Schema parity** — Spot-check 2–3 tool input schemas in the guide against the matching Pydantic models in `agent_brain_mcp/schemas.py`. Default values and constraints (e.g. `top_k: int = 10 (1-100)`) must match the model definitions.
+5. **Worked-example smoke test** — Run the two non-destructive worked examples against a live local backend to confirm the JSON-RPC requests are valid:
+   ```bash
+   agent-brain start          # ensure backend is up
+   agent-brain-mcp --backend auto < tests/example-list-tools.jsonl
+   ```
+   Where `example-list-tools.jsonl` contains the `tools/list`, `resources/list`, and `prompts/list` requests from the guide. (The repo's `agent-brain-mcp/tests/test_tools_list.py` already covers this — borrow its harness pattern for an ad-hoc check.)
+6. **Lint/format** — Run `task before-push` from the repo root before pushing (per `CLAUDE.md`'s mandatory rule). Even though no Python changes, the task may include doc linting (e.g. markdownlint, link checkers) that must pass.
+7. **Plan-of-record** — After completion, copy this plan to `docs/plans/2026-05-30-mcp-user-guide.md` so the repo retains the planning artifact (per project convention).


### PR DESCRIPTION
## Summary

- Adds `docs/MCP_USER_GUIDE.md` (680 lines) as the canonical user-facing guide for `agent-brain-mcp`: plugin-vs-MCP decision, per-host configuration (Claude Desktop, Cursor/Windsurf, Claude Agent SDK, LangChain DeepAgents via `langchain-mcp-adapters`), full reference for all 7 tools / 5 resources / 6 prompts with input/output schemas pulled from `agent_brain_mcp/schemas.py`, three end-to-end worked examples, error mapping, cancellation, troubleshooting, and v2–v4 roadmap pointers.
- Trims the embedded MCP section in `docs/USER_GUIDE.md` (~90 lines) to a short summary that keeps one config snippet inline and links to the new guide.
- Refreshes `agent-brain-mcp/README.md`: clears the stale "Phase 0 scaffold (10.0.7)" status (v1 shipped in 10.1.0), adds `pip install agent-brain-ag-mcp` and a "Full guide" pointer.
- Plan-of-record saved to `docs/plans/2026-05-30-mcp-user-guide.md`.

## Verification

Documentation-only change. Verified locally:

- `task before-push` — passed (lint, typecheck, 416 tests, 80% coverage).
- Tool / resource / prompt name parity — diffed against `tools/__init__.py`, `resources/corpus.py`, `prompts/__init__.py`. Counts match (7 / 5 / 6); names byte-exact.
- Schema parity — spot-checked `search_documents` and `index_folder` input tables against `agent_brain_mcp/schemas.py`. Defaults and constraints (e.g. `top_k: int = 10 (1-100)`, `alpha: float = 0.5 (0.0-1.0)`) match field-for-field.
- Internal cross-links — every `./PLUGIN_GUIDE.md`, `./USER_GUIDE.md`, `./API_REFERENCE.md`, `./CONFIGURATION.md`, `./GRAPHRAG_GUIDE.md`, `./plans/...`, and `./roadmaps/mcp/...` reference resolves to a real file; the one anchor (`#multi-project-support`) is verified against `USER_GUIDE.md`.

## Test plan

- [ ] Render `docs/MCP_USER_GUIDE.md` in the GitHub web view; confirm tables and fenced JSON blocks display cleanly.
- [ ] Click through every cross-link from the new guide (Related docs section + inline references) and confirm each lands on the right page / section.
- [ ] Spot-check the Claude Agent SDK and `langchain-mcp-adapters` snippets against the current upstream READMEs — the API shapes were fetched fresh via ctx7 (`/anthropics/claude-agent-sdk-python`, `/langchain-ai/langchain-mcp-adapters`) but worth a sanity check before publication.
- [ ] Optional: run the §End-to-end worked example #1 against a live local backend (`agent-brain start` → MCP `tools/call index_folder` → `tools/call get_job`) to confirm the JSON-RPC shapes are byte-exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)