### PR TITLE
docs(mcp): refresh MCP docs for v10.4 + add MCP Quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,11 @@ agent-brain/
 - [Quick Start](docs/QUICK_START.md) - Get running in minutes
 - [Plugin Guide](docs/PLUGIN_GUIDE.md) - Complete plugin documentation
 - [User Guide](docs/USER_GUIDE.md) - Detailed usage guide
+- [MCP Quickstart](docs/MCP_QUICKSTART.md) - Use Agent Brain over MCP in ~5 minutes
 
 ### Reference
 - [API Reference](docs/API_REFERENCE.md) - REST API documentation
+- [MCP User Guide](docs/MCP_USER_GUIDE.md) - MCP server: 16 tools, resources, prompts, OAuth
 - [Configuration](docs/CONFIGURATION.md) - All configuration options
 - [Provider Configuration](agent-brain-plugin/skills/using-agent-brain/references/provider-configuration.md) - Provider setup
 - [Integrations](docs/INTEGRATIONS.md) - Connect agent-brain-mcp to LLM frameworks + editors

--- a/agent-brain-mcp/README.md
+++ b/agent-brain-mcp/README.md
@@ -4,15 +4,18 @@ Model Context Protocol server for [Agent Brain](https://github.com/SpillwaveSolu
 
 Exposes the running Agent Brain instance as an MCP server consumable by Claude Desktop, Cursor, Windsurf, Claude Agent SDK, LangChain DeepAgents, and any other MCP-aware client.
 
-## v1 surface
+## Surface (v10.4)
 
-- **7 Tools**: `search_documents`, `query_count`, `index_folder`, `get_job`, `list_jobs`, `cancel_job`, `server_health`
+- **16 Tools**: `search_documents`, `query_count`, `explain_result`, `index_folder`, `add_documents`, `inject_documents`, `get_job`, `list_jobs`, `wait_for_job`, `cancel_job`, `list_folders`, `remove_folder`, `cache_status`, `clear_cache`, `list_file_types`, `server_health`
 - **5 Resources** (read-only): `corpus://config`, `corpus://status`, `corpus://health`, `corpus://providers`, `corpus://folders`
 - **6 Prompts**: `find-callers`, `find-implementation`, `explain-architecture`, `compare-search-modes`, `onboard-to-codebase`, `audit-indexed-folders`
-- **Transport**: stdio
+- **Listen transport**: stdio (default) or Streamable HTTP (`--transport http`)
 - **Backend**: UDS (preferred) or HTTP, selectable via `--backend {auto,uds,http}`
+- **Auth**: OAuth 2.1 on the HTTP listen transport (`AGENT_BRAIN_AUTH=oauth`), **off by default**
 
-Shipped in Agent Brain 10.1.0 (May 2026); see [`CHANGELOG.md`](../docs/CHANGELOG.md). v2 (subscriptions + streamable HTTP), v3 (CLI-via-MCP + framework adapters), and v4 (OAuth) are tracked under [`docs/roadmaps/mcp/`](../docs/roadmaps/mcp/).
+The full v1–v4 MCP roadmap shipped by Agent Brain 10.4.0; see [`CHANGELOG.md`](../docs/CHANGELOG.md)
+and the [MCP User Guide](../docs/MCP_USER_GUIDE.md). Register for Claude Code with
+`agent-brain install-agent --agent claude --with-mcp`.
 
 ## Install
 
@@ -76,17 +79,22 @@ curl http://127.0.0.1:8765/healthz
 # → {"status":"ok","transport":"http"}
 ```
 
-### Loopback only — no auth in v10.2
+### Loopback bind + authentication
 
-`--host` accepts **only** `127.0.0.1`, `localhost`, or `::1`. Binding to a public interface is rejected at startup with the error `--host must be one of {127.0.0.1, localhost, ::1} (auth is deferred to v4; binding to public interfaces is unsafe in v2)`. There is **no `--allow-public-bind` escape hatch** — authentication is reserved for MCP v4 (OAuth 2.1; tracked as [OAUTH-01](https://github.com/SpillwaveSolutions/agent-brain/issues/188)).
+`--host` accepts **only** `127.0.0.1`, `localhost`, or `::1` (no `--allow-public-bind` escape
+hatch). For remote access, run the loopback HTTP listener **behind a gateway / reverse proxy** and
+enable authentication rather than binding a public interface directly.
 
-The startup banner names this constraint explicitly:
+**Authentication (v10.4):** OAuth 2.1 on the HTTP listen transport is **off by default**
+(`AGENT_BRAIN_AUTH=none`). Set `AGENT_BRAIN_AUTH=oauth` (+ `AGENT_BRAIN_OAUTH_RESOURCE`) to require
+audience-bound Bearer tokens with per-tool scopes (`agent-brain:read|index|admin|subscribe`,
+default-deny on writes). Co-located and split AS/RS topologies are supported. See the
+[MCP User Guide → Authentication](../docs/MCP_USER_GUIDE.md#authentication).
 
-```
-MCP server listening on http://127.0.0.1:8765/mcp (loopback only, no auth — do NOT expose this port)
-```
-
-**Local trust model:** any process running as the same user on this host can reach the port and drive MCP tools (including `cancel_job` which is annotated `destructiveHint: true`). Do not run `--transport http` on a shared / multi-user host without external sandboxing.
+**Local trust model (no-auth mode):** with `AGENT_BRAIN_AUTH=none`, any process running as the same
+user on this host can reach the port and drive MCP tools (including destructive ones like
+`cancel_job`). Do not run `--transport http` unauthenticated on a shared / multi-user host without
+external sandboxing.
 
 ### No silent fallback
 

--- a/docs/MCP_QUICKSTART.md
+++ b/docs/MCP_QUICKSTART.md
@@ -1,0 +1,153 @@
+# MCP Quickstart — use Agent Brain over MCP in ~5 minutes
+
+A copy-paste walkthrough to get the Agent Brain **MCP server** running and registered with
+**Claude Code**, so the model can search your indexed corpus as a native tool. For the full
+reference (all 16 tools, resources, prompts, OAuth, per-host config) see the
+[MCP User Guide](./MCP_USER_GUIDE.md).
+
+> **MCP server vs. plugin:** the *plugin* gives you `/agent-brain-*` slash commands you drive by
+> hand. The *MCP server* lets the model itself call Agent Brain as tools during a session. You can
+> run both against the same backend. This guide sets up the MCP server.
+
+---
+
+## Prerequisites
+
+- Python 3.10+
+- A provider key for embeddings (e.g. `OPENAI_API_KEY`), or Ollama for a fully-local setup
+- Claude Code (this works in any MCP host; the one-command registration targets Claude Code)
+
+---
+
+## Step 1 — Install the packages
+
+```bash
+pip install agent-brain-rag agent-brain-cli agent-brain-ag-mcp
+# verify
+agent-brain --version
+agent-brain-mcp --help
+```
+
+> PyPI ships the MCP server as `agent-brain-ag-mcp`; the console script is `agent-brain-mcp`.
+
+## Step 2 — Start the backend and index something
+
+The MCP server is a thin proxy — it indexes nothing itself. You need a running backend with
+content in it.
+
+```bash
+cd /path/to/your/project
+export OPENAI_API_KEY="sk-..."        # or configure Ollama — see the Configuring guide
+
+agent-brain init                      # creates .agent-brain/
+agent-brain start                     # starts the FastAPI backend
+agent-brain index ./docs ./src        # index some docs/code
+agent-brain status                    # expect: healthy, document count > 0
+```
+
+## Step 3 — Register the MCP server with Claude Code
+
+One command writes the `.mcp.json` entry for you (idempotent; preview with `--dry-run` first):
+
+```bash
+agent-brain install-agent --agent claude --with-mcp --dry-run   # preview
+agent-brain install-agent --agent claude --with-mcp             # do it
+```
+
+This merges an `agent-brain` server into the project's `.mcp.json` (preserving any other servers),
+pinning an absolute `AGENT_BRAIN_STATE_DIR`. Confirm:
+
+```bash
+cat .mcp.json
+```
+
+```json
+{
+  "mcpServers": {
+    "agent-brain": {
+      "command": "agent-brain-mcp",
+      "args": ["--backend", "auto"],
+      "env": { "AGENT_BRAIN_STATE_DIR": "/abs/path/to/your/project/.agent-brain" }
+    }
+  }
+}
+```
+
+> **Other hosts / runtimes:** auto-registration currently targets Claude Code. For Claude Desktop,
+> Cursor, Windsurf, OpenCode, Gemini, or Codex, paste the same `mcpServers` block into that host's
+> config (see [MCP User Guide → Configuration](./MCP_USER_GUIDE.md#configuration)).
+
+## Step 4 — Reload Claude Code and approve the server
+
+Restart Claude Code (or reload the window) in that project. Claude Code reads `.mcp.json` on
+startup and will prompt you to approve the new `agent-brain` server. After approval, the 16 tools
+become available to the model.
+
+Verify from a terminal that the server itself is healthy:
+
+```bash
+# Drive the server through the CLI's MCP transport
+agent-brain --transport mcp resources list
+agent-brain --transport mcp resources read corpus://status
+```
+
+You should see the `corpus://` resources and a status payload with your document count.
+
+## Step 5 — Use it
+
+In a Claude Code session in that project, just ask in natural language — the model will pick the
+`search_documents` tool itself:
+
+> "Search the indexed corpus for how authentication is handled."
+> "Use agent-brain to find the callers of `register_claude_mcp`."
+> "What does `corpus://status` report for the index?"
+
+You don't invoke tools by name; the model selects them. The MCP tools cover search
+(`search_documents` across semantic / bm25 / hybrid / graph / multi modes), indexing
+(`index_folder`, `add_documents`, `inject_documents`), jobs (`list_jobs`, `wait_for_job`,
+`cancel_job`), folders, cache, and health. See the
+[tool reference](./MCP_USER_GUIDE.md#tool-reference-16-tools).
+
+---
+
+## Optional — remote server with OAuth (v10.4)
+
+For local use you need **no auth** — skip this. To run Agent Brain on a remote/shared host, enable
+OAuth 2.1 on the HTTP listen transport (off by default):
+
+```bash
+# Server side
+export AGENT_BRAIN_AUTH=oauth
+export AGENT_BRAIN_OAUTH_RESOURCE="https://agent-brain.example.com/mcp"
+agent-brain-mcp --transport http --host 127.0.0.1 --port 8765    # behind a gateway
+
+# Client side — register with the client OAuth dance enabled
+agent-brain install-agent --agent claude --with-mcp --mcp-auth oauth
+```
+
+The client opens a browser once, caches tokens at `<state_dir>/mcp-oauth-tokens.json`, and refreshes
+silently. Per-tool scopes (`agent-brain:read|index|admin|subscribe`) apply, with default-deny on the
+mutating tools. Full setup: [MCP User Guide → Authentication](./MCP_USER_GUIDE.md#authentication).
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| Server doesn't appear in Claude Code | Reload the window; confirm `.mcp.json` exists at the project root and you approved the server |
+| `agent-brain-mcp: command not found` in the host | Use the absolute path from `which agent-brain-mcp` as `command` in `.mcp.json` |
+| Tools return "backend unavailable" | The backend isn't running — `agent-brain start`, then `agent-brain status` |
+| Empty / no results | Index something first (`agent-brain index ./docs`) and check `agent-brain status` shows a document count |
+| Wrong corpus | `AGENT_BRAIN_STATE_DIR` points at the wrong `.agent-brain`; re-run `install-agent --with-mcp` from the right project root |
+| `install-agent --with-mcp` won't merge | Your `.mcp.json` is invalid JSON — the command fails closed; fix/remove it and re-run |
+| 401 / 403 from a remote server | 401 → set `AGENT_BRAIN_MCP_AUTH=oauth` on the client; 403 `insufficient_scope` → the token lacks the tool's scope |
+
+---
+
+## Related docs
+
+- [MCP User Guide](./MCP_USER_GUIDE.md) — full tool/resource/prompt reference, OAuth, per-host config
+- [Configuring Agent Brain](../agent-brain-plugin/skills/configuring-agent-brain/references/mcp-setup-guide.md) — MCP setup reference in the plugin skill
+- [User Guide](./USER_GUIDE.md) — backend setup, indexing, retrieval modes
+- [Plugin Guide](./PLUGIN_GUIDE.md) — the slash-command companion

--- a/docs/MCP_USER_GUIDE.md
+++ b/docs/MCP_USER_GUIDE.md
@@ -21,7 +21,7 @@ Complete reference for `agent-brain-mcp` — the Model Context Protocol server t
   - [Other agent frameworks (preview)](#other-agent-frameworks-preview)
 - [MCP transport axes (v10.2+)](#mcp-transport-axes-v102)
 - [CLI flags and environment variables](#cli-flags-and-environment-variables)
-- [Tool reference (7 tools)](#tool-reference-7-tools)
+- [Tool reference (16 tools)](#tool-reference-16-tools)
 - [Resource reference (5 resources)](#resource-reference-5-resources)
 - [Prompt reference (6 prompts)](#prompt-reference-6-prompts)
 - [End-to-end worked examples](#end-to-end-worked-examples)
@@ -39,9 +39,14 @@ Complete reference for `agent-brain-mcp` — the Model Context Protocol server t
 
 - **PyPI distribution:** `agent-brain-ag-mcp`
 - **Console script:** `agent-brain-mcp`
-- **Transport (to the LLM client):** stdio (JSON-RPC 2.0)
+- **Transport (to the LLM client):** stdio (default) or Streamable HTTP (`--transport http`)
 - **Transport (to the backend):** UDS (preferred) or HTTP, selectable with `--backend {auto|uds|http}`
-- **v1 surface:** 7 tools, 5 read-only resources, 6 prompts
+- **Surface (v10.4):** **16 tools**, 5 read-only resources, 6 prompts
+- **Auth (v10.4):** OAuth 2.1 on the HTTP listen transport, **off by default** — see [Authentication](#authentication)
+- **Quick start:** for a copy-paste walkthrough see the **[MCP Quickstart](./MCP_QUICKSTART.md)**
+
+> **Register it for Claude Code in one command:** `agent-brain install-agent --agent claude --with-mcp`
+> writes the `.mcp.json` entry for you (see [Register automatically](#register-automatically-claude-code)).
 
 If you want slash commands inside Claude Code, OpenCode, Gemini CLI, or Codex, use the [plugin](./PLUGIN_GUIDE.md) instead. If your LLM client speaks MCP natively (Claude Desktop, Cursor, an agent SDK), use this server.
 
@@ -70,6 +75,8 @@ You can run both at the same time against the same backend — they don't confli
 - **Structured tool output** — every tool advertises an `outputSchema` and returns a typed `structuredContent` block alongside the human-readable summary, so model clients that consume MCP structured output get typed data.
 - **Corpus state as resources** — read backend config, status, health, providers, and indexed folders via `corpus://...` URIs without a tool call (i.e. without an LLM round-trip).
 - **Opinionated multi-step prompts** — six parameterized templates (`find-callers`, `find-implementation`, `explain-architecture`, `compare-search-modes`, `onboard-to-codebase`, `audit-indexed-folders`) that chain tool calls into useful end-to-end flows.
+- **One-command registration** — `install-agent --agent claude --with-mcp` writes/merges the `.mcp.json` entry (idempotent, dry-run aware) instead of hand-editing JSON.
+- **OAuth 2.1 for remote servers (v10.4)** — run Agent Brain remotely behind OAuth on the HTTP transport, with per-tool scopes (`agent-brain:read|index|admin|subscribe`) and default-deny on the mutating tools. Off by default; local/loopback needs no auth.
 - **UDS-or-HTTP backend transport** — `--backend auto` prefers UDS for lower latency and falls back to HTTP transparently.
 - **Version-compat startup check** — the server calls `GET /health/` once at startup and refuses to start if the backend reports a version below the pinned `MIN_BACKEND_VERSION`. Prevents wire drift.
 - **Structured JSON-RPC errors** — HTTP failures map to MCP error codes including custom `-32000…-32003` codes for `BackendConflict`, `BackendUnavailable`, `ServiceIndexing`, and `BackendTimeout`. Every error carries `data.httpStatus` and `data.cause`.
@@ -104,6 +111,28 @@ For multi-instance / shared deployments, see [`docs/USER_GUIDE.md`](./USER_GUIDE
 ---
 
 ## Configuration
+
+### Register automatically (Claude Code)
+
+The fastest path — let the CLI write the registration for you while installing the plugin:
+
+```bash
+# Install the plugin AND register the agent-brain MCP server for Claude Code
+agent-brain install-agent --agent claude --with-mcp
+
+# Preview without writing
+agent-brain install-agent --agent claude --with-mcp --dry-run
+
+# Register with client-side OAuth (for a remote, OAuth-protected server)
+agent-brain install-agent --agent claude --with-mcp --mcp-auth oauth
+```
+
+This writes/merges an `agent-brain` entry into the project-level `.mcp.json` (or `~/.claude.json`
+with `--global`), **preserving any other servers and keys**, pins an absolute
+`AGENT_BRAIN_STATE_DIR`, and is **idempotent** (re-running reports `unchanged`). Flags:
+`--with-mcp`, `--mcp-backend {auto,uds,http}`, `--mcp-auth {none,oauth}`. Auto-registration
+currently targets Claude Code; for OpenCode / Gemini / Codex it prints a note and skips —
+register manually with the JSON below (tracked as [#224](https://github.com/SpillwaveSolutions/agent-brain/issues/224)–[#226](https://github.com/SpillwaveSolutions/agent-brain/issues/226)).
 
 ### Universal stdio config
 
@@ -141,7 +170,7 @@ Add to `claude_desktop_config.json` (location varies by OS — `~/Library/Applic
 }
 ```
 
-Restart Claude Desktop. The 7 tools, 5 resources, and 6 prompts will appear in the tool/resource pickers.
+Restart Claude Desktop. The 16 tools, 5 resources, and 6 prompts will appear in the tool/resource pickers.
 
 ### Cursor / Windsurf / generic MCP IDE
 
@@ -254,8 +283,8 @@ Agent Brain's MCP integration has **two orthogonal transport axes**. Conflating 
 └─────────────┘                     └──────────────────┘                     └────────────────────┘
        ▲                                                                                ▲
        │                                                                                │
-       │           OAUTH-01 / MCP v4                                #179 (Bearer-token,
-       │           (deferred — no auth in v10.2)                    backend-axis only)
+       │      OAuth 2.1 on the listen axis                          X-API-Key on the
+       │      (shipped v10.4 — OFF by default)                      backend axis (#179)
        │                                                                                │
        └──────────────────────────── deliberately distinct axes ────────────────────────┘
 ```
@@ -267,12 +296,26 @@ The two axes are independent:
 
 ### Authentication
 
-**Neither axis ships authentication in v10.2 (MCP v2):**
+**Local/loopback needs no auth.** For `stdio` and loopback HTTP, leave the defaults — the server
+runs as a child of a trusted local client (subprocess hygiene covers stdio).
 
-- The MCP HTTP listen transport binds **loopback only** (`127.0.0.1`, `localhost`, `::1`) and is **unauthenticated**. Authentication on the listen axis is reserved for MCP v4 (OAuth 2.1, tracked as [OAUTH-01 / #188](https://github.com/SpillwaveSolutions/agent-brain/issues/188)). The CLI rejects non-loopback hosts at startup with no `--allow-public-bind` escape hatch.
-- The optional **Bearer-token middleware on `agent-brain-serve`** (issue [#179](https://github.com/SpillwaveSolutions/agent-brain/issues/179)) is a **backend-axis** concern. When it lands, `agent-brain-mcp`'s backend httpx client passes the token through, but the MCP listen transport itself remains unauthenticated until v4.
+**OAuth 2.1 on the listen axis shipped in v10.4** (closes [#188](https://github.com/SpillwaveSolutions/agent-brain/issues/188)) for running Agent Brain remotely. It is **off by default** and opt-in via env vars:
 
-In short: #179 ≠ OAUTH-01. They protect different axes.
+| Variable | Side | Values | Notes |
+|----------|------|--------|-------|
+| `AGENT_BRAIN_AUTH` | server | `none` (default) / `basic` / `oauth` | Server-side auth mode on the HTTP listen transport |
+| `AGENT_BRAIN_OAUTH_RESOURCE` | server | absolute URI (scheme, no fragment) | Required **only** in `oauth` mode (RFC 8707 resource id); invalid value → exit 2 at startup |
+| `AGENT_BRAIN_MCP_AUTH` | client | unset (off) / `oauth` | Opts the MCP client into the OAuth dance (browser flow + token cache) |
+
+Highlights:
+
+- Co-located AS/RS (single binary, RS256 JWT) **and** split AS/RS (external IdP — Keycloak/Auth0/Cognito via JWKS / introspection).
+- Discovery: Protected Resource Metadata (RFC 9728) + Authorization Server Metadata (RFC 8414); PKCE **S256-only**.
+- **Per-tool scopes** — `agent-brain:read | index | admin | subscribe` — enforced server-side with **default-deny** on the mutating tools; an under-scoped call gets HTTP 403 `insufficient_scope`.
+- Resource Indicators (RFC 8707) + confused-deputy prevention: the client OAuth token never reaches the MCP→backend leg, which keeps using `X-API-Key`.
+- Client tokens persist at `<state_dir>/mcp-oauth-tokens.json` (chmod `0o600`) and refresh silently.
+
+The optional **`X-API-Key` middleware on `agent-brain-serve`** (issue [#179](https://github.com/SpillwaveSolutions/agent-brain/issues/179)) is a separate **backend-axis** concern from the listen-axis OAuth above — they protect different hops.
 
 ### Local trust model
 
@@ -285,7 +328,7 @@ In short: #179 ≠ OAUTH-01. They protect different axes.
 | Claude Desktop / Claude Code / generic MCP CLI clients | `stdio` (default)         |
 | IDE plugins or framework adapters that prefer HTTP/SSE | `http`                    |
 | CI smoke tests driving the official MCP Python SDK     | `http`                    |
-| Anything exposed beyond `127.0.0.1`                    | **not supported in v10.2** — wait for MCP v4 / OAUTH-01 |
+| Remote / shared host exposed beyond `127.0.0.1`        | `http` **behind a gateway with `AGENT_BRAIN_AUTH=oauth`** (v10.4) |
 
 The backend axis is unchanged from v10.1 — `--backend auto` keeps working in both cases.
 
@@ -311,6 +354,15 @@ The backend axis is unchanged from v10.1 — `--backend auto` keeps working in b
 | `--host <ip-or-name>` | — | `127.0.0.1` | Bind host for `--transport http`. Only `127.0.0.1`, `localhost`, and `::1` are accepted (loopback whitelist). Ignored when `--transport stdio`. |
 | `--port <int>` | — | `8765` | TCP port for `--transport http`. Ignored when `--transport stdio`. |
 
+### Auth axis (v10.4, off by default)
+
+| Env var | Side | Default | Description |
+|---|---|---|---|
+| `AGENT_BRAIN_AUTH` | server | `none` | `none` / `basic` / `oauth` — enables OAuth 2.1 on the HTTP listen transport |
+| `AGENT_BRAIN_OAUTH_RESOURCE` | server | — | Required in `oauth` mode: absolute resource URI (scheme, no fragment) |
+| `AGENT_BRAIN_OAUTH_ISSUER` | server | — | Optional external Authorization Server issuer (split AS/RS) |
+| `AGENT_BRAIN_MCP_AUTH` | client | unset | Set to `oauth` to opt the MCP client into the OAuth dance |
+
 ### Resolution precedence
 
 **Backend axis** (top wins):
@@ -329,9 +381,13 @@ The backend axis is unchanged from v10.1 — `--backend auto` keeps working in b
 
 ---
 
-## Tool reference (7 tools)
+## Tool reference (16 tools)
 
 Every tool returns both a human-readable `content` block and a typed `structuredContent` payload validated against its `outputSchema`. REST endpoint columns refer to the FastAPI backend the MCP server proxies to — see [`API_REFERENCE.md`](./API_REFERENCE.md) for full backend schemas.
+
+The 7 core tools are documented in detail below; the 9 added in v10.2–v10.3 are summarized in
+[Additional tools](#additional-tools-v102v103). Each tool's required OAuth scope (enforced only
+when `AGENT_BRAIN_AUTH=oauth`) is listed in [Tool scopes](#tool-scopes).
 
 ### `search_documents` (readOnly, openWorld)
 
@@ -462,6 +518,39 @@ Return Agent Brain server health, version, and mode.
 **Output:** `{status, version, message?, mode?, instance_id?}`
 
 **Use when:** the model wants a quick liveness check (also called at MCP startup for the version-compat gate).
+
+---
+
+### Additional tools (v10.2–v10.3)
+
+These 9 tools complete the 16-tool surface. Each returns the same `content` + typed
+`structuredContent` shape; see `agent_brain_mcp/schemas.py` and [`API_REFERENCE.md`](./API_REFERENCE.md)
+for full field-level schemas.
+
+| Tool | Annotation | Wraps | Purpose |
+|---|---|---|---|
+| `explain_result` | readOnly | `POST /query/explain` | Explain why a result matched (score breakdown across modes) |
+| `add_documents` | openWorld | `POST /index/add` | Add specific documents to the index without a full folder scan |
+| `inject_documents` | openWorld | `POST /index/inject` | Index with a content-enrichment script (`--script`) |
+| `wait_for_job` | openWorld | polls `GET /jobs/{id}` | Block until a job completes, emitting progress notifications |
+| `list_folders` | readOnly | `GET /index/folders` | List indexed folders with chunk counts |
+| `remove_folder` | destructive | `DELETE /index/folders` | Remove all chunks for a folder (requires `confirm: true`) |
+| `cache_status` | readOnly | `GET /cache/status` | Embedding-cache statistics (hit rate, size) |
+| `clear_cache` | destructive | `POST /cache/clear` | Clear cached embeddings (requires `confirm: true`) |
+| `list_file_types` | readOnly | `GET /types` | List file-type presets and extensions |
+
+### Tool scopes
+
+When `AGENT_BRAIN_AUTH=oauth`, each tool requires the scope below (default-deny: a token without
+the scope gets HTTP 403 `insufficient_scope`). With the default `AGENT_BRAIN_AUTH=none`, scopes are
+not enforced.
+
+| Scope | Tools |
+|---|---|
+| `agent-brain:read` | `search_documents`, `explain_result`, `query_count`, `server_health`, `cache_status`, `list_folders`, `list_file_types`, `list_jobs`, `get_job` |
+| `agent-brain:index` | `index_folder`, `add_documents`, `inject_documents`, `wait_for_job` |
+| `agent-brain:admin` | `cancel_job`, `remove_folder`, `clear_cache` |
+| `agent-brain:subscribe` | resource subscriptions (`corpus://`, `job://`) |
 
 ---
 
@@ -719,22 +808,22 @@ which agent-brain-mcp   # paste the result into "command"
 
 ---
 
-## What's not in v1, and what's coming
+## Roadmap status (v1–v4 shipped)
 
-**Not in v1:**
+The full MCP roadmap is complete as of **v10.4**:
 
-- Resource subscriptions (`resources/subscribe`) — v2.
-- Streamable HTTP MCP transport — v2 (stdio only in v1).
-- `chunk://<id>` and `graph-entity://<type>/<id>` resource schemes — v2 (need new backend endpoints).
-- 9 deferred tools: `explain_result`, `add_documents`, `inject_documents`, `wait_for_job`, `list_folders`, `remove_folder`, `cache_status`, `clear_cache`, `list_file_types` — v2.
-- CLI-via-MCP (`agent-brain --transport mcp`) and the agent-framework adapter matrix — v3.
-- OAuth 2.1 for remote Agent Brain instances — v4.
+- ✅ **v2** — resource subscriptions (`resources/subscribe`), Streamable HTTP transport, the
+  `chunk://` / `graph-entity://` schemes, and the 9 additional tools.
+- ✅ **v3** — CLI-via-MCP (`agent-brain --transport mcp`) and the agent-framework adapter matrix.
+- ✅ **v4** — OAuth 2.1 for remote Agent Brain instances (see [Authentication](#authentication)).
 
-See [`docs/roadmaps/mcp/`](./roadmaps/mcp/) for per-version scope:
+What's next (not yet shipped):
 
-- [v2 — subscriptions and resources](./roadmaps/mcp/v2-subscriptions-and-resources.md)
-- [v3 — CLI-via-MCP and frameworks](./roadmaps/mcp/v3-cli-via-mcp-and-frameworks.md)
-- [v4 — OAuth for remote](./roadmaps/mcp/v4-oauth-for-remote.md)
+- Multi-runtime `--with-mcp` auto-registration for OpenCode / Gemini / Codex — [#224](https://github.com/SpillwaveSolutions/agent-brain/issues/224)–[#226](https://github.com/SpillwaveSolutions/agent-brain/issues/226).
+- Enterprise hardening + cloud deployment — [#219](https://github.com/SpillwaveSolutions/agent-brain/issues/219) and follow-ups #200–#205.
+
+See [`docs/roadmaps/mcp/`](./roadmaps/mcp/) for the original per-version scope and
+[`docs/plans/backlog-survey.md`](./plans/backlog-survey.md) for the current backlog.
 
 ---
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1042,7 +1042,15 @@ The dual-bind path runs two `uvicorn.Server` instances on the shared asyncio loo
 
 ## Using Agent Brain via MCP
 
-Agent Brain ships an MCP (Model Context Protocol) server — `agent-brain-mcp` — that exposes the indexed corpus as **7 tools, 5 read-only resources, and 6 prompts** over stdio. Any MCP-aware host (Claude Desktop, Cursor, Windsurf, Claude Agent SDK, LangChain DeepAgents, …) can call Agent Brain directly without shelling out to the CLI.
+Agent Brain ships an MCP (Model Context Protocol) server — `agent-brain-mcp` — that exposes the indexed corpus as **16 tools, 5 read-only resources, and 6 prompts** over stdio or Streamable HTTP. Any MCP-aware host (Claude Desktop, Cursor, Windsurf, Claude Agent SDK, LangChain DeepAgents, …) can call Agent Brain directly without shelling out to the CLI. Remote deployments can require **OAuth 2.1** (off by default).
+
+Register it for Claude Code in one command:
+
+```bash
+agent-brain install-agent --agent claude --with-mcp
+```
+
+…or configure any MCP host manually:
 
 ```json
 {
@@ -1056,7 +1064,7 @@ Agent Brain ships an MCP (Model Context Protocol) server — `agent-brain-mcp` �
 }
 ```
 
-For per-host configuration (Claude Desktop, Cursor / Windsurf, Claude Agent SDK, LangChain DeepAgents), the full tool/resource/prompt reference with schemas, end-to-end worked examples, error-mapping table, troubleshooting, and the v2–v4 roadmap, see **[MCP User Guide](./MCP_USER_GUIDE.md)**.
+For a copy-paste walkthrough see the **[MCP Quickstart](./MCP_QUICKSTART.md)**. For per-host configuration, the full tool/resource/prompt reference with schemas, OAuth setup, worked examples, and troubleshooting, see the **[MCP User Guide](./MCP_USER_GUIDE.md)**.
 
 For the slash-command companion that runs inside Claude Code / OpenCode / Gemini CLI / Codex, see **[Plugin Guide](./PLUGIN_GUIDE.md)**.
 


### PR DESCRIPTION
## Summary

Brings the MCP docs in line with shipped v10.4 and the new `install-agent --with-mcp` registration, and adds a hands-on quickstart you can follow.

- **New `docs/MCP_QUICKSTART.md`** — 5-minute copy-paste walkthrough: install → index → `install-agent --agent claude --with-mcp` → reload Claude Code → verify → use; plus an optional remote-OAuth section and troubleshooting.
- **`docs/MCP_USER_GUIDE.md`** — corrected the biggest staleness: **7 → 16 tools** (added a tool table + per-tool **scope** table), rewrote **Authentication** (OAuth 2.1 **shipped in v10.4, off by default** — was "deferred to v4"), added a **Register automatically** section and an auth env-var table, and updated the roadmap-status section (v1–v4 all shipped).
- **`docs/USER_GUIDE.md` + `agent-brain-mcp/README.md`** — 7→16 tools, `--with-mcp`, OAuth-shipped (replaced stale "no auth in v10.2").
- **`README.md`** — links the MCP Quickstart + MCP User Guide in the docs index (they weren't linked before).

Docs-only.

## Test plan
- `task before-push` — ✅ pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)