### PR TITLE
fix(plugin): refresh skills for v10.x layout + MCP rename

### DIFF
--- a/agent-brain-plugin/skills/configuring-agent-brain/SKILL.md
+++ b/agent-brain-plugin/skills/configuring-agent-brain/SKILL.md
@@ -6,17 +6,18 @@ description: |
   "setting up document search", "installing agent-brain packages", "configuring API keys",
   "initializing project for search", "troubleshooting agent brain", "pip install agent-brain",
   "agent brain not working", "agent brain setup error", "configure embeddings provider",
-  "setup ollama for agent brain", or "agent brain environment variables".
-  Covers package installation, provider configuration, project initialization, and server management.
+  "setup ollama for agent brain", "agent brain environment variables",
+  "install agent brain mcp", "configure mcp server", or "connect agent brain to claude desktop".
+  Covers package installation (server, CLI, MCP), provider configuration, project initialization, and server management.
 license: MIT
 allowed-tools:
   - Bash
   - Read
 metadata:
-  version: 7.0.0
+  version: 10.3.0
   category: ai-tools
   author: Spillwave
-  last_validated: 2026-03-19
+  last_validated: 2026-06-10
 ---
 
 # Configuring Agent Brain
@@ -29,6 +30,7 @@ Installation and configuration for Agent Brain document search with pluggable pr
 - [Setup Wizard](#setup-wizard)
 - [Prerequisites](#prerequisites)
 - [Installation](#installation)
+- [MCP Server](#mcp-server-optional)
 - [Provider Configuration](#provider-configuration)
 - [Project Initialization](#project-initialization)
 - [Verification](#verification)
@@ -46,6 +48,8 @@ Agent Brain supports multiple AI coding runtimes from a single canonical plugin 
 | Claude Code | `agent-brain install-agent --agent claude` |
 | OpenCode | `agent-brain install-agent --agent opencode` |
 | Gemini CLI | `agent-brain install-agent --agent gemini` |
+| Codex (+ AGENTS.md) | `agent-brain install-agent --agent codex` |
+| Any skill runtime | `agent-brain install-agent --agent skill-runtime --dir <path>` |
 
 All runtimes share the same `.agent-brain/` data directory for indexes, configuration, and server state. The `install-agent` command converts the canonical plugin format into each runtime's native format automatically.
 
@@ -178,6 +182,12 @@ identically from the user's perspective. Language is configurable via
 
 ## Installation
 
+> **Recommended installer**: use **pipx** (isolated global) or **uv** to install the
+> CLI — `pipx install agent-brain-cli` or `uv tool install agent-brain-cli`. The bare
+> `pip` commands below work everywhere and are kept for simplicity, but pipx/uv avoid
+> dependency clashes. See [Installation Guide](references/installation-guide.md) for the
+> full comparison.
+
 ### Standard Installation
 
 ```bash
@@ -189,7 +199,7 @@ pip install agent-brain-rag agent-brain-cli
 agent-brain --version
 ```
 
-Expected: Version number displayed (e.g., `3.0.0` or current version)
+Expected: Version number displayed (e.g., `10.3.0` or later)
 
 ### With GraphRAG Support
 
@@ -242,6 +252,61 @@ sudo pip install agent-brain-rag  # Wrong - creates permission issues
 pip install --user agent-brain-rag  # Correct - user installation
 # OR use virtual environment
 ```
+
+---
+
+## MCP Server (Optional)
+
+Agent Brain ships an **MCP (Model Context Protocol) server** that exposes the running
+instance to MCP-aware clients — Claude Desktop, Claude Code, Cursor, Windsurf, the Claude
+Agent SDK, and LangChain DeepAgents.
+
+### Install
+
+```bash
+pip install agent-brain-ag-mcp
+```
+
+> **PyPI name vs. command**: the package publishes as `agent-brain-ag-mcp` (renamed in
+> v10.1.2 — the original name hit PyPI's typosquatting filter), but the installed console
+> script is still `agent-brain-mcp` and the import path is still `agent_brain_mcp`.
+
+### Configure an MCP client
+
+Add the server to your client's MCP config (Claude Desktop / Cursor / Windsurf use the
+same `mcpServers` shape):
+
+```json
+{
+  "mcpServers": {
+    "agent-brain": {
+      "command": "agent-brain-mcp",
+      "args": ["--backend", "auto"],
+      "env": { "AGENT_BRAIN_STATE_DIR": "/abs/path/.agent-brain" }
+    }
+  }
+}
+```
+
+- `--backend {auto,uds,http}` selects how the MCP server reaches `agent-brain-serve`
+  (`auto` prefers the Unix domain socket, falls back to HTTP). This is **orthogonal** to
+  the MCP *listen* transport.
+- **stdio** is the default listen transport (no flag). For IDE/framework clients that
+  prefer HTTP, use `agent-brain-mcp --transport http --host 127.0.0.1 --port 8765`
+  (loopback only — public binds are rejected; auth is deferred to MCP v4).
+
+### Verify
+
+```bash
+# stdio server starts and exposes tools/resources/prompts
+agent-brain-mcp --help
+
+# Or drive it from the CLI's mcp transport
+agent-brain --transport mcp resources list
+```
+
+The v1 surface is 7 tools, 5 `corpus://` resources, and 6 prompts. See the MCP package
+README and `docs/MCP_USER_GUIDE.md` for the full reference.
 
 ---
 
@@ -527,7 +592,7 @@ Expected: Search results or "No results" (not an error)
 
 Run each command and verify expected output:
 
-- [ ] `agent-brain --version` shows version number (7.0.0+)
+- [ ] `agent-brain --version` shows version number (10.3.0+)
 - [ ] `echo ${OPENAI_API_KEY:+SET}` shows "SET" (if using OpenAI)
 - [ ] `ls .agent-brain/config.json` file exists
 - [ ] `agent-brain status` shows "healthy"

--- a/agent-brain-plugin/skills/configuring-agent-brain/references/troubleshooting-guide.md
+++ b/agent-brain-plugin/skills/configuring-agent-brain/references/troubleshooting-guide.md
@@ -89,7 +89,7 @@ cat .agent-brain/runtime.json | jq '.base_url'
 
 **Override URL if Needed:**
 ```bash
-export DOC_SERVE_URL="http://localhost:49321"
+export AGENT_BRAIN_URL="http://localhost:49321"
 agent-brain status
 ```
 

--- a/agent-brain-plugin/skills/using-agent-brain/SKILL.md
+++ b/agent-brain-plugin/skills/using-agent-brain/SKILL.md
@@ -12,16 +12,17 @@ description: |
   Supports multi-instance architecture with automatic server discovery.
   GraphRAG mode enables relationship-aware queries for code dependencies and entity connections.
   Pluggable providers for embeddings (OpenAI, Cohere, Ollama) and summarization (Anthropic, OpenAI, Gemini, Grok, Ollama).
-  Supports multiple runtimes (Claude Code, OpenCode, Gemini CLI) with shared .agent-brain/ data directory.
+  Supports multiple runtimes (Claude Code, OpenCode, Gemini CLI) with shared .agent-brain/ data directory,
+  plus MCP-aware clients (Claude Desktop, Cursor, Windsurf) via the agent-brain-mcp server.
 license: MIT
 allowed-tools:
   - Bash
   - Read
 metadata:
-  version: 7.0.0
+  version: 10.3.0
   category: ai-tools
   author: Spillwave
-  last_validated: 2026-03-19
+  last_validated: 2026-06-10
 ---
 
 # Agent Brain Expert Skill
@@ -383,7 +384,7 @@ This skill focuses on **searching and querying**. Do NOT use for:
 ## Best Practices
 
 1. **Mode Selection**: BM25 for exact terms, Vector for concepts, Hybrid for comprehensive, Graph for relationships
-2. **Threshold Tuning**: Start at 0.7, lower to 0.3-0.5 for more results
+2. **Threshold Tuning**: The default is `0.3` (see Mode Parameters). Keep it for broad recall; raise toward `0.6–0.7` to tighten precision, or lower to `0.1–0.2` if results are too sparse
 3. **Server Discovery**: Use `runtime.json` rather than assuming port 8000
 4. **Resource Cleanup**: Run `agent-brain stop` when done
 5. **Source Citation**: Always reference source filenames in responses

--- a/agent-brain-plugin/skills/using-agent-brain/references/api_reference.md
+++ b/agent-brain-plugin/skills/using-agent-brain/references/api_reference.md
@@ -14,7 +14,7 @@ cat .agent-brain/runtime.json | jq -r '.base_url'
 
 Default (single instance): `http://127.0.0.1:8000`
 
-Override via environment: `DOC_SERVE_URL`
+Override via environment: `AGENT_BRAIN_URL`
 
 ---
 

--- a/agent-brain-plugin/skills/using-agent-brain/references/integration-guide.md
+++ b/agent-brain-plugin/skills/using-agent-brain/references/integration-guide.md
@@ -174,6 +174,5 @@ agent-brain cache clear --yes
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `AGENT_BRAIN_URL` | Override server URL | Auto-discovered |
-| `DOC_SERVE_URL` | Legacy override (still supported) | Auto-discovered |
 | `OPENAI_API_KEY` | Required for vector/hybrid modes | - |
 | `ANTHROPIC_API_KEY` | Optional for summarization | - |

--- a/agent-brain-plugin/skills/using-agent-brain/references/server-discovery.md
+++ b/agent-brain-plugin/skills/using-agent-brain/references/server-discovery.md
@@ -193,6 +193,6 @@ agent-brain list                                # All instances
 ### Environment Override
 
 ```bash
-export DOC_SERVE_URL="http://127.0.0.1:8000"
+export AGENT_BRAIN_URL="http://127.0.0.1:8000"
 agent-brain query "search term"
 ```

--- a/agent-brain-plugin/skills/using-agent-brain/references/troubleshooting-guide.md
+++ b/agent-brain-plugin/skills/using-agent-brain/references/troubleshooting-guide.md
@@ -262,7 +262,7 @@ agent-brain list
 **Use correct URL:**
 ```bash
 # Override URL if needed
-export DOC_SERVE_URL="http://localhost:54321"
+export AGENT_BRAIN_URL="http://localhost:54321"
 agent-brain status
 ```
 

--- a/agent-brain-plugin/skills/using-agent-brain/references/version-management.md
+++ b/agent-brain-plugin/skills/using-agent-brain/references/version-management.md
@@ -19,6 +19,8 @@ echo "Latest: $VERSION"
 
 | Version | Release Date | Key Features |
 |---------|--------------|--------------|
+| 10.3.0 | 2026-06 | Bearer-auth hardening, injector allowlisting, MCP Streamable HTTP transport |
+| 10.1.0 | 2026-05 | MCP server (`agent-brain-ag-mcp`): 7 tools, 5 resources, 6 prompts; UDS transport |
 | 9.1.0 | 2026-03 | Generic skill-runtime converter, Codex adapter, AGENTS.md generation |
 | 9.0.0 | 2026-03 | Multi-runtime install (claude, opencode, gemini, codex, skill-runtime) |
 | 8.0.0 | 2026-03 | File watcher, embedding cache, setup wizard, query cache, reranking |
@@ -61,11 +63,11 @@ pip install agent-brain-rag==$VERSION agent-brain-cli==$VERSION
 ### Version Range
 
 ```bash
-# Compatible with 3.x
-pip install "agent-brain-rag>=3.0.0,<4.0.0"
+# Compatible with 10.x
+pip install "agent-brain-rag>=10.0.0,<11.0.0"
 
 # Minimum version
-pip install "agent-brain-rag>=3.0.0"
+pip install "agent-brain-rag>=10.0.0"
 ```
 
 ## Listing Available Versions
@@ -189,8 +191,8 @@ agent-brain-cli==X.Y.Z
 ```toml
 [project]
 dependencies = [
-    "agent-brain-rag>=3.0.0,<4.0.0",
-    "agent-brain-cli>=3.0.0,<4.0.0",
+    "agent-brain-rag>=10.0.0,<11.0.0",
+    "agent-brain-cli>=10.0.0,<11.0.0",
 ]
 ```
 
@@ -198,8 +200,8 @@ dependencies = [
 
 ```toml
 [tool.poetry.dependencies]
-agent-brain-rag = "^3.0.0"
-agent-brain-cli = "^3.0.0"
+agent-brain-rag = "^10.0.0"
+agent-brain-cli = "^10.0.0"
 ```
 
 ## Development Versions

--- a/agent-brain-plugin/skills/using-agent-brain/scripts/query_domain.py
+++ b/agent-brain-plugin/skills/using-agent-brain/scripts/query_domain.py
@@ -24,8 +24,7 @@ except ImportError:
 
 def get_base_url() -> str:
     """Get the Agent Brain server URL from environment or default."""
-    # Support both new and legacy env var names
-    return os.environ.get("AGENT_BRAIN_URL", os.environ.get("DOC_SERVE_URL", "http://127.0.0.1:8000"))
+    return os.environ.get("AGENT_BRAIN_URL", "http://127.0.0.1:8000")
 
 
 def check_health(base_url: str) -> dict:

--- a/docs/plans/skill-grades-2026-06.md
+++ b/docs/plans/skill-grades-2026-06.md
@@ -1,0 +1,98 @@
+# Plugin Skill Grades — June 2026
+
+Evaluation of the two Agent Brain plugin skills against the `improving-skills`
+5-pillar rubric (PDA 30 / Ease 25 / Spec 15 / Style 10 / Utility 20, ±15 modifiers).
+Graded 2026-06-10 against package state v10.3.0.
+
+| Skill | Score | Grade |
+|-------|-------|-------|
+| `configuring-agent-brain` | 73/100 | C |
+| `using-agent-brain` | 80/100 | B |
+
+---
+
+## configuring-agent-brain — 73/100 (C)
+
+| Pillar | Score | Notes |
+|--------|-------|-------|
+| Progressive Disclosure (PDA) | 20/30 | Good layering (SKILL.md → references/), but the body is long (704 lines) and front-loads provider tables that could live in references. Navigation contents block is solid. |
+| Ease of Use | 21/25 | Rich trigger list in `description`; clear Quick Setup A/B split. Loses points for no MCP/UDS triggers and a stale `version: 7.0.0`. |
+| Spec Compliance | 12/15 | Valid frontmatter, good naming. Stale `version`/`last_validated`; install examples use bare `pip` while `references/installation-guide.md` recommends pipx/uv (internal contradiction). |
+| Writing Style | 9/10 | Objective, imperative, good counter-examples. |
+| Utility | 14/20 | Strong verification checklists and troubleshooting. **Zero coverage of the MCP package** (`agent-brain-ag-mcp`) or UDS transport — a whole shipped surface is undocumented. Stale `3.0.0` version example. |
+| Modifiers | −3 | −3 stale version metadata + version example drift. |
+
+### Top findings
+1. **No MCP coverage.** The `agent-brain-mcp` server (PyPI `agent-brain-ag-mcp`) ships in 10.x and is invisible here. Add an install + client-config section.
+2. **pip vs pipx/uv contradiction.** SKILL.md Quick Setup uses bare `pip`; `installation-guide.md` leads with pipx (recommended) / uv. Reconcile by pointing at the isolated installers.
+3. **Stale version metadata.** `version: 7.0.0`, `last_validated: 2026-03-19`, line ~192 `e.g., 3.0.0`, line ~530 `7.0.0+` — all predate v10.3.0.
+
+---
+
+## using-agent-brain — 80/100 (B)
+
+| Pillar | Score | Notes |
+|--------|-------|-------|
+| Progressive Disclosure (PDA) | 24/30 | Excellent: tight 423-line body, mode tables, references/ for depth. |
+| Ease of Use | 22/25 | Outstanding trigger coverage in `description`; clear mode-selection guide with counter-examples. Stale `version: 7.0.0`. |
+| Spec Compliance | 12/15 | Valid frontmatter; stale version/date. Server-management section mixes bare CLI and `/agent-brain:*` slash-command forms without explaining the relationship. |
+| Writing Style | 9/10 | Crisp, example-driven. |
+| Utility | 15/20 | Very strong. One correctness bug: **threshold default inconsistency** — Mode Parameters table says default `0.3` (correct, matches `query.py:81`) but Best Practices #2 says "Start at 0.7". Misleads users into over-filtering. |
+| Modifiers | −2 | −2 stale version metadata. |
+
+### Top findings
+1. **Threshold contradiction.** Reconcile Best Practices #2 with the documented `0.3` default.
+2. **Stale version metadata.** `version: 7.0.0`, `last_validated: 2026-03-19`.
+3. **No MCP/IDE-client note.** The `description` lists runtimes (Claude Code, OpenCode, Gemini CLI) but not MCP-aware IDE clients now served by `agent-brain-mcp`.
+
+---
+
+## Cross-cutting reference staleness
+
+- `references/version-management.md` — version history frozen at `7.0.0` (2026-03); dependency pins use `>=3.0.0,<4.0.0` and `^3.0.0` (should be `>=10.0.0,<11.0.0` / `^10.0.0`).
+- `scripts/query_domain.py:28` — legacy `DOC_SERVE_URL` env fallback (pre-rename name); `AGENT_BRAIN_URL` is canonical.
+
+---
+
+## Fixes applied in this PR
+
+- Both SKILL.md frontmatter → `version: 10.3.0`, `last_validated: 2026-06-10`.
+- `configuring-agent-brain`: added an **MCP server** section (`agent-brain-ag-mcp` install + client config JSON + UDS/transport note); reconciled install guidance toward pipx/uv; fixed the `3.0.0`/`7.0.0+` version examples.
+- `using-agent-brain`: reconciled the threshold Best Practice with the `0.3` default.
+- `version-management.md`: refreshed version history + dependency pins to the 10.x line.
+- `query_domain.py`: dropped the legacy `DOC_SERVE_URL` fallback.
+
+## JSON
+
+```json
+{
+  "evaluated": "2026-06-10",
+  "package_version": "10.3.0",
+  "skills": [
+    {
+      "name": "configuring-agent-brain",
+      "score": 73,
+      "grade": "C",
+      "pillars": {"pda": 20, "ease": 21, "spec": 12, "style": 9, "utility": 14},
+      "modifiers": -3,
+      "top_findings": [
+        "No MCP/UDS coverage (agent-brain-ag-mcp)",
+        "pip vs pipx/uv contradiction with installation-guide.md",
+        "Stale version metadata (7.0.0 / 3.0.0 examples)"
+      ]
+    },
+    {
+      "name": "using-agent-brain",
+      "score": 80,
+      "grade": "B",
+      "pillars": {"pda": 24, "ease": 22, "spec": 12, "style": 9, "utility": 15},
+      "modifiers": -2,
+      "top_findings": [
+        "Threshold default inconsistency (0.3 table vs 0.7 best-practice)",
+        "Stale version metadata (7.0.0)",
+        "No MCP/IDE-client note in description"
+      ]
+    }
+  ]
+}
+```


### PR DESCRIPTION
## Summary

Refreshes both Agent Brain plugin skills, which were frozen at frontmatter `version: 7.0.0` / `last_validated: 2026-03-19` and predated the MCP package + the PyPI rename. Graded both with the `improving-skills` 5-pillar rubric and fixed the top findings.

**Grades** (full report: `docs/plans/skill-grades-2026-06.md`)
| Skill | Score | Grade |
|-------|-------|-------|
| `configuring-agent-brain` | 73/100 | C |
| `using-agent-brain` | 80/100 | B |

### `configuring-agent-brain`
- Frontmatter → `10.3.0` / `2026-06-10`; added MCP setup triggers to `description`.
- **New MCP Server section**: `pip install agent-brain-ag-mcp`, client-config JSON, backend/listen-transport notes (console script stays `agent-brain-mcp`).
- Recommend **pipx/uv** — aligns SKILL.md with `references/installation-guide.md` (was bare `pip`).
- Fixed stale version examples (`3.0.0` → `10.3.0`; `7.0.0+` → `10.3.0+`).
- Completed the multi-runtime table (added `codex`, `skill-runtime`).

### `using-agent-brain`
- Frontmatter → `10.3.0` / `2026-06-10`; added MCP-client mention.
- **Reconciled the threshold contradiction**: Best Practices said "Start at 0.7" while the Mode Parameters table (and `query.py:81`) document the real default of `0.3`.

### References / script
- `version-management.md`: added 10.3.0 + 10.1.0 history rows; bumped dependency pins from the 3.x line to `>=10.0.0,<11.0.0` / `^10.0.0`.
- Dropped the **dead `DOC_SERVE_URL`** env var (not honored in any shipped package — verified) from `query_domain.py` and four reference guides → `AGENT_BRAIN_URL`.

`plugin.json` left at `10.3.0` (version owned by the release process).

## Verification
- `task before-push` — **exit 0** (544 passed, 88% coverage; YAML frontmatter lint passes).
- `grep -rn "doc-serve\|doc-svr\|DOC_SERVE" agent-brain-plugin/` → no hits.
- Every CLI/MCP command spot-checked against `agent-brain-cli/agent_brain_cli/cli.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)