### PR TITLE
feat(cli): install-agent --with-mcp registers the MCP server + skill coverage

### DIFF
--- a/agent-brain-cli/agent_brain_cli/commands/install_agent.py
+++ b/agent-brain-cli/agent_brain_cli/commands/install_agent.py
@@ -11,6 +11,7 @@ from rich.panel import Panel
 from agent_brain_cli.runtime.claude_converter import ClaudeConverter
 from agent_brain_cli.runtime.codex_converter import CodexConverter
 from agent_brain_cli.runtime.gemini_converter import GeminiConverter
+from agent_brain_cli.runtime.mcp_registration import register_claude_mcp
 from agent_brain_cli.runtime.opencode_converter import OpenCodeConverter
 from agent_brain_cli.runtime.parser import parse_plugin_dir
 from agent_brain_cli.runtime.skill_runtime_converter import SkillRuntimeConverter
@@ -96,6 +97,55 @@ def _resolve_target_dir(
 
 RUNTIME_CHOICES = ["claude", "opencode", "gemini", "skill-runtime", "codex"]
 
+# Runtimes for which we can auto-register the MCP server today.
+MCP_SUPPORTED_RUNTIMES = {"claude"}
+
+
+def _resolve_mcp_paths(scope: str, project_root: Path | None) -> tuple[Path, Path]:
+    """Return (config_path, state_dir) for MCP registration.
+
+    Project scope writes the project-level ``.mcp.json`` Claude Code reads from
+    the project root; global scope targets the user-level ``~/.claude.json``.
+    """
+    if scope == "global":
+        return Path.home() / ".claude.json", Path.home() / ".agent-brain"
+    root = project_root if project_root is not None else Path.cwd()
+    return root / ".mcp.json", root / ".agent-brain"
+
+
+def _register_mcp(
+    agent: str,
+    scope: str,
+    project_root: Path | None,
+    mcp_auth: str,
+    mcp_backend: str,
+    dry_run: bool,
+) -> dict[str, Any]:
+    """Register the MCP server for supported runtimes; report what happened."""
+    if agent not in MCP_SUPPORTED_RUNTIMES:
+        return {
+            "skipped": True,
+            "reason": (
+                f"MCP auto-registration is currently supported only for "
+                f"{', '.join(sorted(MCP_SUPPORTED_RUNTIMES))}; configure "
+                f"{agent} manually (see the configuring-agent-brain skill)."
+            ),
+        }
+    config_path, state_dir = _resolve_mcp_paths(scope, project_root)
+    result = register_claude_mcp(
+        config_path,
+        state_dir,
+        backend=mcp_backend,
+        auth=mcp_auth,
+        dry_run=dry_run,
+    )
+    return {
+        "skipped": False,
+        "action": result.action,
+        "path": str(result.path),
+        "server_name": result.server_name,
+    }
+
 
 @click.command("install-agent")
 @click.option(
@@ -146,6 +196,23 @@ RUNTIME_CHOICES = ["claude", "opencode", "gemini", "skill-runtime", "codex"]
     type=click.Path(exists=True, file_okay=False, resolve_path=True),
     help="Project path for --project scope (default: cwd)",
 )
+@click.option(
+    "--with-mcp",
+    is_flag=True,
+    help="Also register the agent-brain MCP server (Claude Code .mcp.json)",
+)
+@click.option(
+    "--mcp-auth",
+    type=click.Choice(["none", "oauth"]),
+    default="none",
+    help="MCP client auth mode written into the registration (default: none)",
+)
+@click.option(
+    "--mcp-backend",
+    type=click.Choice(["auto", "uds", "http"]),
+    default="auto",
+    help="How the MCP server reaches agent-brain-serve (default: auto)",
+)
 def install_agent_command(
     agent: str,
     scope: str,
@@ -154,6 +221,9 @@ def install_agent_command(
     dry_run: bool,
     json_output: bool,
     path: str | None,
+    with_mcp: bool,
+    mcp_auth: str,
+    mcp_backend: str,
 ) -> None:
     """Install Agent Brain plugin for a specific runtime.
 
@@ -220,6 +290,12 @@ def install_agent_command(
         converter = converter_cls()
         scope_enum = Scope.GLOBAL if scope == "global" else Scope.PROJECT
 
+        mcp_summary: dict[str, Any] | None = None
+        if with_mcp:
+            mcp_summary = _register_mcp(
+                agent, scope, project_root, mcp_auth, mcp_backend, dry_run
+            )
+
         if dry_run:
             _handle_dry_run(
                 converter,
@@ -229,6 +305,7 @@ def install_agent_command(
                 agent,
                 scope,
                 json_output,
+                mcp_summary,
             )
             return
 
@@ -250,6 +327,8 @@ def install_agent_command(
                 "files_created": len(files),
                 "source_dir": str(source),
             }
+            if mcp_summary is not None:
+                result["mcp_registration"] = mcp_summary
             click.echo(json.dumps(result, indent=2))
         else:
             console.print(
@@ -263,6 +342,7 @@ def install_agent_command(
                     border_style="green",
                 )
             )
+            _print_mcp_summary(mcp_summary)
 
     except SystemExit:
         raise
@@ -288,6 +368,7 @@ def _handle_dry_run(
     agent: str,
     scope: str,
     json_output: bool,
+    mcp_summary: dict[str, Any] | None = None,
 ) -> None:
     """Handle dry-run mode: simulate install in temp dir."""
     import tempfile
@@ -311,19 +392,17 @@ def _handle_dry_run(
                 planned.append(f)
 
     if json_output:
-        click.echo(
-            json.dumps(
-                {
-                    "dry_run": True,
-                    "agent": agent,
-                    "scope": scope,
-                    "target_dir": str(target),
-                    "files": [str(f) for f in planned],
-                    "file_count": len(planned),
-                },
-                indent=2,
-            )
-        )
+        payload: dict[str, Any] = {
+            "dry_run": True,
+            "agent": agent,
+            "scope": scope,
+            "target_dir": str(target),
+            "files": [str(f) for f in planned],
+            "file_count": len(planned),
+        }
+        if mcp_summary is not None:
+            payload["mcp_registration"] = mcp_summary
+        click.echo(json.dumps(payload, indent=2))
     else:
         console.print(
             Panel(
@@ -338,3 +417,17 @@ def _handle_dry_run(
         )
         for f in planned:
             console.print(f"  [dim]{f}[/]")
+        _print_mcp_summary(mcp_summary)
+
+
+def _print_mcp_summary(mcp_summary: dict[str, Any] | None) -> None:
+    """Render the MCP registration outcome for human-readable output."""
+    if mcp_summary is None:
+        return
+    if mcp_summary.get("skipped"):
+        console.print(f"[yellow]MCP:[/] {mcp_summary['reason']}")
+        return
+    console.print(
+        f"[green]MCP server registered[/] ([bold]{mcp_summary['action']}[/]) "
+        f"→ {mcp_summary['path']}"
+    )

--- a/agent-brain-cli/agent_brain_cli/runtime/mcp_registration.py
+++ b/agent-brain-cli/agent_brain_cli/runtime/mcp_registration.py
@@ -1,0 +1,123 @@
+"""Register the Agent Brain MCP server into a Claude Code config file.
+
+Claude Code discovers MCP servers from a JSON config with an ``mcpServers``
+object — a project-level ``.mcp.json`` at the project root, or the user-level
+``~/.claude.json`` for global scope. This module writes/merges the
+``agent-brain`` entry into that file without disturbing other servers or keys.
+
+It deliberately does NOT shell out to ``claude mcp add``: the file-based path is
+dependency-free (no ``claude`` CLI required), deterministic, dry-run friendly,
+and matches the file-writing pattern the rest of ``install-agent`` already uses.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+MCP_SERVER_NAME = "agent-brain"
+MCP_COMMAND = "agent-brain-mcp"
+
+
+def build_mcp_server_entry(
+    state_dir: Path,
+    backend: str = "auto",
+    auth: str = "none",
+) -> dict[str, Any]:
+    """Build the ``mcpServers`` entry for the Agent Brain MCP server.
+
+    Args:
+        state_dir: The ``.agent-brain`` state directory the MCP server should
+            use. Resolved to an absolute path — MCP clients launch the server
+            from an unknown cwd, so a relative path would break discovery.
+        backend: How the MCP server reaches ``agent-brain-serve``
+            (``auto`` | ``uds`` | ``http``).
+        auth: ``none`` (default) or ``oauth``. ``oauth`` injects
+            ``AGENT_BRAIN_MCP_AUTH=oauth`` to opt the client into the OAuth dance.
+
+    Returns:
+        A dict suitable for ``mcpServers[<name>]``.
+    """
+    env: dict[str, str] = {
+        "AGENT_BRAIN_STATE_DIR": str(state_dir.expanduser().resolve())
+    }
+    if auth == "oauth":
+        env["AGENT_BRAIN_MCP_AUTH"] = "oauth"
+    return {
+        "command": MCP_COMMAND,
+        "args": ["--backend", backend],
+        "env": env,
+    }
+
+
+@dataclass
+class McpRegistrationResult:
+    """Outcome of an MCP registration attempt."""
+
+    path: Path
+    action: str  # "created" | "updated" | "unchanged"
+    server_name: str
+    entry: dict[str, Any]
+
+
+def register_claude_mcp(
+    config_path: Path,
+    state_dir: Path,
+    *,
+    backend: str = "auto",
+    auth: str = "none",
+    dry_run: bool = False,
+) -> McpRegistrationResult:
+    """Merge the Agent Brain MCP entry into a Claude Code config file.
+
+    Args:
+        config_path: Path to ``.mcp.json`` (project) or ``~/.claude.json`` (global).
+        state_dir: The ``.agent-brain`` state directory for the server.
+        backend: MCP backend selector passed to the server.
+        auth: ``none`` or ``oauth``.
+        dry_run: When True, compute the action but write nothing.
+
+    Returns:
+        An :class:`McpRegistrationResult` describing what (would have) changed.
+
+    Raises:
+        ValueError: If an existing config file is not valid JSON.
+    """
+    entry = build_mcp_server_entry(state_dir, backend=backend, auth=auth)
+
+    data: dict[str, Any]
+    file_existed = config_path.exists()
+    if file_existed:
+        try:
+            data = json.loads(config_path.read_text())
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"Existing {config_path.name} is not valid JSON: {exc}. "
+                "Fix or remove it, then re-run."
+            ) from exc
+    else:
+        data = {}
+
+    servers = data.setdefault("mcpServers", {})
+    existing = servers.get(MCP_SERVER_NAME)
+
+    if existing == entry:
+        action = "unchanged"
+    elif not file_existed:
+        action = "created"
+    else:
+        action = "updated"
+
+    if action != "unchanged" and not dry_run:
+        servers[MCP_SERVER_NAME] = entry
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(data, indent=2) + "\n")
+
+    return McpRegistrationResult(
+        path=config_path,
+        action=action,
+        server_name=MCP_SERVER_NAME,
+        entry=entry,
+    )

