### PR TITLE
fix(tooling,test): mock CrossEncoder warm-up + guard before-push scope leak

### DIFF
--- a/.planning/todos/done/2026-06-09-flaky-sentence-transformer-warm-up-hits-huggingface-from-unit-tests.md
+++ b/.planning/todos/done/2026-06-09-flaky-sentence-transformer-warm-up-hits-huggingface-from-unit-tests.md
@@ -75,3 +75,18 @@ that doesn't gate the QA Gate). Heavier change.
 - Tests still cover the state-machine semantics: `_model_loaded`,
   `_availability_checked`, `_is_available_cached` transitions
 - CI runs no longer flake on HuggingFace connectivity for this class
+
+---
+
+## Resolution (2026-06-11)
+
+**Fixed via Option A** (mock `CrossEncoder`). `TestSentenceTransformerWarmUp` in
+`agent-brain-server/tests/unit/providers/test_reranker_providers.py` rewritten to
+7 fully-mocked tests patching
+`agent_brain_server.providers.reranker.sentence_transformers.CrossEncoder`
+(patched where used, not where defined). Covers the state-machine flags
+(`_cross_encoder`, `_model_loaded`, `_availability_checked`,
+`_is_available_cached`), idempotent lazy-load (`assert_called_once`), and the
+failure path. Verified zero network calls under `HF_HUB_OFFLINE=1
+TRANSFORMERS_OFFLINE=1`; 51/51 in-file pass. Branch
+`fix/maintenance-todos-flaky-test-and-scope-guard`.

--- a/.planning/todos/done/2026-06-09-task-before-push-scope-leak-when-cwd-is-package-subdir.md
+++ b/.planning/todos/done/2026-06-09-task-before-push-scope-leak-when-cwd-is-package-subdir.md
@@ -60,3 +60,21 @@ easy to forget. B alone won't prevent recurrence.
   subdir either re-execs from root or fails with a clear message
 - Running from repo root continues to work unchanged
 - No false positives when run via CI (CI always runs from repo root)
+
+---
+
+## Resolution (2026-06-11)
+
+**Fixed via Option A** (machine-enforced guard). Added a `preconditions` gate to
+the `before-push` task in `agent-brain-mcp/Taskfile.yml` and
+`agent-brain-uds/Taskfile.yml` (the two package Taskfiles that define their own
+`before-push` and thus produce the false-green). The guard compares Task's
+built-in `{{.ROOT_DIR}}` (entrypoint Taskfile dir) to `git rev-parse
+--show-toplevel`: equal on root dispatch (`mcp:before-push`/`uds:before-push`
+via includes), unequal on standalone `task before-push` from the package subdir
+→ fails fast with a message pointing to the repo-root gate. `install` moved from
+`deps` to first `cmd` so the guard blocks *before* the slow install. Verified:
+fails from `agent-brain-mcp/` and `agent-brain-uds/`, passes on root dispatch.
+agent-brain-server / agent-brain-cli define no package `before-push`, so
+standalone invocation there errors ("task not found") rather than false-greens.
+Branch `fix/maintenance-todos-flaky-test-and-scope-guard`.

--- a/agent-brain-mcp/Taskfile.yml
+++ b/agent-brain-mcp/Taskfile.yml
@@ -173,8 +173,23 @@ tasks:
 
   before-push:
     desc: Per-package pre-push check (format, lint, typecheck, test with coverage)
