### PR TITLE
chore(planning): log two latent CI/test issues surfaced by PR #197 as TODOs

### DIFF
--- a/.planning/todos/pending/2026-06-09-flaky-sentence-transformer-warm-up-hits-huggingface-from-unit-tests.md
+++ b/.planning/todos/pending/2026-06-09-flaky-sentence-transformer-warm-up-hits-huggingface-from-unit-tests.md
@@ -1,0 +1,77 @@
+---
+created: 2026-06-09T05:30:00.000Z
+title: TestSentenceTransformerWarmUp.test_warm_up_success is a flaky network test misclassified as unit
+area: testing
+files:
+  - agent-brain-server/tests/unit/providers/test_reranker_providers.py:533-552
+---
+
+## Problem
+
+`agent-brain-server/tests/unit/providers/test_reranker_providers.py::TestSentenceTransformerWarmUp::test_warm_up_success`
+lives under `tests/unit/` but calls a real `provider.warm_up()` that downloads
+`cross-encoder/ms-marco-MiniLM-L-6-v2` (~80 MB) from huggingface.co. Same goes
+for the sibling `test_availability_caching` (same class, same model, real
+`is_available()` call).
+
+Symptom on PR #197 second CI run:
+```
+WARNING  CrossEncoder warm-up failed: We couldn't connect to 'https://huggingface.co'
+to load this file, couldn't find it in the cached files and it looks like
+cross-encoder/ms-marco-MiniLM-L-6-v2 is not the path to a directory containing
+a file named config.json.
+FAILED tests/unit/providers/test_reranker_providers.py::TestSentenceTransformerWarmUp::test_warm_up_success
+  - assert False is True
+```
+
+The third CI run passed (HF cache warm) — confirming this is purely
+network/cache-state dependent, not a real regression. But the failure mode
+silently torpedoes unrelated PRs. PR #197 burned a CI iteration on this.
+
+## Solution
+
+Two options (recommended: A):
+
+**Option A — Mock `SentenceTransformer` in the unit test.** Keep the test as a
+unit test by patching the cross-encoder class so no network call is made. This
+is the right test layer: we're verifying `warm_up()`'s state-machine behavior
+(`_model_loaded`, `_availability_checked`, `_is_available_cached`), not that
+HuggingFace serves models.
+
+```python
+from unittest.mock import patch, MagicMock
+
+def test_warm_up_success(self) -> None:
+    config = RerankerConfig(
+        provider=RerankerProviderType.SENTENCE_TRANSFORMERS,
+        model="cross-encoder/ms-marco-MiniLM-L-6-v2",
+    )
+    provider = SentenceTransformerRerankerProvider(config)
+    assert provider._model_loaded is False
+
+    with patch(
+        "agent_brain_server.providers.reranker.sentence_transformers.CrossEncoder",
+        return_value=MagicMock(),
+    ):
+        result = provider.warm_up()
+
+    assert result is True
+    assert provider._model_loaded is True
+    # ... etc
+```
+
+Apply the same pattern to `test_availability_caching`.
+
+**Option B — Move + mark as integration.** Move both tests to
+`agent-brain-server/tests/integration/providers/` and add
+`@pytest.mark.network`. Then teach CI to skip `network` tests when offline
+(or accept that integration tests can be flaky and run them in a separate job
+that doesn't gate the QA Gate). Heavier change.
+
+## Acceptance
+
+- Both tests in `TestSentenceTransformerWarmUp` run with zero network calls
+  (verify with `pytest --disable-socket` or by inspection)
+- Tests still cover the state-machine semantics: `_model_loaded`,
+  `_availability_checked`, `_is_available_cached` transitions
+- CI runs no longer flake on HuggingFace connectivity for this class

--- a/.planning/todos/pending/2026-06-09-task-before-push-scope-leak-when-cwd-is-package-subdir.md
+++ b/.planning/todos/pending/2026-06-09-task-before-push-scope-leak-when-cwd-is-package-subdir.md
@@ -1,0 +1,62 @@
+---
+created: 2026-06-09T05:30:00.000Z
+title: task before-push silently scopes to one package when invoked from a subdir, not the full monorepo
+area: tooling
+files:
+  - Taskfile.yml
+  - CLAUDE.md
+  - .claude/CLAUDE.md
+---
+
+## Problem
+
+Running `task before-push` from a package subdirectory (e.g. `agent-brain-mcp/`)
+only exercises that package's test suite. CI runs the full monorepo (server +
+CLI + mcp + plugin), so a "green local gate" can still ship code that breaks CI.
+
+This bit us on PR #197 (v10.3 phases 56–60). Local `task before-push` reported
+`544 passed, 88% coverage — All checks passed` but actually only ran the
+agent-brain-mcp package tests. CI then surfaced three CLI failures that were
+trivially fixable but cost two extra CI iterations:
+
+1. `test_backend_client_protocol.py::test_backend_client_protocol_declares_expected_methods`
+2. `test_mcp_backend_protocol.py::test_mcp_backend_protocol_declares_expected_methods`
+3. `test_mcp_start_command.py::test_start_lock_collision_exits_one`
+
+(See merged commit `2d53c76` for the fix.)
+
+CLAUDE.md and `.claude/CLAUDE.md` both say "NEVER PUSH WITHOUT TESTING" and
+mandate `task before-push` — but neither warns that the invocation directory
+matters, so the rule reads as "I ran the gate, I'm safe."
+
+## Solution
+
+Two options (pick one — or do both):
+
+**Option A — Guard in Taskfile:** Make `before-push` fail fast (or print a loud
+banner and re-exec from repo root) when invoked outside the repo root. Catches
+the mistake at the moment it happens.
+
+```yaml
+before-push:
+  preconditions:
+    - sh: test "$(pwd)" = "$(git rev-parse --show-toplevel)"
+      msg: "task before-push must run from the monorepo root (got $(pwd))"
+```
+
+**Option B — Document explicitly:** Update CLAUDE.md and `.claude/CLAUDE.md` to
+add a one-line callout under the "NEVER PUSH WITHOUT TESTING" section:
+
+> **Always run `task before-push` from the monorepo root.** Invoking it from a
+> package subdirectory silently scopes the gate to that package only — CI will
+> still catch the gap, but you'll burn a PR cycle.
+
+Recommended: do A (machine-enforced) since the docs rule already exists and is
+easy to forget. B alone won't prevent recurrence.
+
+## Acceptance
+
+- `task before-push` from `agent-brain-mcp/`, `agent-brain-cli/`, or any package
+  subdir either re-execs from root or fails with a clear message
+- Running from repo root continues to work unchanged
+- No false positives when run via CI (CI always runs from repo root)