--- a/agent-brain-cli/tests/test_install_agent_mcp.py
+++ b/agent-brain-cli/tests/test_install_agent_mcp.py
@@ -1,0 +1,118 @@
+"""Tests for `install-agent --with-mcp` MCP registration wiring."""
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from agent_brain_cli.commands.install_agent import install_agent_command
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def plugin_dir(tmp_path: Path) -> Path:
+    """Minimal canonical plugin directory (mirrors test_install_agent)."""
+    root = tmp_path / "plugin"
+    (root / ".claude-plugin").mkdir(parents=True)
+    (root / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "agent-brain", "version": "1.0.0"})
+    )
+    cmds = root / "commands"
+    cmds.mkdir()
+    (cmds / "agent-brain-search.md").write_text(
+        "---\nname: agent-brain-search\n"
+        "description: Search docs\nparameters: []\nskills: []\n"
+        "---\nSearch body."
+    )
+    return root
+
+
+def _install(runner: CliRunner, plugin_dir: Path, project: Path, *extra: str):
+    return runner.invoke(
+        install_agent_command,
+        [
+            "--agent",
+            "claude",
+            "--plugin-dir",
+            str(plugin_dir),
+            "--path",
+            str(project),
+            *extra,
+        ],
+    )
+
+
+class TestInstallAgentWithMcp:
+    def test_default_does_not_register_mcp(
+        self, runner: CliRunner, plugin_dir: Path, tmp_path: Path
+    ) -> None:
+        result = _install(runner, plugin_dir, tmp_path)
+        assert result.exit_code == 0
+        assert not (tmp_path / ".mcp.json").exists()
+
+    def test_with_mcp_writes_project_mcp_json(
+        self, runner: CliRunner, plugin_dir: Path, tmp_path: Path
+    ) -> None:
+        result = _install(runner, plugin_dir, tmp_path, "--with-mcp")
+        assert result.exit_code == 0
+        config = tmp_path / ".mcp.json"
+        assert config.exists()
+        data = json.loads(config.read_text())
+        entry = data["mcpServers"]["agent-brain"]
+        assert entry["command"] == "agent-brain-mcp"
+        # State dir points at the project's .agent-brain (absolute).
+        state_dir = Path(entry["env"]["AGENT_BRAIN_STATE_DIR"])
+        assert state_dir.is_absolute()
+        assert state_dir.name == ".agent-brain"
+
+    def test_with_mcp_dry_run_writes_nothing(
+        self, runner: CliRunner, plugin_dir: Path, tmp_path: Path
+    ) -> None:
+        result = _install(runner, plugin_dir, tmp_path, "--with-mcp", "--dry-run")
+        assert result.exit_code == 0
+        assert not (tmp_path / ".mcp.json").exists()
+
+    def test_with_mcp_oauth_injects_client_auth(
+        self, runner: CliRunner, plugin_dir: Path, tmp_path: Path
+    ) -> None:
+        result = _install(
+            runner, plugin_dir, tmp_path, "--with-mcp", "--mcp-auth", "oauth"
+        )
+        assert result.exit_code == 0
+        data = json.loads((tmp_path / ".mcp.json").read_text())
+        env = data["mcpServers"]["agent-brain"]["env"]
+        assert env["AGENT_BRAIN_MCP_AUTH"] == "oauth"
+
+    def test_with_mcp_json_output_reports_registration(
+        self, runner: CliRunner, plugin_dir: Path, tmp_path: Path
+    ) -> None:
+        result = _install(runner, plugin_dir, tmp_path, "--with-mcp", "--json")
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["mcp_registration"]["action"] == "created"
+        assert payload["mcp_registration"]["server_name"] == "agent-brain"
+
+    def test_with_mcp_unsupported_runtime_warns_but_succeeds(
+        self, runner: CliRunner, plugin_dir: Path, tmp_path: Path
+    ) -> None:
+        result = runner.invoke(
+            install_agent_command,
+            [
+                "--agent",
+                "opencode",
+                "--plugin-dir",
+                str(plugin_dir),
+                "--path",
+                str(tmp_path),
+                "--with-mcp",
+            ],
+        )
+        # Non-fatal: install still succeeds, but no .mcp.json and a clear note.
+        assert result.exit_code == 0
+        assert not (tmp_path / ".mcp.json").exists()
+        assert "mcp" in result.output.lower()