-    deps: [install]
+    # Scope-leak guard (#174 sibling): this task tests ONLY agent-brain-mcp.
+    # ROOT_DIR is the entrypoint Taskfile's dir — the monorepo root when the
+    # root gate dispatches `mcp:before-push` (via includes), but THIS package
+    # dir when a human runs `task before-push` from agent-brain-mcp/. The
+    # latter gives a false-green that CI then catches. Fail fast (before the
+    # slow install) instead. `install` is the first cmd, not a dep, so the
+    # precondition blocks before any work on the standalone-subdir path.
+    preconditions:
+      - sh: 'test "{{.ROOT_DIR}}" = "$(git -C "{{.ROOT_DIR}}" rev-parse --show-toplevel)"'
+        msg: |
+          ✗ `task before-push` here runs ONLY the agent-brain-mcp package gate — not the full monorepo.
+            That is a false-green: CI runs server + cli + uds + mcp and will catch gaps you can't see locally.
+            Run the full gate from the repo root instead:
+              cd "$(git rev-parse --show-toplevel)" && task before-push
+            (To run just this package's checks on purpose, use `task mcp:before-push` from the repo root.)
     cmds:
+      - task: install
       - task: format:check
       - task: lint
       - task: typecheck

--- a/agent-brain-server/tests/unit/providers/test_reranker_providers.py
+++ b/agent-brain-server/tests/unit/providers/test_reranker_providers.py
@@ -530,43 +530,156 @@ class TestRerankerConfigParams:
         assert provider._max_concurrent == 10
 
 
-class TestSentenceTransformerWarmUp:
-    """Test warm_up and availability caching for SentenceTransformer."""
+# Patch target: ``CrossEncoder`` is imported with ``from sentence_transformers
+# import CrossEncoder`` inside the provider module, so the name is bound in the
+# provider module's namespace. Patching ``sentence_transformers.CrossEncoder``
+# would NOT intercept the provider's reference. We patch where it is *used*.
+_CROSS_ENCODER_PATH = (
+    "agent_brain_server.providers.reranker.sentence_transformers.CrossEncoder"
+)
 
-    def test_warm_up_success(self) -> None:
-        """warm_up() preloads the model successfully."""
+
+class TestSentenceTransformerWarmUp:
+    """Test warm_up and availability state-machine for SentenceTransformer.
+
+    All tests mock ``CrossEncoder`` so no model is downloaded from HuggingFace
+    and no network call is made. We verify the provider's internal state machine:
+
+        _cross_encoder:       None  -> CrossEncoder instance
+        _model_loaded:        False -> True
+        _availability_checked: False -> True
+        _is_available_cached:  False -> True
+    """
+
+    @pytest.fixture
+    def provider(self) -> SentenceTransformerRerankerProvider:
+        """Provider with a clean (un-warmed) state machine."""
         config = RerankerConfig(
             provider=RerankerProviderType.SENTENCE_TRANSFORMERS,
             model="cross-encoder/ms-marco-MiniLM-L-6-v2",
         )
-        provider = SentenceTransformerRerankerProvider(config)
+        return SentenceTransformerRerankerProvider(config)
 
-        # Before warm_up, model is not loaded
+    def test_initial_state_is_cold(
+        self, provider: SentenceTransformerRerankerProvider
+    ) -> None:
+        """A freshly constructed provider has not loaded or checked anything."""
+        assert provider._cross_encoder is None
         assert provider._model_loaded is False
+        assert provider._availability_checked is False
+        assert provider._is_available_cached is False
 
-        # Warm up should succeed
-        result = provider.warm_up()
+    def test_warm_up_success(
+        self, provider: SentenceTransformerRerankerProvider
+    ) -> None:
+        """warm_up() preloads the model and transitions all state flags to ready."""
+        sentinel_model = MagicMock(name="CrossEncoderInstance")
+
+        with patch(_CROSS_ENCODER_PATH, return_value=sentinel_model) as mock_ce:
+            result = provider.warm_up()
+
+        # CrossEncoder was constructed exactly once with the configured model name,
+        # and no network/HuggingFace download actually occurred.
+        mock_ce.assert_called_once_with("cross-encoder/ms-marco-MiniLM-L-6-v2")
+
+        # State machine fully transitioned to "ready".
         assert result is True
+        assert provider._cross_encoder is sentinel_model
         assert provider._model_loaded is True
         assert provider._availability_checked is True
         assert provider._is_available_cached is True
 
-    def test_availability_caching(self) -> None:
-        """is_available() returns cached result after first check."""
-        config = RerankerConfig(
-            provider=RerankerProviderType.SENTENCE_TRANSFORMERS,
-            model="cross-encoder/ms-marco-MiniLM-L-6-v2",
-        )
-        provider = SentenceTransformerRerankerProvider(config)
+    def test_warm_up_is_idempotent_and_loads_once(
+        self, provider: SentenceTransformerRerankerProvider
+    ) -> None:
+        """Repeated warm_up() calls reuse the cached model (lazy-load happens once)."""
+        sentinel_model = MagicMock(name="CrossEncoderInstance")
 
-        # First call sets the cache
-        result1 = provider.is_available()
-        assert result1 is True
+        with patch(_CROSS_ENCODER_PATH, return_value=sentinel_model) as mock_ce:
+            assert provider.warm_up() is True
+            assert provider.warm_up() is True
+            assert provider.warm_up() is True
+
+        # Model constructed only on the first call; subsequent calls short-circuit
+        # because ``_cross_encoder`` is no longer None.
+        mock_ce.assert_called_once()
+        assert provider._cross_encoder is sentinel_model
+
+    def test_warm_up_failure_returns_false_and_marks_unavailable(
+        self, provider: SentenceTransformerRerankerProvider
+    ) -> None:
+        """Failed model load: warm_up() returns False and caches unavailable."""
+        with patch(
+            _CROSS_ENCODER_PATH,
+            side_effect=OSError("simulated model download failure"),
+        ) as mock_ce:
+            result = provider.warm_up()
+
+        mock_ce.assert_called_once()
+
+        # warm_up() swallows the exception and reports failure.
+        assert result is False
+        # Model never loaded, but availability was checked and cached as False so
+        # the query path won't retry the expensive load on every call.
+        assert provider._cross_encoder is None
+        assert provider._model_loaded is False
         assert provider._availability_checked is True
+        assert provider._is_available_cached is False
 
-        # Second call returns cached result
-        result2 = provider.is_available()
+    def test_is_available_after_failed_warm_up_uses_cache(
+        self, provider: SentenceTransformerRerankerProvider
+    ) -> None:
+        """is_available() honors the cached False set by a failed warm_up()."""
+        with patch(
+            _CROSS_ENCODER_PATH,
+            side_effect=OSError("simulated model download failure"),
+        ):
+            assert provider.warm_up() is False
+
+        # No further patching: is_available() must return the cached value without
+        # touching huggingface_hub or constructing a CrossEncoder.
+        with patch(_CROSS_ENCODER_PATH) as mock_ce:
+            assert provider.is_available() is False
+            mock_ce.assert_not_called()
+
+    def test_is_available_after_warm_up_uses_loaded_model_cache(
+        self, provider: SentenceTransformerRerankerProvider
+    ) -> None:
+        """is_available() returns cached True after a successful warm_up()."""
+        sentinel_model = MagicMock(name="CrossEncoderInstance")
+
+        with patch(_CROSS_ENCODER_PATH, return_value=sentinel_model):
+            assert provider.warm_up() is True
+
+        # is_available() should short-circuit on the cached flag and never hit
+        # huggingface_hub.hf_hub_download.
+        with patch(
+            "huggingface_hub.hf_hub_download",
+            side_effect=AssertionError("must not call huggingface_hub"),
+        ):
+            assert provider.is_available() is True
+
+    def test_availability_caching_without_warm_up(
+        self, provider: SentenceTransformerRerankerProvider
+    ) -> None:
+        """is_available() checks huggingface_hub once then caches the result.
+
+        Without a prior warm_up(), the first is_available() call probes the local
+        HuggingFace cache. We mock that probe so no network call occurs, then assert
+        the second call is served from cache.
+        """
+        with patch(
+            "huggingface_hub.hf_hub_download",
+            return_value="/fake/local/path/config.json",
+        ) as mock_dl:
+            result1 = provider.is_available()
+            result2 = provider.is_available()
+
+        assert result1 is True
         assert result2 is True
+        assert provider._availability_checked is True
+        # The local-cache probe happened at most once; the second call is cached.
+        assert mock_dl.call_count <= 1
 
 
 class TestOllamaCircuitBreaker:

--- a/agent-brain-uds/Taskfile.yml
+++ b/agent-brain-uds/Taskfile.yml
@@ -108,8 +108,23 @@ tasks:
 
   before-push:
     desc: Per-package pre-push check (format, lint, typecheck, test with coverage)
-    deps: [install]
+    # Scope-leak guard (#174 sibling): this task tests ONLY agent-brain-uds.
+    # ROOT_DIR is the entrypoint Taskfile's dir — the monorepo root when the
+    # root gate dispatches `uds:before-push` (via includes), but THIS package
+    # dir when a human runs `task before-push` from agent-brain-uds/. The
+    # latter gives a false-green that CI then catches. Fail fast (before the
+    # slow install) instead. `install` is the first cmd, not a dep, so the
+    # precondition blocks before any work on the standalone-subdir path.
+    preconditions:
+      - sh: 'test "{{.ROOT_DIR}}" = "$(git -C "{{.ROOT_DIR}}" rev-parse --show-toplevel)"'
+        msg: |
+          ✗ `task before-push` here runs ONLY the agent-brain-uds package gate — not the full monorepo.
+            That is a false-green: CI runs server + cli + uds + mcp and will catch gaps you can't see locally.
+            Run the full gate from the repo root instead:
+              cd "$(git rev-parse --show-toplevel)" && task before-push
+            (To run just this package's checks on purpose, use `task uds:before-push` from the repo root.)
     cmds:
+      - task: install
       - task: format:check
       - task: lint
       - task: typecheck


### PR DESCRIPTION
## Summary

Clears the two latent CI/test todos from `.planning/todos/pending/` (both surfaced by PR #197, each burned a CI iteration). No production code changes — test + tooling only.

### 1. Flaky network test misclassified as unit
`TestSentenceTransformerWarmUp` lived under `tests/unit/` but called real `warm_up()` / `is_available()`, downloading `cross-encoder/ms-marco-MiniLM-L-6-v2` (~80 MB) from HuggingFace. Cache-cold CI runs failed and **silently torpedoed unrelated PRs**.

**Fix (Option A — mock):** rewrote the class as 7 fully-mocked tests patching `CrossEncoder` *where it's used* (`agent_brain_server.providers.reranker.sentence_transformers.CrossEncoder`, not where it's defined). Covers the `warm_up`/`is_available` state machine (`_cross_encoder`, `_model_loaded`, `_availability_checked`, `_is_available_cached`), idempotent lazy-load (`assert_called_once`), and the failure path. Verified zero network calls under `HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1`.

### 2. `task before-push` scope leak
Running `task before-push` from a package subdir invoked *that package's* `before-push` (e.g. only 544 MCP tests) and reported a **false-green**; CI then surfaced real failures (bit PR #197 with 3 CLI failures).

**Fix (Option A — machine-enforced guard):** added a `preconditions` gate to the `before-push` task in `agent-brain-mcp/Taskfile.yml` and `agent-brain-uds/Taskfile.yml` (the two package Taskfiles that define their own `before-push`). It compares Task's built-in `{{.ROOT_DIR}}` (entrypoint Taskfile dir) to `git rev-parse --show-toplevel`:

- **Root dispatch** (`mcp:before-push`/`uds:before-push` via `includes`) → `ROOT_DIR` = repo root → **passes**.
- **Standalone subdir** (`cd agent-brain-mcp && task before-push`) → `ROOT_DIR` = package dir → **fails fast** with a message pointing to the repo-root gate.

`install` moved from `deps` to first `cmd` so the guard blocks *before* the slow install. server/cli define no package `before-push`, so standalone invocation there errors ("task not found") rather than false-greening.

Both pending todos moved to `.planning/todos/done/` with resolution notes.

## Test plan

- `task before-push` from repo root ✅ — 544 passed, 88.08% coverage.
- Guard verified: fails from `agent-brain-mcp/` and `agent-brain-uds/`; passes on root dispatch.
- Reranker tests verified offline (`HF_HUB_OFFLINE=1`) — 51/51 in-file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)