### PR TITLE
security(api): v2 auth hardening — Bearer scheme + refuse-without-key gate (closes #199)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,18 +9,39 @@ API_PORT=8000
 DEBUG=false
 
 # =============================================================================
-# API Authentication (Issue #179)
+# API Authentication (Issues #179 + #199)
 # =============================================================================
-# When set, every data endpoint (/query, /index, /index/*, /graph, etc.)
-# requires the value in the `X-API-Key` request header; /health stays open.
-# When empty (default), endpoints are unauthenticated — safe ONLY on the
-# 127.0.0.1 loopback for single-user dev. The server REFUSES TO START
-# (exit 2) when API_HOST is anything other than 127.0.0.1/localhost/::1
-# and AGENT_BRAIN_API_KEY is unset. `agent-brain init` auto-generates a
-# urlsafe 32-byte key into project-local .agent-brain/config.json so the
-# CLI and MCP discover it automatically; pass --no-api-key to opt out.
-# When DEBUG=false AND a key is set, /docs and /redoc are also hidden
-# (the schema would otherwise leak the protected surface).
+# Every data endpoint (/query, /index, /index/*, /graph, etc.) requires
+# `Authorization: Bearer <token>` per RFC 6750; /health stays open. The
+# server REFUSES TO START (exit 2) on ANY bind host (loopback included)
+# when no key is configured — 127.0.0.1 is not a trust boundary on
+# multi-process machines. To run without auth (single-user dev box only),
+# pass INSECURE_NO_AUTH=true explicitly so the choice is visible in logs.
+#
+# API_KEY is the canonical v2 env var as of #199 (preferred). Set it to a
+# urlsafe 32-byte value (e.g. `python -c "import secrets;
+# print(secrets.token_urlsafe(32))"`).
+#
+# `agent-brain init` auto-generates a key into project-local
+# .agent-brain/config.json (chmod 0600) so the CLI and MCP discover it
+# automatically; pass --no-api-key to opt out at init time. `agent-brain
+# start --insecure` runs the server with INSECURE_NO_AUTH=true and strips
+# any inherited key from the subprocess env.
+#
+# When DEBUG=false AND a key is set, /docs, /redoc, and /openapi.json are
+# also hidden (the schema would otherwise leak the protected surface).
+API_KEY=
+
+# Explicit opt-out flag for the refuse-without-key startup gate (#199).
+# Mirrors Postgres --allow-empty-password and Redis protected-mode no:
+# the server starts unauthenticated and logs a loud warning at boot.
+# ONLY safe on a single-user, single-process machine.
+INSECURE_NO_AUTH=false
+
+# AGENT_BRAIN_API_KEY (deprecated since #199) — kept as a one-release
+# compatibility alias for PR #195 / #179 deployments. The Settings
+# validator backfills its value into API_KEY at startup. Switch to
+# API_KEY (above) before this alias is removed.
 AGENT_BRAIN_API_KEY=
 
 # =============================================================================

--- a/agent-brain-cli/agent_brain_cli/client/api_client.py
+++ b/agent-brain-cli/agent_brain_cli/client/api_client.py
@@ -167,13 +167,15 @@ class DocServeClient:
         Args:
             base_url: Server base URL.
             timeout: Request timeout in seconds.
-            api_key: Optional X-API-Key value (Issue #179). When supplied,
-                every outbound request carries the header. ``None`` means
-                no auth (legacy single-user loopback dev path).
+            api_key: Optional bearer token (Issues #179, #199). When supplied,
+                every outbound request carries an ``Authorization: Bearer``
+                header per RFC 6750. ``None`` means no auth header (server
+                must be in ``INSECURE_NO_AUTH=true`` mode to accept the
+                request).
         """
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
-        headers = {"X-API-Key": api_key} if api_key else None
+        headers = {"Authorization": f"Bearer {api_key}"} if api_key else None
         self._client = httpx.Client(timeout=timeout, headers=headers)
 
     @classmethod
@@ -192,9 +194,10 @@ class DocServeClient:
         Args:
             client: An already-configured ``httpx.Client``. The wrapper
                 takes ownership and will close it on ``__exit__``.
-            api_key: Optional X-API-Key to merge into the client's
-                default headers (Issue #179). Caller may also have set
-                the header on ``client`` directly; both paths work.
+            api_key: Optional bearer token to merge into the client's
+                default headers as ``Authorization: Bearer <token>``
+                (Issues #179, #199). Caller may also have set the
+                header on ``client`` directly; both paths work.
 
         Returns:
             A DocServeClient backed by ``client``.
@@ -204,7 +207,7 @@ class DocServeClient:
         timeout = client.timeout
         instance.timeout = timeout.read or 30.0
         if api_key:
-            client.headers["X-API-Key"] = api_key
+            client.headers["Authorization"] = f"Bearer {api_key}"
         instance._client = client
         return instance
 

--- a/agent-brain-cli/agent_brain_cli/client/transport.py
+++ b/agent-brain-cli/agent_brain_cli/client/transport.py
@@ -106,7 +106,7 @@ def open_backend(ctx: click.Context, *, timeout: float = 30.0) -> BackendClient:
             state_dir=state_dir,
         )
         if obj.get("debug_transport"):
-            auth_marker = "with X-API-Key" if api_key else "no auth"
+            auth_marker = "with Bearer token" if api_key else "no auth"
             target_label = mcp_target if mcp_target else "subprocess: agent-brain-mcp"
             click.echo(
                 f"[debug-transport] mcp ({mcp_transport}) -> "

--- a/agent-brain-cli/agent_brain_cli/commands/start.py
+++ b/agent-brain-cli/agent_brain_cli/commands/start.py
@@ -210,6 +210,16 @@ def update_registry(project_root: Path, state_dir: Path) -> None:
     is_flag=True,
     help="Bind only the Unix Domain Socket (no TCP listener). Implies --uds.",
 )
+@click.option(
+    "--insecure",
+    is_flag=True,
+    help=(
+        "Start the server with authentication disabled (sets INSECURE_NO_AUTH=true). "
+        "Strips any inherited API_KEY / AGENT_BRAIN_API_KEY env var so the server's "
+        "startup gate honors the opt-out unambiguously. Only safe on a single-user, "
+        "single-process machine. (Issue #199)"
+    ),
+)
 def start_command(
     path: str | None,
     host: str | None,
@@ -220,6 +230,7 @@ def start_command(
     strict: bool,
     uds: bool,
     uds_only: bool,
+    insecure: bool,
 ) -> None:
     """Start an Agent Brain server for this project.
 
@@ -368,12 +379,30 @@ def start_command(
         env = os.environ.copy()
         env["AGENT_BRAIN_PROJECT_ROOT"] = str(project_root)
         env["AGENT_BRAIN_STATE_DIR"] = str(state_dir)
-        # Issue #179: propagate the project-local API key from config.json
-        # into the server subprocess. Existing env value wins so operators
-        # can override the file-stored key without re-running init.
-        config_api_key = config.get("api_key")
-        if config_api_key and not env.get("AGENT_BRAIN_API_KEY"):
-            env["AGENT_BRAIN_API_KEY"] = str(config_api_key)
+
+        # Issue #199: --insecure short-circuits all key propagation and
+        # tells the server's startup gate to accept the auth-disabled
+        # posture explicitly. Strip any inherited key so a stale
+        # API_KEY in the shell doesn't silently re-enable auth and
+        # confuse operators who asked for --insecure on purpose.
+        if insecure:
+            env["INSECURE_NO_AUTH"] = "true"
+            env.pop("API_KEY", None)
+            env.pop("AGENT_BRAIN_API_KEY", None)
+        else:
+            # Issue #199: propagate the project-local API key from config.json
+            # into the server subprocess as ``API_KEY`` (canonical v2 name).
+            # Existing env values win so operators can override the file-
+            # stored key without re-running init. The server's Settings
+            # validator backfills the deprecated AGENT_BRAIN_API_KEY env
+            # var, so legacy env-var setters keep working.
+            config_api_key = config.get("api_key")
+            if (
+                config_api_key
+                and not env.get("API_KEY")
+                and not env.get("AGENT_BRAIN_API_KEY")
+            ):
+                env["API_KEY"] = str(config_api_key)
         if strict:
             env["AGENT_BRAIN_STRICT_MODE"] = "true"
         if enable_uds:

--- a/agent-brain-cli/agent_brain_cli/config.py
+++ b/agent-brain-cli/agent_brain_cli/config.py
@@ -415,20 +415,22 @@ def get_server_url(config: AgentBrainConfig | None = None) -> str:
 
 
 def resolve_api_key(state_dir: Path | None = None) -> str | None:
-    """Resolve the X-API-Key value the CLI should send (Issue #179).
+    """Resolve the bearer-token value the CLI should send (Issues #179, #199).
 
     Precedence (first non-empty wins):
-      1. ``AGENT_BRAIN_API_KEY`` environment variable
-      2. ``runtime.json::api_key`` for the resolved state directory
+      1. ``API_KEY`` environment variable (canonical v2 name)
+      2. ``AGENT_BRAIN_API_KEY`` environment variable (deprecated; logs a
+         one-time warning per process when used)
+      3. ``runtime.json::api_key`` for the resolved state directory
          (set by the running server)
-      3. ``config.json::api_key`` for the resolved state directory
+      4. ``config.json::api_key`` for the resolved state directory
          (set by ``agent-brain init``, used when the server hasn't
          started yet)
 
     Returns ``None`` when no source provides a value, which is the
-    correct behavior for a server running in default no-auth loopback
-    mode — the client sends no header and the server's no-op dependency
-    accepts the request.
+    correct behavior for a server running with ``INSECURE_NO_AUTH=true``
+    (the per-request gate is a no-op and the server's startup gate
+    emitted the loud warning).
 
     Args:
         state_dir: Optional state directory to read from. Defaults to
@@ -436,13 +438,25 @@ def resolve_api_key(state_dir: Path | None = None) -> str | None:
             to thread the path through.
 
     Returns:
-        The resolved API key or ``None``.
+        The resolved bearer token or ``None``.
     """
     import json
 
-    env_key = os.getenv("AGENT_BRAIN_API_KEY")
+    env_key = os.getenv("API_KEY")
     if env_key:
         return env_key
+
+    legacy_env_key = os.getenv("AGENT_BRAIN_API_KEY")
+    if legacy_env_key:
+        # Log once per process to avoid spamming long-running CLI sessions.
+        if not getattr(resolve_api_key, "_legacy_env_warned", False):
+            logger.warning(
+                "AGENT_BRAIN_API_KEY environment variable is deprecated; "
+                "switch to API_KEY. Support will be removed in a future "
+                "release. (Issue #199)"
+            )
+            resolve_api_key._legacy_env_warned = True  # type: ignore[attr-defined]
+        return legacy_env_key
 
     if state_dir is None:
         try:

--- a/agent-brain-cli/tests/test_api_key_propagation.py
+++ b/agent-brain-cli/tests/test_api_key_propagation.py
@@ -1,18 +1,23 @@
-"""Tests for X-API-Key propagation through CLI client + transport (Issue #179).
+"""Tests for Bearer-token propagation through CLI client + transport.
 
-Covers three independent surfaces:
+Issues #179 + #199 (199-04 swap from X-API-Key to Authorization: Bearer).
 
-1. ``DocServeClient(api_key=...)`` — header set on the underlying httpx.Client.
-2. ``DocServeClient.from_httpx(client, api_key=...)`` — header injected into
-   a pre-built UDS client.
-3. ``resolve_api_key`` — env > runtime.json > None precedence chain.
+Covers four independent surfaces:
+
+1. ``DocServeClient(api_key=...)`` — ``Authorization: Bearer`` header set on
+   the underlying httpx.Client (199-04 swap from ``X-API-Key``).
+2. ``DocServeClient.from_httpx(client, api_key=...)`` — same header injected
+   into a pre-built UDS client.
+3. ``resolve_api_key`` — env (API_KEY > AGENT_BRAIN_API_KEY w/ deprecation
+   log) > runtime.json > config.json > None precedence chain.
 4. ``open_backend(ctx)`` — end-to-end: env-provided key reaches the client's
-   default headers.
+   default headers as a Bearer token.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 import os
 from collections.abc import Generator
 from pathlib import Path
@@ -27,14 +32,28 @@ from agent_brain_cli.config import resolve_api_key
 
 @pytest.fixture
 def clean_env() -> Generator[None, None, None]:
-    keys = [k for k in os.environ if k.startswith("AGENT_BRAIN_")]
-    saved = {k: os.environ.pop(k) for k in keys}
+    """Strip every Agent Brain auth env var and the canonical ``API_KEY``."""
+    candidates = {
+        k for k in os.environ if k.startswith("AGENT_BRAIN_") or k == "API_KEY"
+    }
+    saved = {k: os.environ.pop(k) for k in candidates}
     try:
         yield
     finally:
-        for k in keys:
+        for k in candidates:
             os.environ.pop(k, None)
         os.environ.update(saved)
+
+
+@pytest.fixture(autouse=True)
+def reset_legacy_warn_flag() -> Generator[None, None, None]:
+    """The deprecation warning fires once per process via a function attribute.
+    Reset it around each test so we can re-assert the warning is emitted."""
+    if hasattr(resolve_api_key, "_legacy_env_warned"):
+        delattr(resolve_api_key, "_legacy_env_warned")
+    yield
+    if hasattr(resolve_api_key, "_legacy_env_warned"):
+        delattr(resolve_api_key, "_legacy_env_warned")
 
 
 # ---------------------------------------------------------------------------
@@ -43,35 +62,41 @@ def clean_env() -> Generator[None, None, None]:
 
 
 class TestDocServeClientHeader:
-    def test_api_key_added_to_httpx_default_headers(self) -> None:
+    def test_bearer_header_added_to_httpx_default_headers(self) -> None:
         client = DocServeClient(base_url="http://test", api_key="secret-token")
         try:
-            assert client._client.headers["X-API-Key"] == "secret-token"
+            assert client._client.headers["Authorization"] == "Bearer secret-token"
+            # X-API-Key MUST NOT be sent — server still accepts it but the
+            # CLI side has moved to Bearer entirely.
+            assert "X-API-Key" not in client._client.headers
         finally:
             client.close()
 
-    def test_no_header_when_api_key_omitted(self) -> None:
+    def test_no_auth_header_when_api_key_omitted(self) -> None:
         client = DocServeClient(base_url="http://test")
         try:
+            assert "Authorization" not in client._client.headers
             assert "X-API-Key" not in client._client.headers
         finally:
             client.close()
 
     def test_empty_string_api_key_treated_as_no_auth(self) -> None:
-        """Truthy check prevents an empty string from setting an empty header."""
+        """Truthy check prevents an empty string from sending a malformed
+        ``Authorization: Bearer `` header (note trailing space)."""
         client = DocServeClient(base_url="http://test", api_key="")
         try:
-            assert "X-API-Key" not in client._client.headers
+            assert "Authorization" not in client._client.headers
         finally:
             client.close()
 
 
 class TestFromHttpxHeaderInjection:
-    def test_api_key_injected_onto_existing_httpx_client(self) -> None:
+    def test_bearer_header_injected_onto_existing_httpx_client(self) -> None:
         inner = httpx.Client(base_url="http://uds-target")
         wrapper = DocServeClient.from_httpx(inner, api_key="uds-secret")
         try:
-            assert inner.headers["X-API-Key"] == "uds-secret"
+            assert inner.headers["Authorization"] == "Bearer uds-secret"
+            assert "X-API-Key" not in inner.headers
             # The wrapper hands ownership to the inner client
             assert wrapper._client is inner
         finally:
@@ -81,7 +106,7 @@ class TestFromHttpxHeaderInjection:
         inner = httpx.Client(base_url="http://uds-target")
         wrapper = DocServeClient.from_httpx(inner)
         try:
-            assert "X-API-Key" not in inner.headers
+            assert "Authorization" not in inner.headers
         finally:
             wrapper.close()
 
@@ -92,17 +117,63 @@ class TestFromHttpxHeaderInjection:
 
 
 class TestResolveApiKeyPrecedence:
-    def test_env_var_wins(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    def test_api_key_env_var_wins(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
     ) -> None:
-        monkeypatch.setenv("AGENT_BRAIN_API_KEY", "env-key")
+        """API_KEY is the canonical v2 env var — beats every other source."""
+        monkeypatch.setenv("API_KEY", "v2-env-key")
+        monkeypatch.setenv("AGENT_BRAIN_API_KEY", "legacy-env-key")
         (tmp_path / "runtime.json").write_text(json.dumps({"api_key": "file-key"}))
 
-        assert resolve_api_key(tmp_path) == "env-key"
+        assert resolve_api_key(tmp_path) == "v2-env-key"
+
+    def test_legacy_env_var_wins_when_api_key_unset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """AGENT_BRAIN_API_KEY still works but logs a one-time deprecation warning."""
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.setenv("AGENT_BRAIN_API_KEY", "legacy-env-key")
+        (tmp_path / "runtime.json").write_text(json.dumps({"api_key": "file-key"}))
+
+        with caplog.at_level(logging.WARNING, logger="agent_brain_cli.config"):
+            assert resolve_api_key(tmp_path) == "legacy-env-key"
+
+        assert any(
+            "AGENT_BRAIN_API_KEY environment variable is deprecated" in record.message
+            for record in caplog.records
+        )
+
+    def test_legacy_deprecation_warning_fires_once_per_process(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Long-running CLI sessions should see the warning once, not on every call."""
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.setenv("AGENT_BRAIN_API_KEY", "legacy-key")
+
+        with caplog.at_level(logging.WARNING, logger="agent_brain_cli.config"):
+            resolve_api_key(tmp_path)
+            resolve_api_key(tmp_path)
+            resolve_api_key(tmp_path)
+
+        warnings = [
+            r
+            for r in caplog.records
+            if "AGENT_BRAIN_API_KEY environment variable is deprecated" in r.message
+        ]
+        assert len(warnings) == 1
 
     def test_runtime_json_used_when_env_empty(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
+        monkeypatch.delenv("API_KEY", raising=False)
         monkeypatch.delenv("AGENT_BRAIN_API_KEY", raising=False)
         (tmp_path / "runtime.json").write_text(json.dumps({"api_key": "file-key"}))
 
@@ -111,6 +182,7 @@ class TestResolveApiKeyPrecedence:
     def test_returns_none_when_no_source_set(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
+        monkeypatch.delenv("API_KEY", raising=False)
         monkeypatch.delenv("AGENT_BRAIN_API_KEY", raising=False)
         # No runtime.json
         assert resolve_api_key(tmp_path) is None
@@ -118,6 +190,7 @@ class TestResolveApiKeyPrecedence:
     def test_returns_none_when_runtime_json_omits_key(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
+        monkeypatch.delenv("API_KEY", raising=False)
         monkeypatch.delenv("AGENT_BRAIN_API_KEY", raising=False)
         (tmp_path / "runtime.json").write_text(json.dumps({"base_url": "x"}))
 
@@ -126,6 +199,7 @@ class TestResolveApiKeyPrecedence:
     def test_corrupt_runtime_json_returns_none(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
+        monkeypatch.delenv("API_KEY", raising=False)
         monkeypatch.delenv("AGENT_BRAIN_API_KEY", raising=False)
         (tmp_path / "runtime.json").write_text("{not valid json")
 
@@ -138,10 +212,10 @@ class TestResolveApiKeyPrecedence:
 
 
 class TestOpenBackendEndToEnd:
-    def test_env_api_key_reaches_http_client(self, clean_env: None) -> None:
+    def test_env_api_key_reaches_http_client_as_bearer(self, clean_env: None) -> None:
         from agent_brain_cli.client.transport import open_backend
 
-        os.environ["AGENT_BRAIN_API_KEY"] = "e2e-secret"
+        os.environ["API_KEY"] = "e2e-secret"
         cmd = click.Command("test")
         ctx = click.Context(cmd)
         ctx.obj = {
@@ -150,6 +224,7 @@ class TestOpenBackendEndToEnd:
         }
         client = open_backend(ctx)
         try:
-            assert client._client.headers["X-API-Key"] == "e2e-secret"
+            assert client._client.headers["Authorization"] == "Bearer e2e-secret"
+            assert "X-API-Key" not in client._client.headers
         finally:
             client.close()

--- a/agent-brain-cli/tests/test_init_api_key.py
+++ b/agent-brain-cli/tests/test_init_api_key.py
@@ -40,12 +40,16 @@ def temp_project(tmp_path: Path) -> Generator[Path, None, None]:
 
 @pytest.fixture
 def clean_env() -> Generator[None, None, None]:
-    keys = [k for k in os.environ if k.startswith("AGENT_BRAIN_")]
-    saved = {k: os.environ.pop(k) for k in keys}
+    """Strip Agent Brain env vars *and* the canonical ``API_KEY`` so the test
+    exercises the file-fallback path even when the dev shell has API_KEY set."""
+    candidates = {
+        k for k in os.environ if k.startswith("AGENT_BRAIN_") or k == "API_KEY"
+    }
+    saved = {k: os.environ.pop(k) for k in candidates}
     try:
         yield
     finally:
-        for k in keys:
+        for k in candidates:
             os.environ.pop(k, None)
         os.environ.update(saved)
 

--- a/agent-brain-cli/tests/test_start_insecure.py
+++ b/agent-brain-cli/tests/test_start_insecure.py
@@ -1,0 +1,173 @@
+"""Tests for ``agent-brain start --insecure`` env handling (Issue #199, 199-04).
+
+The CLI's job at start time is to produce the subprocess env dict that the
+server's startup gate (199-03) will read. There are three cases:
+
+1. No --insecure, config.json has ``api_key``: env carries ``API_KEY``.
+2. No --insecure, env already has API_KEY or AGENT_BRAIN_API_KEY: CLI does
+   not overwrite — operator's explicit value wins.
+3. ``--insecure``: env carries ``INSECURE_NO_AUTH=true`` and every key var
+   is stripped so a stale shell entry can't silently re-enable auth.
+
+We don't need to spawn a real subprocess to test this — the env dict is
+constructed in-process and consumed via ``os.execvpe`` / ``subprocess.Popen``,
+so the env-construction logic is the testable contract.
+
+Rather than refactor ``start_command`` to factor out env building (a
+bigger surface), we monkeypatch ``subprocess.Popen`` and capture the
+``env`` kwarg it would have received.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from agent_brain_cli.commands import start as start_mod
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def temp_project(tmp_path: Path) -> Generator[Path, None, None]:
+    """A pre-initialized project with config.json carrying an api_key."""
+    project = tmp_path / "project"
+    project.mkdir()
+    state_dir = project / ".agent-brain"
+    state_dir.mkdir()
+    (state_dir / "data").mkdir()
+    (state_dir / "logs").mkdir()
+    (state_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "api_key": "file-stored-key",
+                "bind_host": "127.0.0.1",
+                "port_range_start": 8000,
+                "port_range_end": 8100,
+                "auto_port": True,
+                "project_root": str(project),
+            }
+        )
+    )
+    yield project
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip auth env vars + state-dir env so each test starts deterministic."""
+    monkeypatch.delenv("API_KEY", raising=False)
+    monkeypatch.delenv("AGENT_BRAIN_API_KEY", raising=False)
+    monkeypatch.delenv("INSECURE_NO_AUTH", raising=False)
+    monkeypatch.delenv("AGENT_BRAIN_STATE_DIR", raising=False)
+
+
+@pytest.fixture
+def captured_popen(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    """Capture Popen's env kwarg without actually spawning the server.
+
+    Returns a dict the test asserts on. We also short-circuit the
+    health-check loop so start_command's foreground/daemon split doesn't
+    hang the test."""
+    captured: dict[str, object] = {}
+
+    class _FakeProc:
+        pid = 99999
+
+        def poll(self) -> int | None:
+            return None
+
+    def _fake_popen(*args, **kwargs):  # type: ignore[no-untyped-def]
+        captured["env"] = kwargs.get("env")
+        captured["cmd"] = args[0] if args else kwargs.get("args")
+        return _FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", _fake_popen)
+    # Pretend the server immediately reports healthy so we don't loop.
+    monkeypatch.setattr(start_mod, "check_health", lambda *a, **kw: True)
+    return captured
+
+
+class TestInsecureFlag:
+    def test_insecure_sets_no_auth_env_and_strips_keys(
+        self,
+        runner: CliRunner,
+        temp_project: Path,
+        captured_popen: dict[str, object],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """--insecure → INSECURE_NO_AUTH=true, no key propagation."""
+        # A stale shell entry that --insecure must NOT silently honor.
+        monkeypatch.setenv("API_KEY", "stale-shell-key")
+
+        result = runner.invoke(
+            start_mod.start_command,
+            ["--path", str(temp_project), "--insecure"],
+        )
+
+        assert result.exit_code == 0, result.output
+        env = captured_popen["env"]
+        assert isinstance(env, dict)
+        assert env.get("INSECURE_NO_AUTH") == "true"
+        assert "API_KEY" not in env
+        assert "AGENT_BRAIN_API_KEY" not in env
+
+    def test_default_propagates_config_api_key_under_canonical_name(
+        self,
+        runner: CliRunner,
+        temp_project: Path,
+        captured_popen: dict[str, object],
+    ) -> None:
+        """Without --insecure, the file-stored key flows through as API_KEY."""
+        result = runner.invoke(start_mod.start_command, ["--path", str(temp_project)])
+
+        assert result.exit_code == 0, result.output
+        env = captured_popen["env"]
+        assert isinstance(env, dict)
+        assert env.get("API_KEY") == "file-stored-key"
+        assert "INSECURE_NO_AUTH" not in env
+
+    def test_existing_api_key_env_wins_over_config_file(
+        self,
+        runner: CliRunner,
+        temp_project: Path,
+        captured_popen: dict[str, object],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Operator-provided env var beats the file-stored key."""
+        monkeypatch.setenv("API_KEY", "shell-provided-key")
+
+        result = runner.invoke(start_mod.start_command, ["--path", str(temp_project)])
+
+        assert result.exit_code == 0, result.output
+        env = captured_popen["env"]
+        assert isinstance(env, dict)
+        assert env.get("API_KEY") == "shell-provided-key"
+
+    def test_legacy_env_var_alone_is_not_overwritten(
+        self,
+        runner: CliRunner,
+        temp_project: Path,
+        captured_popen: dict[str, object],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If the operator set AGENT_BRAIN_API_KEY explicitly, we don't shadow
+        it with the config-file value under API_KEY — the server's Settings
+        validator backfills the legacy env var into API_KEY at startup."""
+        monkeypatch.setenv("AGENT_BRAIN_API_KEY", "legacy-shell-key")
+
+        result = runner.invoke(start_mod.start_command, ["--path", str(temp_project)])
+
+        assert result.exit_code == 0, result.output
+        env = captured_popen["env"]
+        assert isinstance(env, dict)
+        assert env.get("AGENT_BRAIN_API_KEY") == "legacy-shell-key"
+        # Should NOT add API_KEY from config (would override the operator's choice).
+        assert "API_KEY" not in env or env.get("API_KEY") is None

--- a/agent-brain-server/agent_brain_server/api/main.py
+++ b/agent-brain-server/agent_brain_server/api/main.py
@@ -671,12 +671,21 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
 
 def _check_api_key_startup_gate(resolved_host: str) -> None:
-    """Refuse to start when binding non-loopback without an API key (Issue #179).
+    """Refuse to start without an API key unless ``INSECURE_NO_AUTH=true`` (Issue #199).
 
-    Loopback (``127.0.0.1`` / ``localhost`` / ``::1``) + empty key emits a
-    loud warning and proceeds. Any other bind host without a key exits with
-    code 2 — the same code uvicorn uses for "port in use" — so process
-    managers can distinguish a misconfiguration from a server crash.
+    Inverts the old #179 contract:
+
+    * Before 199-03: loopback + empty key was *allowed* (warning), non-loopback
+      was refused. This left ``127.0.0.1`` as an implicit "no-auth is fine here"
+      escape hatch — OWASP API1/API2:2023 risk for any multi-process box.
+    * 199-03: every bind host requires a key. The only opt-out is an explicit
+      ``INSECURE_NO_AUTH=true`` env var (mirrors Postgres ``--allow-empty-password``
+      / Redis ``protected-mode no``) which emits a loud warning at startup so
+      operators see the choice in their logs.
+
+    The Settings validator (``_backfill_api_key_from_legacy``) copies the
+    deprecated ``AGENT_BRAIN_API_KEY`` env var into ``API_KEY`` before this
+    check runs, so existing PR #195 / Issue #179 installs upgrade silently.
 
     Refreshes the settings lru_cache first so env vars set by the CLI
     subprocess wrapper (and tests) are picked up before the check fires.
@@ -686,26 +695,25 @@ def _check_api_key_startup_gate(resolved_host: str) -> None:
     get_settings.cache_clear()
     current_settings = get_settings()
 
-    loopback_hosts = {"127.0.0.1", "localhost", "::1"}
-    api_key_set = bool(current_settings.AGENT_BRAIN_API_KEY)
-
-    if api_key_set:
+    if current_settings.API_KEY is not None:
         return
 
-    if resolved_host in loopback_hosts:
+    if current_settings.INSECURE_NO_AUTH:
         logger.warning(
-            "Starting on %s with no AGENT_BRAIN_API_KEY set — endpoints are "
-            "unauthenticated. Safe for single-user dev only. Set "
-            "AGENT_BRAIN_API_KEY before exposing the server beyond loopback.",
+            "Starting on %s with INSECURE_NO_AUTH=true — endpoints are "
+            "unauthenticated and accept requests from any caller. This is "
+            "ONLY safe on a single-user, single-process machine. Set "
+            "API_KEY to switch back to authenticated mode. (Issue #199)",
             resolved_host,
         )
         return
 
     logger.critical(
-        "Refusing to start on %s without AGENT_BRAIN_API_KEY. The default "
-        "no-auth posture is only allowed on loopback (127.0.0.1, localhost, "
-        "::1). Set AGENT_BRAIN_API_KEY in the environment or bind to "
-        "127.0.0.1. (Issue #179)",
+        "Refusing to start on %s without API_KEY. The 199-03 default is "
+        "auth-required on every bind host (loopback included) because "
+        "127.0.0.1 is not a trust boundary on multi-process machines. Set "
+        "API_KEY in the environment, or pass INSECURE_NO_AUTH=true to opt "
+        "out explicitly. (Issue #199)",
         resolved_host,
     )
     sys.exit(2)
@@ -714,11 +722,19 @@ def _check_api_key_startup_gate(resolved_host: str) -> None:
 def _build_app() -> FastAPI:
     """Construct the FastAPI app, gating /docs and /openapi.json when configured.
 
-    When ``AGENT_BRAIN_API_KEY`` is set AND ``DEBUG`` is False, the interactive
-    docs (``/docs``, ``/redoc``) and the OpenAPI schema (``/openapi.json``) are
-    disabled — there's no point requiring an API key to read endpoints if the
-    schema describing them is publicly browsable. In DEBUG mode the docs stay
-    open so developers keep their normal workflow.
+    When ``API_KEY`` is set AND ``DEBUG`` is False, the interactive docs
+    (``/docs``, ``/redoc``) and the OpenAPI schema (``/openapi.json``) are
+    disabled — there's no point requiring a bearer token to read endpoints
+    if the schema describing them is publicly browsable. In DEBUG mode the
+    docs stay open so developers keep their normal workflow.
+
+    When ``API_KEY`` is None (loopback dev or ``INSECURE_NO_AUTH=true``), the
+    docs stay open because the endpoints themselves are open — gating the
+    schema would only obscure them, not protect anything.
+
+    Reads ``settings.API_KEY`` (post-validator backfill from the deprecated
+    ``AGENT_BRAIN_API_KEY`` env var, see config.settings), so callers who
+    haven't migrated their env vars yet still get the gated docs.
 
     Extracted as a factory so tests can build alternate apps under a
     monkeypatched environment without re-importing the module.
@@ -727,9 +743,7 @@ def _build_app() -> FastAPI:
 
     get_settings.cache_clear()
     current_settings = get_settings()
-    docs_gated = (
-        bool(current_settings.AGENT_BRAIN_API_KEY) and not current_settings.DEBUG
-    )
+    docs_gated = current_settings.API_KEY is not None and not current_settings.DEBUG
     return FastAPI(
         title="Agent Brain RAG API",
         description=(
@@ -834,8 +848,11 @@ def run(
             _project_root = env_root or str(_state_dir.parent.parent.parent)
 
         # Create runtime state — surface the configured API key so the CLI
-        # and MCP clients can discover it from runtime.json (Issue #179).
-        # write_runtime() chmods the file to 0o600.
+        # and MCP clients can discover it from runtime.json (Issues #179, #199).
+        # write_runtime() chmods the file to 0o600. Reads the resolved
+        # ``settings.API_KEY`` (Settings validator backfilled the deprecated
+        # AGENT_BRAIN_API_KEY env var into it) so the CLI sees a single
+        # source of truth regardless of which env var was set.
         _runtime_state = RuntimeState(
             mode="project",
             project_root=_project_root,
@@ -843,7 +860,7 @@ def run(
             port=resolved_port,
             pid=os.getpid(),
             base_url=f"http://{resolved_host}:{resolved_port}",
-            api_key=settings.AGENT_BRAIN_API_KEY or None,
+            api_key=(settings.API_KEY.get_secret_value() if settings.API_KEY else None),
         )
 
         # Write runtime.json before starting server

--- a/agent-brain-server/agent_brain_server/api/routers/cache.py
+++ b/agent-brain-server/agent_brain_server/api/routers/cache.py
@@ -19,12 +19,12 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from agent_brain_server.api.security import verify_api_key
+from agent_brain_server.api.security import verify_bearer_token
 from agent_brain_server.services.embedding_cache import get_embedding_cache
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(dependencies=[Depends(verify_api_key)])
+router = APIRouter(dependencies=[Depends(verify_bearer_token)])
 
 
 async def _cache_status_impl(request: Request) -> dict[str, Any]:

--- a/agent-brain-server/agent_brain_server/api/routers/folders.py
+++ b/agent-brain-server/agent_brain_server/api/routers/folders.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
-from agent_brain_server.api.security import verify_api_key
+from agent_brain_server.api.security import verify_bearer_token
 from agent_brain_server.models.folders import (
     FolderDeleteRequest,
     FolderDeleteResponse,
@@ -22,7 +22,7 @@ from agent_brain_server.models.folders import (
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(dependencies=[Depends(verify_api_key)])
+router = APIRouter(dependencies=[Depends(verify_bearer_token)])
 
 
 @router.get(

--- a/agent-brain-server/agent_brain_server/api/routers/graph.py
+++ b/agent-brain-server/agent_brain_server/api/routers/graph.py
@@ -41,7 +41,7 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
-from agent_brain_server.api.security import verify_api_key
+from agent_brain_server.api.security import verify_bearer_token
 from agent_brain_server.config.provider_config import load_provider_settings
 from agent_brain_server.config.settings import settings
 from agent_brain_server.models import ENTITY_TYPES, GraphEntityRecord
@@ -52,7 +52,7 @@ from agent_brain_server.storage.graph_store import (
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(dependencies=[Depends(verify_api_key)])
+router = APIRouter(dependencies=[Depends(verify_bearer_token)])
 
 
 # Frozen at module import for predictable 400-body content. The 17 SCHEMA-01

--- a/agent-brain-server/agent_brain_server/api/routers/index.py
+++ b/agent-brain-server/agent_brain_server/api/routers/index.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 
-from agent_brain_server.api.security import verify_api_key
+from agent_brain_server.api.security import verify_bearer_token
 from agent_brain_server.config import settings
 from agent_brain_server.config.provider_config import load_provider_settings
 from agent_brain_server.models import IndexRequest, IndexResponse
@@ -28,7 +28,7 @@ def _graphrag_enabled() -> bool:
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(dependencies=[Depends(verify_api_key)])
+router = APIRouter(dependencies=[Depends(verify_bearer_token)])
 
 # Maximum queue length for backpressure
 MAX_QUEUE_LENGTH = settings.AGENT_BRAIN_MAX_QUEUE

--- a/agent-brain-server/agent_brain_server/api/routers/jobs.py
+++ b/agent-brain-server/agent_brain_server/api/routers/jobs.py
@@ -4,11 +4,11 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 
-from agent_brain_server.api.security import verify_api_key
+from agent_brain_server.api.security import verify_bearer_token
 from agent_brain_server.job_queue.job_service import JobQueueService
 from agent_brain_server.models.job import JobDetailResponse, JobListResponse
 
-router = APIRouter(dependencies=[Depends(verify_api_key)])
+router = APIRouter(dependencies=[Depends(verify_bearer_token)])
 
 
 @router.get(

--- a/agent-brain-server/agent_brain_server/api/routers/query.py
+++ b/agent-brain-server/agent_brain_server/api/routers/query.py
@@ -5,12 +5,12 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import JSONResponse
 
-from agent_brain_server.api.security import verify_api_key
+from agent_brain_server.api.security import verify_bearer_token
 from agent_brain_server.models import ChunkRecord, QueryRequest, QueryResponse
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(dependencies=[Depends(verify_api_key)])
+router = APIRouter(dependencies=[Depends(verify_bearer_token)])
 
 
 @router.post(

--- a/agent-brain-server/agent_brain_server/api/security.py
+++ b/agent-brain-server/agent_brain_server/api/security.py
@@ -1,38 +1,106 @@
-"""API key authentication dependency for protected routers (Issue #179).
+"""Bearer-token authentication for protected routers (Issues #179 + #199).
 
-When ``settings.AGENT_BRAIN_API_KEY`` is empty, ``verify_api_key`` is a no-op
-so single-user loopback dev keeps its current zero-config experience. When the
-setting is non-empty, the dependency requires an ``X-API-Key`` request header
-whose value matches the setting in constant time.
+``verify_bearer_token`` is the canonical FastAPI dependency as of 199-02.
+It enforces RFC 6750 ``Authorization: Bearer <token>`` on every gated router
+and also accepts the deprecated ``X-API-Key`` header (from PR #195) with a
+one-time deprecation log so existing callers keep working through one
+release window.
 
-The startup gate in :mod:`agent_brain_server.api.main` enforces that
-``AGENT_BRAIN_API_KEY`` is set whenever the server binds to anything other than
-``127.0.0.1``; this module only enforces the per-request check.
+Resolution rules:
+
+* If ``settings.INSECURE_NO_AUTH`` is True, the dependency is a no-op (loud
+  warning belongs to the startup gate, not the per-request path).
+* If ``settings.API_KEY`` is unset, the dependency is a no-op so loopback
+  single-user dev keeps its zero-config experience. The startup gate in
+  :mod:`agent_brain_server.api.main` decides when an unset key is allowed
+  (loopback only — non-loopback startup refuses).
+* Otherwise, a request must carry ``Authorization: Bearer <token>``
+  (preferred) OR the deprecated ``X-API-Key`` header. Both are compared in
+  constant time against ``settings.API_KEY``. Mismatch → 401 with
+  ``WWW-Authenticate: Bearer`` per RFC 6750.
+
+The ``Settings`` validator backfills ``API_KEY`` from the legacy
+``AGENT_BRAIN_API_KEY`` env var (see
+:mod:`agent_brain_server.config.settings`), so callers who haven't migrated
+their env vars yet still produce a non-None ``API_KEY`` at runtime.
 """
 
 from __future__ import annotations
 
+import logging
 import secrets
 
 from fastapi import Header, HTTPException, status
 
 from agent_brain_server.config.settings import get_settings
 
+logger = logging.getLogger(__name__)
 
-async def verify_api_key(
+_BEARER_PREFIX = "bearer "
+
+
+async def verify_bearer_token(
+    authorization: str | None = Header(default=None),
     x_api_key: str | None = Header(default=None, alias="X-API-Key"),
 ) -> None:
-    """FastAPI dependency that gates a router on an API key match.
+    """FastAPI dependency that gates a router on a Bearer-token match.
 
-    No-op when ``AGENT_BRAIN_API_KEY`` is empty (loopback dev default).
+    Accepts ``Authorization: Bearer <token>`` (preferred, RFC 6750) and the
+    deprecated ``X-API-Key`` header. No-op when ``API_KEY`` is unset or
+    ``INSECURE_NO_AUTH`` is True (loopback dev default + explicit opt-out).
     """
-    expected = get_settings().AGENT_BRAIN_API_KEY
-    if not expected:
+    settings = get_settings()
+
+    if settings.INSECURE_NO_AUTH:
         return
 
-    if x_api_key is None or not secrets.compare_digest(x_api_key, expected):
+    if settings.API_KEY is None:
+        return
+
+    expected = settings.API_KEY.get_secret_value()
+
+    # Bearer scheme first — canonical per RFC 6750.
+    if authorization is not None:
+        if authorization[: len(_BEARER_PREFIX)].lower() == _BEARER_PREFIX:
+            token = authorization[len(_BEARER_PREFIX) :].strip()
+            if secrets.compare_digest(token, expected):
+                return
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid bearer token",
+                headers={"WWW-Authenticate": 'Bearer error="invalid_token"'},
+            )
+        # Authorization header present but not Bearer — malformed for our scheme.
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid or missing API key",
-            headers={"WWW-Authenticate": "X-API-Key"},
+            detail="Authorization header must use the Bearer scheme",
+            headers={"WWW-Authenticate": 'Bearer error="invalid_request"'},
         )
+
+    # Fallback: deprecated X-API-Key header (PR #195 compatibility).
+    if x_api_key is not None:
+        if secrets.compare_digest(x_api_key, expected):
+            logger.warning(
+                "X-API-Key header is deprecated; switch to 'Authorization: "
+                "Bearer <token>'. Support will be removed in a future release. "
+                "(Issue #199)"
+            )
+            return
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid API key",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Missing credentials. Use 'Authorization: Bearer <token>'.",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+# Backwards-compatible alias. Older imports of ``verify_api_key`` (and the
+# test_auth_enforcement.py structural check that pre-dates 199-02) keep
+# resolving to the same callable so external code doesn't break during the
+# deprecation window. New router code MUST import ``verify_bearer_token``.
+verify_api_key = verify_bearer_token

--- a/agent-brain-server/agent_brain_server/config/settings.py
+++ b/agent-brain-server/agent_brain_server/config/settings.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
-from pydantic import SecretStr
+from pydantic import SecretStr, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
@@ -29,13 +29,32 @@ class Settings(BaseSettings):
     AGENT_BRAIN_API_KEY: str = ""
 
     # API Authentication (Issue #199 v2 — Bearer scheme, secure-by-default).
-    # Plumbing only in 199-01: these fields exist alongside AGENT_BRAIN_API_KEY
-    # but are NOT yet wired into the routers. 199-02 swaps verify_api_key →
-    # verify_bearer_token to consume API_KEY. The env-var alias migration from
-    # AGENT_BRAIN_API_KEY → API_KEY also lands in 199-02 so this commit stays
-    # behavior-preserving.
+    # ``API_KEY`` is the canonical Bearer token storage as of 199-02.
+    # ``AGENT_BRAIN_API_KEY`` (above) is a deprecated env-var alias kept for
+    # one release; the ``_backfill_api_key_from_legacy`` validator copies the
+    # legacy value into ``API_KEY`` after construction so the router
+    # dependency only has to read one field.
+    # ``INSECURE_NO_AUTH=true`` is the explicit opt-out for running with no
+    # authentication — verify_bearer_token treats it as a no-op gate.
     API_KEY: SecretStr | None = None
     INSECURE_NO_AUTH: bool = False
+
+    @model_validator(mode="after")
+    def _backfill_api_key_from_legacy(self) -> "Settings":
+        """Backfill ``API_KEY`` from the deprecated ``AGENT_BRAIN_API_KEY`` env var.
+
+        Migration path for Issue #199. Users who set ``AGENT_BRAIN_API_KEY``
+        (v1 scheme, PR #195) continue to work unchanged — verify_bearer_token
+        reads ``API_KEY`` only, so the validator copies the legacy value into
+        a SecretStr-wrapped ``API_KEY`` when the new field is unset.
+
+        Only one direction (legacy → canonical) — reverse-direction would
+        leak the secret value into the plain-str ``AGENT_BRAIN_API_KEY``
+        field and defeat SecretStr's redaction guarantee.
+        """
+        if self.API_KEY is None and self.AGENT_BRAIN_API_KEY:
+            self.API_KEY = SecretStr(self.AGENT_BRAIN_API_KEY)
+        return self
 
     # OpenAI Configuration
     OPENAI_API_KEY: str = ""

--- a/agent-brain-server/agent_brain_server/config/settings.py
+++ b/agent-brain-server/agent_brain_server/config/settings.py
@@ -6,6 +6,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
+from pydantic import SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
@@ -19,13 +20,22 @@ class Settings(BaseSettings):
     API_PORT: int = 8000
     DEBUG: bool = False
 
-    # API Authentication (Issue #179)
+    # API Authentication (Issue #179 v1 — X-API-Key)
     # When empty (default), data endpoints are unauthenticated — safe only on
     # loopback for single-user dev. The startup gate in api/main.py refuses to
     # start when API_HOST != "127.0.0.1" and this is unset.
     # When set, requests to gated routers must carry the value in the
     # X-API-Key header; /health stays open; /docs is gated when DEBUG is False.
     AGENT_BRAIN_API_KEY: str = ""
+
+    # API Authentication (Issue #199 v2 — Bearer scheme, secure-by-default).
+    # Plumbing only in 199-01: these fields exist alongside AGENT_BRAIN_API_KEY
+    # but are NOT yet wired into the routers. 199-02 swaps verify_api_key →
+    # verify_bearer_token to consume API_KEY. The env-var alias migration from
+    # AGENT_BRAIN_API_KEY → API_KEY also lands in 199-02 so this commit stays
+    # behavior-preserving.
+    API_KEY: SecretStr | None = None
+    INSECURE_NO_AUTH: bool = False
 
     # OpenAI Configuration
     OPENAI_API_KEY: str = ""

--- a/agent-brain-server/agent_brain_server/runtime.py
+++ b/agent-brain-server/agent_brain_server/runtime.py
@@ -3,12 +3,20 @@
 import json
 import logging
 import os
+import secrets
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 from uuid import uuid4
 
 from pydantic import BaseModel, Field
+
+# Token length matches PR #193's design: secrets.token_urlsafe(32) produces a
+# 43-character URL-safe base64 string (~256 bits of entropy), the same shape
+# Postgres-style admin secrets and GitHub PATs use. Defined as a module-level
+# constant so the same length is documented for the CLI auto-gen path
+# (199-04) and the server backfill path (199-03).
+API_KEY_BYTES = 32
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +45,25 @@ class RuntimeState(BaseModel):
     # clients read this field to authenticate their requests; the file is
     # chmod'd to 0o600 by write_runtime so the secret stays user-only.
     api_key: str | None = None
+
+
+def generate_api_key() -> str:
+    """Generate a new API key suitable for ``RuntimeState.api_key``.
+
+    Produces a ``secrets.token_urlsafe(32)`` string (43 URL-safe base64
+    characters, ~256 bits of entropy). Same shape PR #193 uses; same
+    function will be called by both the server backfill path (Issue #199
+    sub-plan 199-03) and the CLI ``agent-brain init`` auto-gen path
+    (Issue #199 sub-plan 199-04).
+
+    This is plumbing only in 199-01 — no caller yet. 199-03 wires it
+    into the server startup gate; 199-04 wires it into the CLI init
+    command.
+
+    Returns:
+        A URL-safe base64 string suitable for use as a Bearer token.
+    """
+    return secrets.token_urlsafe(API_KEY_BYTES)
 
 
 def write_runtime(state_dir: Path, state: RuntimeState) -> None:

--- a/agent-brain-server/tests/integration/test_cli_start_uds_e2e.py
+++ b/agent-brain-server/tests/integration/test_cli_start_uds_e2e.py
@@ -91,6 +91,13 @@ def test_agent_brain_serve_dual_bind_subprocess(short_state_dir: Path) -> None:
     env["AGENT_BRAIN_UDS"] = "1"
     env["AGENT_BRAIN_UDS_PATH"] = str(socket_path)
     env["AGENT_BRAIN_STATE_DIR"] = str(short_state_dir)
+    # Issue #199 (199-03): startup gate refuses subprocess without API_KEY.
+    # This e2e exercises UDS dual-bind, not auth, so opt out explicitly.
+    env["INSECURE_NO_AUTH"] = "true"
+    # Strip any inherited API_KEY/AGENT_BRAIN_API_KEY so the subprocess hits
+    # the INSECURE_NO_AUTH warning path predictably regardless of dev shell state.
+    env.pop("API_KEY", None)
+    env.pop("AGENT_BRAIN_API_KEY", None)
 
     proc = subprocess.Popen(
         [

--- a/agent-brain-server/tests/integration/test_uds_bind_chmod_and_fallback.py
+++ b/agent-brain-server/tests/integration/test_uds_bind_chmod_and_fallback.py
@@ -225,6 +225,9 @@ class TestRunHonorsUdsEnv:
         monkeypatch.setenv(
             "AGENT_BRAIN_UDS_PATH", str(short_state_dir / "agent-brain.sock")
         )
+        # Issue #199 (199-03): startup gate refuses without API_KEY. This
+        # test exercises UDS dispatch only, so opt out of auth explicitly.
+        monkeypatch.setenv("INSECURE_NO_AUTH", "true")
 
         main_mod.run(host="127.0.0.1", port=8765, state_dir=str(short_state_dir))
 
@@ -261,6 +264,9 @@ class TestRunHonorsUdsEnv:
         monkeypatch.setenv(
             "AGENT_BRAIN_UDS_PATH", str(short_state_dir / "agent-brain.sock")
         )
+        monkeypatch.setenv(
+            "INSECURE_NO_AUTH", "true"
+        )  # Issue #199 — UDS dispatch test, not auth
 
         main_mod.run(host="127.0.0.1", port=8765, state_dir=str(short_state_dir))
 
@@ -283,6 +289,9 @@ class TestRunHonorsUdsEnv:
         monkeypatch.setattr(main_mod.uvicorn, "run", _fake_uvicorn_run)
         monkeypatch.delenv("AGENT_BRAIN_UDS", raising=False)
         monkeypatch.delenv("AGENT_BRAIN_UDS_ONLY", raising=False)
+        monkeypatch.setenv(
+            "INSECURE_NO_AUTH", "true"
+        )  # Issue #199 — dispatch test, not auth
 
         main_mod.run(host="127.0.0.1", port=8765)
 

--- a/agent-brain-server/tests/unit/api/test_auth_enforcement.py
+++ b/agent-brain-server/tests/unit/api/test_auth_enforcement.py
@@ -1,16 +1,17 @@
-"""Integration tests proving each non-health router gates on ``verify_api_key``.
+"""Integration tests proving each non-health router gates on ``verify_bearer_token``.
 
 Two layers of evidence:
 
-1. **Structural** — ``router.dependencies`` contains a ``Depends(verify_api_key)``
-   for every non-health router. Cheap regression guard against someone deleting
-   the dependency from a router file.
-2. **Behavioral** — a minimal FastAPI app mounts a stub endpoint underneath each
-   router's dependency stack, and a TestClient verifies that requests without
-   the ``X-API-Key`` header return 401 while requests with the right header
-   reach the stub handler. This exercises the full FastAPI dependency-resolution
-   chain (the unit tests in ``test_security.py`` only cover the dependency in
-   isolation).
+1. **Structural** — ``router.dependencies`` contains a
+   ``Depends(verify_bearer_token)`` for every non-health router. Cheap
+   regression guard against someone deleting the dependency from a router
+   file.
+2. **Behavioral** — a minimal FastAPI app mounts a stub endpoint underneath
+   each router's dependency stack, and a TestClient verifies that requests
+   without the ``Authorization: Bearer`` header return 401 while requests
+   with the right header reach the stub handler. This exercises the full
+   FastAPI dependency-resolution chain (the unit tests in
+   ``test_security.py`` only cover the dependency in isolation).
 """
 
 from __future__ import annotations
@@ -30,7 +31,7 @@ from agent_brain_server.api.routers import (
     query,
 )
 from agent_brain_server.api.routers import health as health_router
-from agent_brain_server.api.security import verify_api_key
+from agent_brain_server.api.security import verify_bearer_token
 from agent_brain_server.config.settings import get_settings
 
 GATED_ROUTERS = [
@@ -56,20 +57,22 @@ def reset_settings_cache() -> Generator[None, None, None]:
 
 
 @pytest.mark.parametrize("name,router", GATED_ROUTERS)
-def test_each_gated_router_declares_verify_api_key(name: str, router: object) -> None:
-    """``router.dependencies`` must include a ``Depends(verify_api_key)`` entry."""
+def test_each_gated_router_declares_verify_bearer_token(
+    name: str, router: object
+) -> None:
+    """``router.dependencies`` must include a ``Depends(verify_bearer_token)`` entry."""
     deps = getattr(router, "dependencies", [])
     assert any(
-        getattr(d, "dependency", None) is verify_api_key for d in deps
-    ), f"router '{name}' is missing Depends(verify_api_key)"
+        getattr(d, "dependency", None) is verify_bearer_token for d in deps
+    ), f"router '{name}' is missing Depends(verify_bearer_token)"
 
 
 def test_health_router_is_intentionally_unauthenticated() -> None:
     """Health endpoints must stay open even when API key is configured."""
     deps = getattr(health_router.router, "dependencies", [])
     assert not any(
-        getattr(d, "dependency", None) is verify_api_key for d in deps
-    ), "health router should NOT carry verify_api_key — it must stay open"
+        getattr(d, "dependency", None) is verify_bearer_token for d in deps
+    ), "health router should NOT carry verify_bearer_token — it must stay open"
 
 
 # ---------------------------------------------------------------------------
@@ -104,31 +107,33 @@ def test_gated_router_returns_401_without_header(
     name: str,
     router: object,
 ) -> None:
-    monkeypatch.setenv("AGENT_BRAIN_API_KEY", "auth-test-key")
+    monkeypatch.setenv("API_KEY", "auth-test-key")
     client = TestClient(_make_stub_app(router))
 
     response = client.get("/__authcheck")
 
     assert (
         response.status_code == 401
-    ), f"router '{name}' did not return 401 without X-API-Key"
+    ), f"router '{name}' did not return 401 without Authorization header"
 
 
 @pytest.mark.parametrize("name,router", GATED_ROUTERS)
-def test_gated_router_returns_200_with_correct_header(
+def test_gated_router_returns_200_with_correct_bearer_header(
     monkeypatch: pytest.MonkeyPatch,
     reset_settings_cache: None,
     name: str,
     router: object,
 ) -> None:
-    monkeypatch.setenv("AGENT_BRAIN_API_KEY", "auth-test-key")
+    monkeypatch.setenv("API_KEY", "auth-test-key")
     client = TestClient(_make_stub_app(router))
 
-    response = client.get("/__authcheck", headers={"X-API-Key": "auth-test-key"})
+    response = client.get(
+        "/__authcheck", headers={"Authorization": "Bearer auth-test-key"}
+    )
 
     assert (
         response.status_code == 200
-    ), f"router '{name}' rejected the correct X-API-Key"
+    ), f"router '{name}' rejected the correct Bearer token"
     assert response.json() == {"ok": "true"}
 
 
@@ -136,7 +141,7 @@ def test_health_router_stays_open_when_key_is_set(
     monkeypatch: pytest.MonkeyPatch, reset_settings_cache: None
 ) -> None:
     """A real /health/ endpoint must respond 200 with no header even when key set."""
-    monkeypatch.setenv("AGENT_BRAIN_API_KEY", "auth-test-key")
+    monkeypatch.setenv("API_KEY", "auth-test-key")
 
     # Mount only the health router; /health/ does not require app.state.
     app = FastAPI()

--- a/agent-brain-server/tests/unit/api/test_security.py
+++ b/agent-brain-server/tests/unit/api/test_security.py
@@ -1,20 +1,32 @@
-"""Unit tests for the ``verify_api_key`` FastAPI dependency (Issue #179).
+"""Unit tests for the ``verify_bearer_token`` FastAPI dependency (Issue #199).
 
 Verifies the dependency in isolation against a minimal FastAPI app so the
 ``Header(...)`` resolver and ``HTTPException`` plumbing exercise the same path
 they take in production routers. The router-wiring tests in
 ``test_auth_enforcement.py`` cover the integration side.
+
+Coverage map:
+
+* No-op paths: ``API_KEY`` unset (loopback default), ``INSECURE_NO_AUTH=true``.
+* Bearer path: 200 on match, 401 on missing/wrong/malformed header.
+* X-API-Key fallback (deprecated): 200 on match (logs deprecation), 401 on
+  wrong header value.
+* Backwards-compat: setting only ``AGENT_BRAIN_API_KEY`` env var still gates
+  the router because the Settings validator backfills ``API_KEY``.
+* WWW-Authenticate header is always ``Bearer`` (RFC 6750), regardless of
+  which header the client tried.
 """
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Generator
 
 import pytest
 from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
 
-from agent_brain_server.api.security import verify_api_key
+from agent_brain_server.api.security import verify_bearer_token
 from agent_brain_server.config.settings import get_settings
 
 
@@ -23,7 +35,7 @@ def reset_settings_cache() -> Generator[None, None, None]:
     """Reset ``get_settings``'s lru_cache around each test.
 
     The Settings class reads env vars at construction; without clearing the
-    cache, a monkeypatched env var won't show up in ``settings.AGENT_BRAIN_API_KEY``.
+    cache, a monkeypatched env var won't show up in ``settings.API_KEY``.
     """
     get_settings.cache_clear()
     yield
@@ -33,17 +45,25 @@ def reset_settings_cache() -> Generator[None, None, None]:
 def _make_app() -> FastAPI:
     app = FastAPI()
 
-    @app.get("/protected", dependencies=[Depends(verify_api_key)])
+    @app.get("/protected", dependencies=[Depends(verify_bearer_token)])
     async def protected() -> dict[str, str]:
         return {"ok": "true"}
 
     return app
 
 
-def test_noop_when_setting_empty_and_no_header(
+# ---------------------------------------------------------------------------
+# No-op paths
+# ---------------------------------------------------------------------------
+
+
+def test_noop_when_api_key_unset_and_no_header(
     monkeypatch: pytest.MonkeyPatch, reset_settings_cache: None
 ) -> None:
-    monkeypatch.setenv("AGENT_BRAIN_API_KEY", "")
+    """Loopback default: no API_KEY → no auth required."""
+    monkeypatch.delenv("API_KEY", raising=False)
+    monkeypatch.delenv("AGENT_BRAIN_API_KEY", raising=False)
+    monkeypatch.delenv("INSECURE_NO_AUTH", raising=False)
     client = TestClient(_make_app())
 
     response = client.get("/protected")
@@ -52,64 +72,202 @@ def test_noop_when_setting_empty_and_no_header(
     assert response.json() == {"ok": "true"}
 
 
-def test_noop_when_setting_empty_even_with_random_header(
+def test_noop_when_api_key_unset_even_with_random_header(
     monkeypatch: pytest.MonkeyPatch, reset_settings_cache: None
 ) -> None:
-    monkeypatch.setenv("AGENT_BRAIN_API_KEY", "")
+    """Headers are ignored entirely when the gate is unconfigured."""
+    monkeypatch.delenv("API_KEY", raising=False)
+    monkeypatch.delenv("AGENT_BRAIN_API_KEY", raising=False)
     client = TestClient(_make_app())
 
-    response = client.get("/protected", headers={"X-API-Key": "ignored"})
+    response = client.get("/protected", headers={"Authorization": "Bearer ignored"})
 
     assert response.status_code == 200
 
 
-def test_401_when_setting_present_and_header_missing(
+def test_insecure_no_auth_bypasses_even_when_key_set(
     monkeypatch: pytest.MonkeyPatch, reset_settings_cache: None
 ) -> None:
-    monkeypatch.setenv("AGENT_BRAIN_API_KEY", "secret-token")
+    """Explicit operator opt-out short-circuits the dependency.
+
+    The startup gate (199-03) is responsible for the loud warning when the
+    server boots with INSECURE_NO_AUTH=true; the per-request path stays
+    quiet so we don't spam logs.
+    """
+    monkeypatch.setenv("API_KEY", "secret-token")
+    monkeypatch.setenv("INSECURE_NO_AUTH", "true")
+    client = TestClient(_make_app())
+
+    response = client.get("/protected")
+
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Bearer scheme (RFC 6750)
+# ---------------------------------------------------------------------------
+
+
+def test_401_when_key_set_and_no_credentials(
+    monkeypatch: pytest.MonkeyPatch, reset_settings_cache: None
+) -> None:
+    monkeypatch.setenv("API_KEY", "secret-token")
     client = TestClient(_make_app())
 
     response = client.get("/protected")
 
     assert response.status_code == 401
-    assert response.json()["detail"] == "Invalid or missing API key"
-    assert response.headers["WWW-Authenticate"] == "X-API-Key"
+    assert response.headers["WWW-Authenticate"] == "Bearer"
+    assert "Bearer" in response.json()["detail"]
 
 
-def test_401_when_setting_present_and_header_wrong(
+def test_200_when_bearer_token_matches(
     monkeypatch: pytest.MonkeyPatch, reset_settings_cache: None
 ) -> None:
-    monkeypatch.setenv("AGENT_BRAIN_API_KEY", "secret-token")
+    monkeypatch.setenv("API_KEY", "secret-token")
+    client = TestClient(_make_app())
+
+    response = client.get(
+        "/protected", headers={"Authorization": "Bearer secret-token"}
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": "true"}
+
+
+def test_401_when_bearer_token_wrong(
+    monkeypatch: pytest.MonkeyPatch, reset_settings_cache: None
+) -> None:
+    monkeypatch.setenv("API_KEY", "secret-token")
+    client = TestClient(_make_app())
+
+    response = client.get("/protected", headers={"Authorization": "Bearer wrong-token"})
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid bearer token"
+    assert "invalid_token" in response.headers["WWW-Authenticate"]
+
+
+def test_401_when_authorization_scheme_is_not_bearer(
+    monkeypatch: pytest.MonkeyPatch, reset_settings_cache: None
+) -> None:
+    """Basic / Digest / Token / etc. are not accepted — Bearer only."""
+    monkeypatch.setenv("API_KEY", "secret-token")
+    client = TestClient(_make_app())
+
+    response = client.get("/protected", headers={"Authorization": "Basic secret-token"})
+
+    assert response.status_code == 401
+    assert "must use the Bearer scheme" in response.json()["detail"]
+    assert "invalid_request" in response.headers["WWW-Authenticate"]
+
+
+def test_bearer_scheme_is_case_insensitive(
+    monkeypatch: pytest.MonkeyPatch, reset_settings_cache: None
+) -> None:
+    """RFC 6750 §2.1: the scheme name is case-insensitive."""
+    monkeypatch.setenv("API_KEY", "secret-token")
+    client = TestClient(_make_app())
+
+    response = client.get(
+        "/protected", headers={"Authorization": "bearer secret-token"}
+    )
+
+    assert response.status_code == 200
+
+
+def test_bearer_token_compared_constant_time(
+    monkeypatch: pytest.MonkeyPatch, reset_settings_cache: None
+) -> None:
+    """The dependency uses secrets.compare_digest — guard against future drift.
+
+    Behavioral test: tokens that are a prefix of the expected key (which a
+    short-circuit ``==`` could accidentally accept) must still 401.
+    """
+    monkeypatch.setenv("API_KEY", "secret-token")
+    client = TestClient(_make_app())
+
+    response = client.get("/protected", headers={"Authorization": "Bearer secret-toke"})
+
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Deprecated X-API-Key fallback (PR #195 compatibility)
+# ---------------------------------------------------------------------------
+
+
+def test_x_api_key_still_works_with_deprecation_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    reset_settings_cache: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Legacy X-API-Key callers keep working but get a one-version warning."""
+    monkeypatch.setenv("API_KEY", "secret-token")
+    client = TestClient(_make_app())
+
+    with caplog.at_level(logging.WARNING, logger="agent_brain_server.api.security"):
+        response = client.get("/protected", headers={"X-API-Key": "secret-token"})
+
+    assert response.status_code == 200
+    assert any(
+        "X-API-Key header is deprecated" in record.message for record in caplog.records
+    )
+
+
+def test_401_when_x_api_key_wrong(
+    monkeypatch: pytest.MonkeyPatch, reset_settings_cache: None
+) -> None:
+    monkeypatch.setenv("API_KEY", "secret-token")
     client = TestClient(_make_app())
 
     response = client.get("/protected", headers={"X-API-Key": "wrong"})
 
     assert response.status_code == 401
+    assert response.headers["WWW-Authenticate"] == "Bearer"
 
 
-def test_200_when_setting_present_and_header_matches(
+# ---------------------------------------------------------------------------
+# Backwards-compat: AGENT_BRAIN_API_KEY env var still configures the gate
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_env_var_backfills_api_key(
     monkeypatch: pytest.MonkeyPatch, reset_settings_cache: None
 ) -> None:
-    monkeypatch.setenv("AGENT_BRAIN_API_KEY", "secret-token")
-    client = TestClient(_make_app())
+    """Users who set only AGENT_BRAIN_API_KEY get a working bearer gate.
 
-    response = client.get("/protected", headers={"X-API-Key": "secret-token"})
-
-    assert response.status_code == 200
-    assert response.json() == {"ok": "true"}
-
-
-def test_header_is_case_insensitive_per_http_spec(
-    monkeypatch: pytest.MonkeyPatch, reset_settings_cache: None
-) -> None:
-    """HTTP header names are case-insensitive; FastAPI's Header() honors that.
-
-    Documenting the behavior with a test so a future refactor doesn't
-    accidentally tighten the matcher.
+    The Settings validator copies the legacy env var into ``API_KEY`` when
+    ``API_KEY`` is unset, so the new dependency stays single-source-of-truth
+    and the migration is transparent.
     """
-    monkeypatch.setenv("AGENT_BRAIN_API_KEY", "secret-token")
+    monkeypatch.delenv("API_KEY", raising=False)
+    monkeypatch.setenv("AGENT_BRAIN_API_KEY", "legacy-token")
     client = TestClient(_make_app())
 
-    response = client.get("/protected", headers={"x-api-key": "secret-token"})
+    response_no_creds = client.get("/protected")
+    response_with_bearer = client.get(
+        "/protected", headers={"Authorization": "Bearer legacy-token"}
+    )
 
-    assert response.status_code == 200
+    assert response_no_creds.status_code == 401
+    assert response_with_bearer.status_code == 200
+
+
+def test_api_key_takes_precedence_over_legacy(
+    monkeypatch: pytest.MonkeyPatch, reset_settings_cache: None
+) -> None:
+    """When both env vars are set, API_KEY wins — validator only backfills when None."""
+    monkeypatch.setenv("API_KEY", "new-token")
+    monkeypatch.setenv("AGENT_BRAIN_API_KEY", "old-token")
+    client = TestClient(_make_app())
+
+    new_token_ok = client.get(
+        "/protected", headers={"Authorization": "Bearer new-token"}
+    )
+    old_token_rejected = client.get(
+        "/protected", headers={"Authorization": "Bearer old-token"}
+    )
+
+    assert new_token_ok.status_code == 200
+    assert old_token_rejected.status_code == 401

--- a/agent-brain-server/tests/unit/api/test_startup_gate.py
+++ b/agent-brain-server/tests/unit/api/test_startup_gate.py
@@ -1,15 +1,15 @@
 """Tests for the API key startup gate and /docs gating in ``api/main.py``.
 
-Covers Issue #179 acceptance:
+Covers Issue #199 (199-03) acceptance — refuse-without-key by default:
 
-- ``API_HOST=0.0.0.0`` + empty key → process exits with code 2.
-- ``API_HOST=127.0.0.1`` + empty key → warning logged, no exit.
-- ``API_HOST=0.0.0.0`` + non-empty key → no exit, no warning.
-- App built with ``AGENT_BRAIN_API_KEY`` set and ``DEBUG=false`` exposes
-  ``docs_url=None`` and ``openapi_url=None`` (Swagger UI hidden when
-  the schema would otherwise leak the protected surface).
-- App built with ``DEBUG=true`` always keeps ``/docs`` mounted regardless
-  of whether a key is configured.
+* No ``API_KEY`` + no ``INSECURE_NO_AUTH`` → ``sys.exit(2)`` on **any** bind
+  host (loopback included; 127.0.0.1 is not a trust boundary).
+* No ``API_KEY`` + ``INSECURE_NO_AUTH=true`` → loud warning, no exit.
+* ``API_KEY`` set → silent start on any host.
+* Legacy ``AGENT_BRAIN_API_KEY`` env var continues to work because the
+  Settings validator backfills it into ``API_KEY``.
+* /docs gating now keys off ``API_KEY`` (single source of truth) instead
+  of the deprecated v1 field.
 """
 
 from __future__ import annotations
@@ -30,60 +30,119 @@ def reset_settings_cache() -> Generator[None, None, None]:
     get_settings.cache_clear()
 
 
+@pytest.fixture(autouse=True)
+def clear_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start each test from a known-empty auth env so unrelated env vars
+    in the dev shell don't leak in."""
+    monkeypatch.delenv("API_KEY", raising=False)
+    monkeypatch.delenv("AGENT_BRAIN_API_KEY", raising=False)
+    monkeypatch.delenv("INSECURE_NO_AUTH", raising=False)
+
+
 # ---------------------------------------------------------------------------
-# Startup gate
+# Startup gate — refuse-without-key (the inversion from 199-03)
 # ---------------------------------------------------------------------------
 
 
-def test_startup_gate_exits_on_non_loopback_without_key(
-    monkeypatch: pytest.MonkeyPatch, reset_settings_cache: None
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1", "0.0.0.0"])
+def test_startup_gate_exits_when_no_key_on_any_host(
+    reset_settings_cache: None, host: str
 ) -> None:
-    monkeypatch.setenv("AGENT_BRAIN_API_KEY", "")
+    """Loopback is no longer an implicit no-auth escape hatch.
 
+    Pre-199-03 contract allowed empty key on 127.0.0.1 with a warning.
+    Post-199-03 every host requires either ``API_KEY`` or
+    ``INSECURE_NO_AUTH=true``.
+    """
     with pytest.raises(SystemExit) as exc_info:
-        _check_api_key_startup_gate("0.0.0.0")
+        _check_api_key_startup_gate(host)
 
     assert exc_info.value.code == 2
 
 
-def test_startup_gate_warns_on_loopback_without_key(
+def test_startup_gate_warns_when_insecure_no_auth_true(
     monkeypatch: pytest.MonkeyPatch,
     reset_settings_cache: None,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    monkeypatch.setenv("AGENT_BRAIN_API_KEY", "")
+    """Explicit operator opt-out: server starts but logs a loud warning."""
+    monkeypatch.setenv("INSECURE_NO_AUTH", "true")
 
     with caplog.at_level(logging.WARNING, logger="agent_brain_server.api.main"):
         _check_api_key_startup_gate("127.0.0.1")
 
     assert any(
-        "AGENT_BRAIN_API_KEY" in record.message and record.levelno == logging.WARNING
+        "INSECURE_NO_AUTH" in record.message and record.levelno == logging.WARNING
         for record in caplog.records
     )
 
 
-@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1"])
-def test_startup_gate_accepts_all_loopback_aliases(
-    monkeypatch: pytest.MonkeyPatch,
-    reset_settings_cache: None,
-    host: str,
-) -> None:
-    monkeypatch.setenv("AGENT_BRAIN_API_KEY", "")
-    # Should not raise SystemExit for any loopback alias
-    _check_api_key_startup_gate(host)
-
-
-def test_startup_gate_silent_when_key_set_even_on_non_loopback(
+def test_startup_gate_warns_even_on_non_loopback_with_insecure(
     monkeypatch: pytest.MonkeyPatch,
     reset_settings_cache: None,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    monkeypatch.setenv("AGENT_BRAIN_API_KEY", "configured-key")
+    """``INSECURE_NO_AUTH=true`` works on every host — same exit path.
+
+    Bound 0.0.0.0 without a key + INSECURE_NO_AUTH is a conscious choice
+    (e.g. an embedded device on a private network). The startup gate
+    doesn't second-guess it.
+    """
+    monkeypatch.setenv("INSECURE_NO_AUTH", "true")
 
     with caplog.at_level(logging.WARNING, logger="agent_brain_server.api.main"):
         _check_api_key_startup_gate("0.0.0.0")
 
-    # Neither warning nor critical when a key is configured
+    assert any("INSECURE_NO_AUTH" in record.message for record in caplog.records)
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "0.0.0.0", "10.0.0.5"])
+def test_startup_gate_silent_when_api_key_set(
+    monkeypatch: pytest.MonkeyPatch,
+    reset_settings_cache: None,
+    caplog: pytest.LogCaptureFixture,
+    host: str,
+) -> None:
+    monkeypatch.setenv("API_KEY", "configured-key")
+
+    with caplog.at_level(logging.WARNING, logger="agent_brain_server.api.main"):
+        _check_api_key_startup_gate(host)
+
+    assert not any(record.levelno >= logging.WARNING for record in caplog.records)
+
+
+def test_startup_gate_accepts_legacy_env_var(
+    monkeypatch: pytest.MonkeyPatch,
+    reset_settings_cache: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """PR #195 / Issue #179 installs keep working — validator backfills API_KEY."""
+    monkeypatch.setenv("AGENT_BRAIN_API_KEY", "legacy-key")
+
+    with caplog.at_level(logging.WARNING, logger="agent_brain_server.api.main"):
+        _check_api_key_startup_gate("0.0.0.0")
+
+    # No exit, no warning — silent start under the legacy env var.
+    assert not any(record.levelno >= logging.WARNING for record in caplog.records)
+
+
+def test_api_key_takes_precedence_over_insecure(
+    monkeypatch: pytest.MonkeyPatch,
+    reset_settings_cache: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When both are set, API_KEY wins — no INSECURE warning fires.
+
+    Treating ``INSECURE_NO_AUTH=true`` as a global override would let a
+    stale environment variable silently disable auth on an otherwise
+    correctly-configured server. The gate checks ``API_KEY`` first.
+    """
+    monkeypatch.setenv("API_KEY", "configured-key")
+    monkeypatch.setenv("INSECURE_NO_AUTH", "true")
+
+    with caplog.at_level(logging.WARNING, logger="agent_brain_server.api.main"):
+        _check_api_key_startup_gate("127.0.0.1")
+
     assert not any(record.levelno >= logging.WARNING for record in caplog.records)
 
 
@@ -92,10 +151,10 @@ def test_startup_gate_silent_when_key_set_even_on_non_loopback(
 # ---------------------------------------------------------------------------
 
 
-def test_docs_gated_when_key_set_and_debug_false(
+def test_docs_gated_when_api_key_set_and_debug_false(
     monkeypatch: pytest.MonkeyPatch, reset_settings_cache: None
 ) -> None:
-    monkeypatch.setenv("AGENT_BRAIN_API_KEY", "docs-test-key")
+    monkeypatch.setenv("API_KEY", "docs-test-key")
     monkeypatch.setenv("DEBUG", "false")
 
     app = _build_app()
@@ -105,10 +164,10 @@ def test_docs_gated_when_key_set_and_debug_false(
     assert app.openapi_url is None
 
 
-def test_docs_open_when_key_set_but_debug_true(
+def test_docs_open_when_api_key_set_but_debug_true(
     monkeypatch: pytest.MonkeyPatch, reset_settings_cache: None
 ) -> None:
-    monkeypatch.setenv("AGENT_BRAIN_API_KEY", "docs-test-key")
+    monkeypatch.setenv("API_KEY", "docs-test-key")
     monkeypatch.setenv("DEBUG", "true")
 
     app = _build_app()
@@ -118,10 +177,10 @@ def test_docs_open_when_key_set_but_debug_true(
     assert app.openapi_url == "/openapi.json"
 
 
-def test_docs_open_when_key_unset(
+def test_docs_open_when_api_key_unset(
     monkeypatch: pytest.MonkeyPatch, reset_settings_cache: None
 ) -> None:
-    monkeypatch.setenv("AGENT_BRAIN_API_KEY", "")
+    """No API_KEY → endpoints are open → no point gating the schema."""
     monkeypatch.setenv("DEBUG", "false")
 
     app = _build_app()
@@ -129,3 +188,16 @@ def test_docs_open_when_key_unset(
     assert app.docs_url == "/docs"
     assert app.redoc_url == "/redoc"
     assert app.openapi_url == "/openapi.json"
+
+
+def test_docs_gated_via_legacy_env_var(
+    monkeypatch: pytest.MonkeyPatch, reset_settings_cache: None
+) -> None:
+    """AGENT_BRAIN_API_KEY → API_KEY backfill flows through to /docs gating."""
+    monkeypatch.setenv("AGENT_BRAIN_API_KEY", "legacy-docs-key")
+    monkeypatch.setenv("DEBUG", "false")
+
+    app = _build_app()
+
+    assert app.docs_url is None
+    assert app.openapi_url is None

--- a/agent-brain-server/tests/unit/test_runtime.py
+++ b/agent-brain-server/tests/unit/test_runtime.py
@@ -5,8 +5,10 @@ import os
 from unittest.mock import patch
 
 from agent_brain_server.runtime import (
+    API_KEY_BYTES,
     RuntimeState,
     delete_runtime,
+    generate_api_key,
     read_runtime,
     validate_runtime,
     write_runtime,
@@ -168,3 +170,35 @@ class TestValidateRuntime:
         state = RuntimeState()  # pid=0, base_url=""
         result = validate_runtime(state)
         assert result is False
+
+
+class TestGenerateApiKey:
+    """Tests for generate_api_key() helper (Issue #199 plumbing — 199-01)."""
+
+    def test_returns_non_empty_string(self):
+        """Generated key is a non-empty str."""
+        key = generate_api_key()
+        assert isinstance(key, str)
+        assert len(key) > 0
+
+    def test_key_has_expected_length(self):
+        """secrets.token_urlsafe(32) produces a 43-character URL-safe base64 string."""
+        # 32 bytes encoded as URL-safe base64 = ceil(32 * 4 / 3) = 43 chars
+        # (no padding for token_urlsafe).
+        assert API_KEY_BYTES == 32
+        key = generate_api_key()
+        assert len(key) == 43
+
+    def test_two_calls_return_different_values(self):
+        """Successive calls produce different tokens — entropy sanity check."""
+        key_a = generate_api_key()
+        key_b = generate_api_key()
+        assert key_a != key_b
+
+    def test_key_uses_url_safe_alphabet(self):
+        """Token contains only URL-safe base64 characters."""
+        key = generate_api_key()
+        allowed = set(
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ" "abcdefghijklmnopqrstuvwxyz" "0123456789-_"
+        )
+        assert set(key).issubset(allowed)

--- a/agent-brain-server/tests/unit/test_settings_auth.py
+++ b/agent-brain-server/tests/unit/test_settings_auth.py
@@ -1,0 +1,58 @@
+"""Unit tests for Settings auth fields added by Issue #199 plumbing.
+
+Sub-plan 199-01 adds two new Settings fields alongside the existing
+AGENT_BRAIN_API_KEY:
+- API_KEY: SecretStr | None — the canonical Bearer token storage
+- INSECURE_NO_AUTH: bool — the --insecure opt-out flag
+
+Neither is wired into the routers yet. Sub-plan 199-02 swaps
+verify_api_key → verify_bearer_token to actually consume API_KEY.
+These tests pin the field shape so the 199-02 swap is mechanical.
+"""
+
+from pydantic import SecretStr
+
+from agent_brain_server.config.settings import Settings
+
+
+class TestNewAuthFields:
+    """Plumbing-only tests for Issue #199 sub-plan 199-01 field additions."""
+
+    def test_api_key_defaults_to_none(self):
+        """API_KEY is None by default — server is unauthenticated unless explicit."""
+        settings = Settings(_env_file=None)
+        assert settings.API_KEY is None
+
+    def test_insecure_no_auth_defaults_to_false(self):
+        """INSECURE_NO_AUTH is False by default — opt-in only."""
+        settings = Settings(_env_file=None)
+        assert settings.INSECURE_NO_AUTH is False
+
+    def test_api_key_is_secret_str_when_set(self):
+        """API_KEY wraps the token in SecretStr so logs/tracebacks redact it."""
+        settings = Settings(_env_file=None, API_KEY="hunter2")
+        assert isinstance(settings.API_KEY, SecretStr)
+        assert settings.API_KEY.get_secret_value() == "hunter2"
+        # repr() must NOT expose the secret value
+        assert "hunter2" not in repr(settings.API_KEY)
+
+    def test_insecure_no_auth_accepts_true(self):
+        """INSECURE_NO_AUTH can be flipped on."""
+        settings = Settings(_env_file=None, INSECURE_NO_AUTH=True)
+        assert settings.INSECURE_NO_AUTH is True
+
+    def test_agent_brain_api_key_still_exists_for_v1_compat(self):
+        """AGENT_BRAIN_API_KEY field is preserved in 199-01 — 199-02 will remove."""
+        settings = Settings(_env_file=None)
+        assert settings.AGENT_BRAIN_API_KEY == ""
+
+    def test_v1_and_v2_fields_are_independent_in_199_01(self):
+        """Setting one does not affect the other (alias migration is 199-02 work)."""
+        settings = Settings(
+            _env_file=None,
+            AGENT_BRAIN_API_KEY="v1-key",
+            API_KEY="v2-key",
+        )
+        assert settings.AGENT_BRAIN_API_KEY == "v1-key"
+        assert settings.API_KEY is not None
+        assert settings.API_KEY.get_secret_value() == "v2-key"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Security
+
+- **REST API auth upgraded to RFC 6750 Bearer scheme + refuse-without-key startup gate** (`agent_brain_server/api/security.py`, `agent_brain_server/api/main.py`, `agent_brain_server/api/routers/*.py`, `agent_brain_server/config/settings.py`, `agent_brain_server/runtime.py`, `agent_brain_cli/agent_brain_cli/client/api_client.py`, `agent_brain_cli/agent_brain_cli/client/transport.py`, `agent_brain_cli/agent_brain_cli/config.py`, `agent_brain_cli/agent_brain_cli/commands/start.py`). Closes [#199](https://github.com/SpillwaveSolutions/agent-brain/issues/199) — the v2 hardening pass on top of the v1 X-API-Key flow from PR #195. Three concrete changes:
+
+  1. **Scheme switch.** The gated routers (`/index`, `/index/cache`, `/index/folders`, `/index/jobs`, `/query`, `/graph`) now consume `Authorization: Bearer <token>` per RFC 6750. The deprecated `X-API-Key` header still works for one release window with a server-side log per request and a per-process CLI warning when the legacy env var is read. Bearer is forward-compatible with the OAuth 2.1 work in [#188](https://github.com/SpillwaveSolutions/agent-brain/issues/188) — same scheme evolves from static key to OAuth-issued bearer.
+  2. **Refuse-without-key by default — every bind host.** The startup gate at `agent_brain_server/api/main.py::_check_api_key_startup_gate` previously allowed `127.0.0.1` with no key (loopback was implicitly trusted). The v2 default refuses to start (`sys.exit(2)`) on **every** host (loopback included) unless either `API_KEY` is set or `INSECURE_NO_AUTH=true` is passed explicitly. 127.0.0.1 is not a trust boundary on multi-process machines (OWASP API1/API2:2023). The explicit opt-out mirrors Postgres `--allow-empty-password` and Redis `protected-mode no` — operators see a loud warning at boot when they take it.
+  3. **CLI `--insecure` flag.** `agent-brain start --insecure` exports `INSECURE_NO_AUTH=true` to the server subprocess AND strips any inherited `API_KEY` / `AGENT_BRAIN_API_KEY` env var, so a stale shell entry can't silently re-enable auth and confuse operators who asked for `--insecure` on purpose. The default path now propagates the project-local key as the canonical `API_KEY` env var (the deprecated `AGENT_BRAIN_API_KEY` keeps working server-side via a `Settings` validator that backfills the new field).
+
+  **Settings:** `API_KEY: SecretStr | None` is now the canonical env var name (logs and tracebacks redact via SecretStr). `INSECURE_NO_AUTH: bool = False` is the operator opt-out. `AGENT_BRAIN_API_KEY: str = ""` is preserved as a deprecated alias and the validator copies it into `API_KEY` at construction time so PR #195 deployments keep working without code changes. `/docs`, `/redoc`, `/openapi.json` gating now keys off `API_KEY` (single source of truth) instead of the v1 field.
+
+  **CLI:** `DocServeClient(api_key=...)` and `DocServeClient.from_httpx(client, api_key=...)` build `Authorization: Bearer <token>` instead of `X-API-Key`. `resolve_api_key()` precedence is now `API_KEY` env > `AGENT_BRAIN_API_KEY` env (deprecation log) > `runtime.json::api_key` > `config.json::api_key` > None.
+
+  **Tests:** 13 new server unit tests for `verify_bearer_token` (`agent-brain-server/tests/unit/api/test_security.py`), 20 retargeted structural + behavioral tests across all 6 gated routers (`test_auth_enforcement.py`), 15 rewritten startup-gate + docs-gating tests (`test_startup_gate.py`) including the refuse-on-loopback inversion, 13 CLI propagation tests covering Bearer headers, the new env-var cascade, and the deprecation-warning latch (`agent-brain-cli/tests/test_api_key_propagation.py`), and 4 new tests for `agent-brain start --insecure` (`test_start_insecure.py`) covering the env-construction contract: `INSECURE_NO_AUTH=true` + key strip, `API_KEY` propagation from config, operator env-var precedence, and legacy `AGENT_BRAIN_API_KEY` preservation. `task before-push` and `task pr-qa-gate` both pass: 1330 server / 553 CLI / 32 UDS / 544 MCP tests, 80%+ coverage every package.
+
+  **Migration for callers of the v1 (X-API-Key) flow:** existing PR #195 / Issue #179 deployments require no immediate changes — the v1 env var name (`AGENT_BRAIN_API_KEY`) and the v1 header (`X-API-Key`) both keep working through one deprecation window. To migrate ahead of removal: rename your env var to `API_KEY` and switch your HTTP clients to `Authorization: Bearer <token>`. Operators who relied on default-no-auth on `127.0.0.1` must either set `API_KEY` (recommended) or pass `INSECURE_NO_AUTH=true` explicitly — the server now refuses to boot otherwise.
+
+  Credit: design and reference implementation from [@jeremylongshore](https://github.com/jeremylongshore)'s [PR #193](https://github.com/SpillwaveSolutions/agent-brain/pull/193). The OWASP framing, the secure-default rationale, the RFC 6750 + forward-compat-to-OAuth choice, and the `INSECURE_NO_AUTH` opt-out shape are all from that branch. PR #199 re-applies the design against the post-v10.2 surface (which had drifted heavily — `api/security.py`, `api/main.py`, `config/settings.py`, `runtime.py`, and the CLI client all moved) as six small sub-plans rather than a single big diff.
+
+---
+
 ## [10.2.1] - 2026-06-05
 
 ### Security


### PR DESCRIPTION
## Summary

v2 auth hardening on top of [PR #195](https://github.com/SpillwaveSolutions/agent-brain/pull/195) (which closed [#179](https://github.com/SpillwaveSolutions/agent-brain/issues/179) with X-API-Key + opt-in-by-default). Closes [#199](https://github.com/SpillwaveSolutions/agent-brain/issues/199).

Three concrete changes — credit to [@jeremylongshore](https://github.com/jeremylongshore)'s [PR #193](https://github.com/SpillwaveSolutions/agent-brain/pull/193) for the design and reference implementation:

1. **Scheme switch to RFC 6750 `Authorization: Bearer <token>`** — forward-compatible with the OAuth 2.1 work in [#188](https://github.com/SpillwaveSolutions/agent-brain/issues/188). The deprecated `X-API-Key` header still works for one release window (server logs per request; CLI logs once per process when the legacy env var is set).
2. **Refuse-without-key on every host (gate inversion).** Pre-#199 allowed `127.0.0.1` with no key on the assumption that loopback is a trust boundary — it isn't on multi-process machines (OWASP API1/API2:2023). Default is now `sys.exit(2)` unless either `API_KEY` is set or `INSECURE_NO_AUTH=true` is passed explicitly (mirrors Postgres `--allow-empty-password` / Redis `protected-mode no`).
3. **CLI `agent-brain start --insecure`** — exports `INSECURE_NO_AUTH=true` to the server subprocess AND strips any inherited `API_KEY` / `AGENT_BRAIN_API_KEY` so a stale shell entry can't silently re-enable auth. Default path now propagates the project-local key as the canonical `API_KEY` env var.

## Sub-plan layout

PR #193 (657 LoC, single commit) conflicted heavily with main because of the v10.2 / v10.3 work that landed afterwards. This branch re-applies the same design as six small sub-plans against the post-v10.2 surface where `api/security.py`, `api/main.py`, `config/settings.py`, `runtime.py`, and the CLI client all moved.

| Commit | Sub-plan | Scope |
|---|---|---|
| `67ddb9f` | 199-01 | Plumbing: `API_KEY: SecretStr`, `INSECURE_NO_AUTH: bool`, `generate_api_key()` helper |
| `443db96` | 199-02 | Router swap: 6 routers → `verify_bearer_token`; Settings validator backfills the deprecated `AGENT_BRAIN_API_KEY` env var into `API_KEY` |
| `a41e3b3` | 199-03 | Startup gate inversion: refuse-without-key on every host; `/docs` gating keyed off `API_KEY`; `runtime.json::api_key` writes the resolved secret |
| `461ac0b` | 199-04 | CLI: `Authorization: Bearer` header, `resolve_api_key()` cascade (env > runtime.json > config.json), `--insecure` flag on `start` |
| (rolled into 199-04) | 199-05 | Cross-checked Jeremy's PR #193 tests — all CLI tests covered; all server tests covered except the deliberate design-difference (we use startup-gate `exit 2` instead of per-request 503 for the misconfigured state) |
| `055f6e0` | 199-06 | CHANGELOG entry + `.env.example` refresh + migration guide for v1 → v2 callers |

## Acceptance criteria (from #199)

- [x] Server uses `Authorization: Bearer <token>` for all routers except `/health` (199-02)
- [x] `agent-brain init` auto-generates a token at `.agent-brain/config.json` (mode 0600) — already shipped in PR #195; preserved
- [x] Server refuses to start without a token unless `INSECURE_NO_AUTH=true` (199-03)
- [x] `/docs`, `/redoc`, `/openapi.json` are 404 unless `DEBUG=true` AND `API_KEY` is set (199-03)
- [x] CLI sends `Authorization: Bearer` automatically (199-04); existing `X-API-Key` callers continue to work with a per-process deprecation warning
- [x] All 24 tests from #193 ported or equivalent coverage exists (61 new/rewritten tests total across the five sub-plans: 13 server unit + 20 router enforcement + 15 startup-gate + 13 CLI propagation + 4 start-insecure)
- [x] CHANGELOG entry credits @jeremylongshore (199-06)

## Migration for callers of the v1 (X-API-Key) flow

**No immediate action required** — the v1 env var name (`AGENT_BRAIN_API_KEY`) and the v1 header (`X-API-Key`) both keep working through one deprecation window. To migrate ahead of removal:

1. Rename `AGENT_BRAIN_API_KEY` to `API_KEY` in your `.env` / process manager.
2. Switch your HTTP clients from `X-API-Key: <token>` to `Authorization: Bearer <token>`.

**Behavior change to watch for** — operators who relied on default-no-auth on `127.0.0.1` must now either set `API_KEY` (recommended) or pass `INSECURE_NO_AUTH=true` explicitly. The server refuses to boot otherwise.

## Test plan

- [x] `task before-push` exits 0: 1330 server / 553 CLI / 32 UDS / 544 MCP tests, all green
- [x] `task pr-qa-gate` exits 0: 80%+ coverage in every package (server 80%, CLI 80%, UDS 98.56%, MCP 88.08%)
- [x] All sub-plan-specific tests pass individually (see commit messages for per-plan test inventories)
- [ ] CI runs the same gates on push — to verify after PR opens
- [ ] Close PR #193 with thanks once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)