--- a/agent-brain-cli/tests/test_mcp_registration.py
+++ b/agent-brain-cli/tests/test_mcp_registration.py
@@ -1,0 +1,100 @@
+"""Tests for MCP server registration into a Claude Code config (`.mcp.json`)."""
+
+import json
+from pathlib import Path
+
+from agent_brain_cli.runtime.mcp_registration import (
+    build_mcp_server_entry,
+    register_claude_mcp,
+)
+
+
+class TestBuildMcpServerEntry:
+    """Unit tests for the server-entry builder."""
+
+    def test_default_entry_shape(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / ".agent-brain"
+        entry = build_mcp_server_entry(state_dir)
+        assert entry["command"] == "agent-brain-mcp"
+        assert entry["args"] == ["--backend", "auto"]
+        assert entry["env"]["AGENT_BRAIN_STATE_DIR"] == str(state_dir)
+        # No-auth default must not inject the client auth toggle.
+        assert "AGENT_BRAIN_MCP_AUTH" not in entry["env"]
+
+    def test_backend_override(self, tmp_path: Path) -> None:
+        entry = build_mcp_server_entry(tmp_path / ".agent-brain", backend="uds")
+        assert entry["args"] == ["--backend", "uds"]
+
+    def test_oauth_injects_client_auth_env(self, tmp_path: Path) -> None:
+        entry = build_mcp_server_entry(tmp_path / ".agent-brain", auth="oauth")
+        assert entry["env"]["AGENT_BRAIN_MCP_AUTH"] == "oauth"
+
+    def test_state_dir_is_absolute(self, tmp_path: Path) -> None:
+        # A relative state dir should be resolved to absolute (MCP clients run
+        # from an unknown cwd, so a relative path would break discovery).
+        entry = build_mcp_server_entry(Path(".agent-brain"))
+        assert Path(entry["env"]["AGENT_BRAIN_STATE_DIR"]).is_absolute()
+
+
+class TestRegisterClaudeMcp:
+    """Unit tests for merging the entry into a `.mcp.json` file."""
+
+    def test_creates_new_config_file(self, tmp_path: Path) -> None:
+        config = tmp_path / ".mcp.json"
+        state_dir = tmp_path / ".agent-brain"
+        result = register_claude_mcp(config, state_dir)
+        assert result.action == "created"
+        assert config.exists()
+        data = json.loads(config.read_text())
+        assert data["mcpServers"]["agent-brain"]["command"] == "agent-brain-mcp"
+
+    def test_preserves_other_servers_and_keys(self, tmp_path: Path) -> None:
+        config = tmp_path / ".mcp.json"
+        config.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {"other": {"command": "other-mcp"}},
+                    "unrelated": {"keep": True},
+                }
+            )
+        )
+        result = register_claude_mcp(config, tmp_path / ".agent-brain")
+        assert result.action == "updated"
+        data = json.loads(config.read_text())
+        # Existing server and unrelated top-level keys are preserved.
+        assert data["mcpServers"]["other"] == {"command": "other-mcp"}
+        assert data["unrelated"] == {"keep": True}
+        assert "agent-brain" in data["mcpServers"]
+
+    def test_idempotent_when_entry_identical(self, tmp_path: Path) -> None:
+        config = tmp_path / ".mcp.json"
+        state_dir = tmp_path / ".agent-brain"
+        first = register_claude_mcp(config, state_dir)
+        assert first.action == "created"
+        second = register_claude_mcp(config, state_dir)
+        assert second.action == "unchanged"
+
+    def test_updates_when_entry_differs(self, tmp_path: Path) -> None:
+        config = tmp_path / ".mcp.json"
+        state_dir = tmp_path / ".agent-brain"
+        register_claude_mcp(config, state_dir, backend="auto")
+        result = register_claude_mcp(config, state_dir, backend="uds")
+        assert result.action == "updated"
+        data = json.loads(config.read_text())
+        assert data["mcpServers"]["agent-brain"]["args"] == ["--backend", "uds"]
+
+    def test_dry_run_does_not_write(self, tmp_path: Path) -> None:
+        config = tmp_path / ".mcp.json"
+        result = register_claude_mcp(config, tmp_path / ".agent-brain", dry_run=True)
+        assert result.action == "created"
+        assert not config.exists()
+
+    def test_corrupt_existing_config_raises_clear_error(self, tmp_path: Path) -> None:
+        config = tmp_path / ".mcp.json"
+        config.write_text("{not valid json")
+        try:
+            register_claude_mcp(config, tmp_path / ".agent-brain")
+        except ValueError as exc:
+            assert ".mcp.json" in str(exc)
+        else:  # pragma: no cover - explicit failure path
+            raise AssertionError("expected ValueError for corrupt config")

