### PR TITLE
docs(todo): track multi-runtime MCP auto-registration follow-ups (#224-#226)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,5 +15,14 @@ Per-phase tracking lives under `.planning/todos/`.
 [`docs/plans/2026-06-09-enterprise-hardening-and-cloud-deployment.md`](docs/plans/2026-06-09-enterprise-hardening-and-cloud-deployment.md).
 Follow-up issues: #200–#205.
 
+## MCP auto-registration — multi-runtime follow-ups
+
+`install-agent --with-mcp` registers the MCP server for Claude Code (shipped in #223).
+Extend the same auto-registration to the other runtimes (each has its own MCP config format):
+
+- [ ] [#224](https://github.com/SpillwaveSolutions/agent-brain/issues/224) — OpenCode (`opencode.json` `mcp`)
+- [ ] [#225](https://github.com/SpillwaveSolutions/agent-brain/issues/225) — Gemini CLI (`settings.json` `mcpServers`)
+- [ ] [#226](https://github.com/SpillwaveSolutions/agent-brain/issues/226) — Codex (`config.toml` `[mcp_servers]`)
+
 > The native MCP server (formerly tracked here as #153/#167) shipped in the v10.1–v10.4 line
 > and is no longer pending. The full MCP v1–v4 roadmap is complete as of v10.4.0.


### PR DESCRIPTION
Adds the multi-runtime MCP auto-registration follow-ups to `TODO.md`: #224 (OpenCode), #225 (Gemini), #226 (Codex) — extending `install-agent --with-mcp` (Claude shipped in #223) to the remaining runtimes. Docs-only.

## Test plan
- `task before-push` — ✅ pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)