### PR DESCRIPTION
## Summary

Two follow-up TODOs surfaced during the PR #197 (v10.3 phases 56-60) merge — neither blocked the merge, but both are worth tracking so they don't bite a future PR.

## TODOs filed in `.planning/todos/pending/`

### 1. `task before-push` silently scopes to one package when invoked from a subdir

When run from a package directory (e.g., \`agent-brain-mcp/\`), the gate only exercises that package's tests but still reports "All checks passed — Ready to push." This let three CLI test fragilities (Python 3.11 vs 3.12 \`Protocol.__protocol_attrs__\` + Click terminal-width wrap) reach CI on #197.

Recommends machine-enforced guard (Taskfile \`preconditions:\`) over docs-only fix.

### 2. \`TestSentenceTransformerWarmUp\` is a misclassified network test

\`agent-brain-server/tests/unit/providers/test_reranker_providers.py::TestSentenceTransformerWarmUp::test_warm_up_success\` lives in \`unit/\` but downloads an ~80 MB cross-encoder model from huggingface.co. Flaked on #197's second CI run (transient HF connectivity), passed on the retry. Recommends mocking \`CrossEncoder\` in-place rather than moving the test.

## Why this is just docs

No code changes — just two markdown TODOs ready for whoever picks them up next. Both gate-passes locally (\`task before-push\` clean).

## Test plan

- [x] \`task before-push\` from repo root — passes
- [ ] CI Quality Assurance Gate passes (markdown-only diff, expected pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)