--- a/agent-brain-plugin/commands/agent-brain-install-agent.md
+++ b/agent-brain-plugin/commands/agent-brain-install-agent.md
@@ -24,9 +24,20 @@ parameters:
   - name: path
     description: "Project path for --project scope (default: cwd)"
     required: false
+  - name: with-mcp
+    description: Also register the agent-brain MCP server (Claude Code .mcp.json)
+    required: false
+  - name: mcp-auth
+    description: "MCP client auth mode to record: none (default) or oauth"
+    required: false
+    default: none
+  - name: mcp-backend
+    description: "How the MCP server reaches agent-brain-serve: auto (default), uds, or http"
+    required: false
+    default: auto
 skills:
   - configuring-agent-brain
-last_validated: 2026-03-16
+last_validated: 2026-06-24
 ---
 
 # Agent Brain Install Agent
@@ -130,6 +141,37 @@ agent-brain install-agent --agent claude --json
 ```bash
 agent-brain install-agent --agent opencode --plugin-dir ./my-custom-plugin
 ```
+
+### Register the MCP server (Claude Code)
+
+Add `--with-mcp` to also register the `agent-brain` MCP server while installing. It
+writes/merges an `agent-brain` entry into the project-level `.mcp.json` (or `~/.claude.json`
+with `--global`), preserving any other servers and keys, and pins an absolute
+`AGENT_BRAIN_STATE_DIR`. It is idempotent and honors `--dry-run`.
+
+```bash
+# Install plugin + register MCP for Claude Code
+agent-brain install-agent --agent claude --with-mcp
+
+# Preview only
+agent-brain install-agent --agent claude --with-mcp --dry-run
+
+# Record client-side OAuth (for a remote, OAuth-protected server)
+agent-brain install-agent --agent claude --with-mcp --mcp-auth oauth
+
+# Force a specific backend
+agent-brain install-agent --agent claude --with-mcp --mcp-backend uds
+```
+
+| Flag | Values | Default | Purpose |
+|------|--------|---------|---------|
+| `--with-mcp` | — | off | Register the MCP server during install |
+| `--mcp-backend` | `auto`/`uds`/`http` | `auto` | How the MCP server reaches `agent-brain-serve` |
+| `--mcp-auth` | `none`/`oauth` | `none` | Write `AGENT_BRAIN_MCP_AUTH=oauth` for remote OAuth servers |
+
+> Auto-registration currently targets **Claude Code**. For OpenCode / Gemini / Codex,
+> `--with-mcp` prints a note and skips (register manually — see the MCP Setup Guide in the
+> `configuring-agent-brain` skill).
 
 ## Output
 

--- a/agent-brain-plugin/commands/agent-brain-setup.md
+++ b/agent-brain-plugin/commands/agent-brain-setup.md
@@ -6,7 +6,7 @@ context: fork
 agent: setup-assistant
 skills:
   - configuring-agent-brain
-last_validated: 2026-03-16
+last_validated: 2026-06-24
 ---
 
 # Complete Agent Brain Setup
@@ -445,6 +445,26 @@ agent-brain status
 ```
 
 Confirm server is healthy and ready.
+
+### Step 13: Register MCP Server (Optional)
+
+If the user wants MCP-aware clients (Claude Code, Claude Desktop, Cursor, Windsurf) to reach
+this corpus, offer to install and register the MCP server. Ask first; this is opt-in.
+
+```bash
+# Install the MCP package (if not already present)
+pip install agent-brain-ag-mcp
+
+# Register for Claude Code (writes/merges project .mcp.json, idempotent)
+agent-brain install-agent --agent claude --with-mcp
+
+# Preview without writing
+agent-brain install-agent --agent claude --with-mcp --dry-run
+```
+
+For a remote, OAuth-protected server, add `--mcp-auth oauth`. For other runtimes, register
+manually (see the **MCP Setup Guide** in the `configuring-agent-brain` skill). Auth is off by
+default for local use.
 
 ## Output
 

--- a/agent-brain-plugin/skills/configuring-agent-brain/SKILL.md
+++ b/agent-brain-plugin/skills/configuring-agent-brain/SKILL.md
@@ -14,10 +14,10 @@ allowed-tools:
   - Bash
   - Read
 metadata:
-  version: 10.3.0
+  version: 10.4.0
   category: ai-tools
   author: Spillwave
-  last_validated: 2026-06-10
+  last_validated: 2026-06-24
 ---
 
 # Configuring Agent Brain
@@ -271,7 +271,39 @@ pip install agent-brain-ag-mcp
 > v10.1.2 — the original name hit PyPI's typosquatting filter), but the installed console
 > script is still `agent-brain-mcp` and the import path is still `agent_brain_mcp`.
 
-### Configure an MCP client
+### Register through the plugin (recommended for Claude Code)
+
+`install-agent` can register the MCP server for you while installing the plugin —
+no hand-editing of `.mcp.json`:
+
+```bash
+# Install the plugin AND register the agent-brain MCP server for Claude Code
+agent-brain install-agent --agent claude --with-mcp
+
+# Preview without writing anything
+agent-brain install-agent --agent claude --with-mcp --dry-run
+
+# Register with client-side OAuth enabled (for a remote, OAuth-protected server)
+agent-brain install-agent --agent claude --with-mcp --mcp-auth oauth
+```
+
+What `--with-mcp` does:
+- Writes/merges an `agent-brain` entry into the project-level `.mcp.json`
+  (or `~/.claude.json` with `--global`), **preserving any other MCP servers and keys**.
+- Pins `AGENT_BRAIN_STATE_DIR` to the project's absolute `.agent-brain` path so the
+  server is discoverable regardless of the client's working directory.
+- Is **idempotent** — re-running reports `unchanged` when the entry already matches.
+
+| Flag | Values | Default | Purpose |
+|------|--------|---------|---------|
+| `--with-mcp` | — | off | Register the MCP server during install |
+| `--mcp-backend` | `auto`/`uds`/`http` | `auto` | How the MCP server reaches `agent-brain-serve` |
+| `--mcp-auth` | `none`/`oauth` | `none` | Write `AGENT_BRAIN_MCP_AUTH=oauth` for remote OAuth servers |
+
+> Auto-registration currently targets **Claude Code**. For OpenCode / Gemini / Codex,
+> register manually with the JSON block below (the flag will print a note and skip).
+
+### Configure an MCP client (manual)
 
 Add the server to your client's MCP config (Claude Desktop / Cursor / Windsurf use the
 same `mcpServers` shape):
@@ -293,7 +325,24 @@ same `mcpServers` shape):
   the MCP *listen* transport.
 - **stdio** is the default listen transport (no flag). For IDE/framework clients that
   prefer HTTP, use `agent-brain-mcp --transport http --host 127.0.0.1 --port 8765`
-  (loopback only — public binds are rejected; auth is deferred to MCP v4).
+  (loopback only — public binds are rejected).
+
+### OAuth 2.1 for remote servers (shipped in v10.4)
+
+For a **local/loopback** server you need no auth — leave the defaults. To run Agent Brain
+remotely (CI box, shared dev server, hosted), the MCP server supports **OAuth 2.1** on the
+Streamable HTTP transport. Auth is **off by default**; opt in with env vars:
+
+| Variable | Side | Values | Notes |
+|----------|------|--------|-------|
+| `AGENT_BRAIN_AUTH` | server | `none` (default) / `basic` / `oauth` | Server-side auth mode |
+| `AGENT_BRAIN_OAUTH_RESOURCE` | server | absolute URI (scheme, no fragment) | Required **only** when `AGENT_BRAIN_AUTH=oauth` (RFC 8707 resource id) |
+| `AGENT_BRAIN_MCP_AUTH` | client | unset (off) / `oauth` | Opts the MCP client into the OAuth dance |
+
+The client side persists tokens at `<state_dir>/mcp-oauth-tokens.json` (chmod `0o600`) and
+refreshes silently. `install-agent --with-mcp --mcp-auth oauth` writes the client toggle for
+you. Per-tool scopes (`agent-brain:read|index|admin|subscribe`) enforce least privilege, with
+default-deny on the mutating tools.
 
 ### Verify
 
@@ -305,8 +354,9 @@ agent-brain-mcp --help
 agent-brain --transport mcp resources list
 ```
 
-The v1 surface is 7 tools, 5 `corpus://` resources, and 6 prompts. See the MCP package
-README and `docs/MCP_USER_GUIDE.md` for the full reference.
+The current surface is **16 tools**, 5 `corpus://` resources, and 6 prompts. See the MCP
+package README, `docs/MCP_USER_GUIDE.md`, and this skill's
+[MCP Setup Guide](references/mcp-setup-guide.md) for the full reference.
 
 ---
 
@@ -759,6 +809,7 @@ the TTL window return instantly without hitting storage.
 | [Configuration Guide](references/configuration-guide.md) | Config file format and locations |
 | [Installation Guide](references/installation-guide.md) | Detailed installation options |
 | [Provider Configuration](references/provider-configuration.md) | All provider settings |
+| [MCP Setup Guide](references/mcp-setup-guide.md) | MCP server install, registration, OAuth, per-runtime config |
 | [Troubleshooting Guide](references/troubleshooting-guide.md) | Extended issue resolution |
 
 ---

--- a/agent-brain-plugin/skills/configuring-agent-brain/references/mcp-setup-guide.md
+++ b/agent-brain-plugin/skills/configuring-agent-brain/references/mcp-setup-guide.md
@@ -1,0 +1,111 @@
+# MCP Setup Guide
+
+How to install, register, and configure the Agent Brain **MCP (Model Context Protocol)
+server** so MCP-aware clients (Claude Code, Claude Desktop, Cursor, Windsurf, the Claude
+Agent SDK, LangChain DeepAgents) can reach your indexed corpus.
+
+## 1. Install the MCP package
+
+```bash
+pip install agent-brain-ag-mcp          # or: uv pip install / pipx install
+```
+
+PyPI name is `agent-brain-ag-mcp`; the console script is `agent-brain-mcp` and the import
+path is `agent_brain_mcp`.
+
+## 2. Register the server
+
+### Option A — through the plugin (Claude Code, recommended)
+
+```bash
+agent-brain install-agent --agent claude --with-mcp
+```
+
+This writes/merges an `agent-brain` entry into the project-level `.mcp.json` (or
+`~/.claude.json` with `--global`), preserving any other servers and keys. It is idempotent
+(re-running reports `unchanged`), supports `--dry-run`, and pins `AGENT_BRAIN_STATE_DIR` to
+the project's absolute `.agent-brain` path.
+
+| Flag | Values | Default | Purpose |
+|------|--------|---------|---------|
+| `--with-mcp` | — | off | Register the MCP server during install |
+| `--mcp-backend` | `auto`/`uds`/`http` | `auto` | How the server reaches `agent-brain-serve` |
+| `--mcp-auth` | `none`/`oauth` | `none` | Write `AGENT_BRAIN_MCP_AUTH=oauth` for remote OAuth servers |
+
+### Option B — manual JSON (any client)
+
+Claude Desktop, Cursor, and Windsurf use the same `mcpServers` shape:
+
+```json
+{
+  "mcpServers": {
+    "agent-brain": {
+      "command": "agent-brain-mcp",
+      "args": ["--backend", "auto"],
+      "env": { "AGENT_BRAIN_STATE_DIR": "/abs/path/.agent-brain" }
+    }
+  }
+}
+```
+
+- `--backend {auto,uds,http}` selects how the MCP server reaches `agent-brain-serve`
+  (`auto` prefers the Unix domain socket, falls back to HTTP). This is **orthogonal** to
+  the MCP *listen* transport.
+- Always pin `AGENT_BRAIN_STATE_DIR` to an **absolute** path — MCP clients launch the
+  server from an unknown working directory.
+
+### Listen transport
+
+`stdio` is the default (no flag). For IDE/framework clients that prefer HTTP:
+
+```bash
+agent-brain-mcp --transport http --host 127.0.0.1 --port 8765   # loopback only
+```
+
+## 3. OAuth 2.1 for remote servers (v10.4+)
+
+Local/loopback servers need no auth. To expose Agent Brain remotely, enable OAuth 2.1 on the
+Streamable HTTP transport. **Off by default.**
+
+| Variable | Side | Values | Notes |
+|----------|------|--------|-------|
+| `AGENT_BRAIN_AUTH` | server | `none` (default) / `basic` / `oauth` | Server-side auth mode |
+| `AGENT_BRAIN_OAUTH_RESOURCE` | server | absolute URI, no fragment | Required only in `oauth` mode (RFC 8707) |
+| `AGENT_BRAIN_MCP_AUTH` | client | unset / `oauth` | Opts the client into the OAuth dance |
+
+- Co-located AS/RS (single binary) and split AS/RS (external IdP: Keycloak/Auth0/Cognito).
+- Per-tool scopes — `agent-brain:read | index | admin | subscribe` — with default-deny on the
+  mutating tools (`index_folder`, `add_documents`, `inject_documents`, `remove_folder`,
+  `cancel_job`, `clear_cache`).
+- Client tokens are stored at `<state_dir>/mcp-oauth-tokens.json` (chmod `0o600`) and refreshed
+  silently. The server validates `aud` (no token passthrough; the MCP→REST leg keeps using
+  `X-API-Key`).
+- Invalid auth config fails closed: an empty/scheme-less/fragmented `AGENT_BRAIN_OAUTH_RESOURCE`
+  in `oauth` mode exits with code 2 at startup.
+
+## 4. Verify
+
+```bash
+agent-brain-mcp --help                          # server starts, lists flags
+agent-brain --transport mcp resources list      # drive it from the CLI
+```
+
+Current surface: **16 tools**, 5 `corpus://` resources, 6 prompts.
+
+## 5. Other runtimes
+
+`install-agent --with-mcp` auto-registers for **Claude Code** today. For OpenCode, Gemini, and
+Codex, register manually using the Option B JSON in that runtime's MCP config location. (The
+flag prints a note and skips for non-Claude runtimes rather than failing.)
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| Client can't find the server | Ensure `agent-brain-mcp` is on `PATH`; use an absolute `AGENT_BRAIN_STATE_DIR` |
+| Tools missing / empty | Start the backend first (`agent-brain start`) and index something |
+| `.mcp.json` not valid JSON | `install-agent --with-mcp` refuses to merge into a corrupt file — fix/remove it and re-run |
+| 401 from a remote server | Set `AGENT_BRAIN_MCP_AUTH=oauth` on the client; confirm the server's `AGENT_BRAIN_OAUTH_RESOURCE` |
+| 403 `insufficient_scope` | The token lacks the tool's scope (e.g. calling an index tool with only `agent-brain:read`) |
+
+See also `docs/MCP_USER_GUIDE.md` and the MCP package README for the full reference.


### PR DESCRIPTION
## Summary

The plugin's install skills now **cover MCP setup**, and `install-agent` can **register the MCP server for you** instead of leaving users to hand-edit `.mcp.json`.

### New CLI capability
`agent-brain install-agent --agent claude --with-mcp` writes/merges an `agent-brain` entry into the project-level `.mcp.json` (or `~/.claude.json` with `--global`):
- **Preserves** any other MCP servers and top-level keys
- Pins an **absolute** `AGENT_BRAIN_STATE_DIR` (clients launch from an unknown cwd)
- **Idempotent** — re-runs report `created` / `updated` / `unchanged`
- **Dry-run** aware; **fails closed** on a corrupt existing `.mcp.json`
- `--mcp-auth {none,oauth}` and `--mcp-backend {auto,uds,http}` flags
- Non-Claude runtimes print a skip note (manual setup) rather than failing

New module: `agent_brain_cli/runtime/mcp_registration.py`.

### Docs / skill coverage
- `configuring-agent-brain/SKILL.md`: rewrote the **stale** MCP section — OAuth 2.1 is **shipped in v10.4** (was "deferred to MCP v4"), surface is **16 tools** (was 7), added `--with-mcp` and an OAuth env-var table; metadata bumped to 10.4.0.
- New `references/mcp-setup-guide.md` (install → register → OAuth → per-runtime → troubleshooting).
- `agent-brain-install-agent.md` + `agent-brain-setup.md`: documented the new flags / added an optional MCP step.

### Tests (TDD)
- 10 unit tests (`test_mcp_registration.py`) + 6 CLI wiring tests (`test_install_agent_mcp.py`), all green; written before implementation.

## Test plan
- `task before-push` — ✅ pass
- `task pr-qa-gate` — ✅ pass (90.85% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
