### PR TITLE
docs: fix Claude Code plugin install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Agent Brain provides **AI-first** document and code search through a Claude Code
 
 | Component | Description |
 |-----------|-------------|
-| **Plugin** | 24 slash commands, 3 agents, 2 skills for Claude Code |
+| **Plugin** | 30 slash commands, 3 agents, 2 skills for Claude Code |
 | **Skills** | Intelligent search mode selection and query optimization |
 | **Agents** | Research assistant, search assistant, setup assistant |
 | **Server** | FastAPI backend for indexing and retrieval |
@@ -23,8 +23,17 @@ Agent Brain provides **AI-first** document and code search through a Claude Code
 ### 1. Install the Plugin
 
 ```bash
-claude plugins install github:SpillwaveSolutions/agent-brain
+# 1. Add the Agent Brain marketplace (the repo is a plugin marketplace)
+claude plugins marketplace add SpillwaveSolutions/agent-brain
+
+# 2. Install the plugin from that marketplace
+claude plugins install agent-brain@agent-brain-marketplace
 ```
+
+> Installing a Claude Code plugin does **not** use `pip`. The plugin is
+> installed through the marketplace above; the underlying Python packages
+> (`agent-brain-rag`, `agent-brain-cli`) are installed for you by the
+> `/agent-brain-setup` wizard (or manually via `pip` — see [CLI Usage](#cli-usage-alternative)).
 
 ### 2. Set Up Your Project
 
@@ -175,7 +184,7 @@ Run completely offline with Ollama:
 ```
 agent-brain/
 ├── agent-brain-plugin/        # Claude Code plugin (primary interface)
-│   ├── commands/              # 24 slash commands
+│   ├── commands/              # 30 slash commands
 │   ├── agents/                # 3 intelligent agents
 │   └── skills/                # 2 context skills
 ├── agent-brain-server/        # FastAPI backend

--- a/agent-brain-plugin/README.md
+++ b/agent-brain-plugin/README.md
@@ -14,8 +14,9 @@ A Claude Code plugin for document search with hybrid BM25/semantic retrieval. In
 ### 1. Install Claude Code Plugin
 
 ```bash
-# From GitHub
-claude plugins install github:SpillwaveSolutions/agent-brain-plugin
+# Add the marketplace, then install the plugin from it
+claude plugins marketplace add SpillwaveSolutions/agent-brain
+claude plugins install agent-brain@agent-brain-marketplace
 ```
 
 ### 2. Install Agent Brain Packages

--- a/docs/PLUGIN_GUIDE.md
+++ b/docs/PLUGIN_GUIDE.md
@@ -29,7 +29,8 @@ Complete reference for the Agent Brain Claude Code plugin - 30 commands, 3 agent
 Install the Agent Brain plugin in Claude Code:
 
 ```bash
-claude plugins install github:SpillwaveSolutions/agent-brain
+claude plugins marketplace add SpillwaveSolutions/agent-brain
+claude plugins install agent-brain@agent-brain-marketplace
 ```
 
 This provides:

--- a/docs/PROJECT_SETUP_PLUGIN_SKILLS_MCP.md
+++ b/docs/PROJECT_SETUP_PLUGIN_SKILLS_MCP.md
@@ -34,7 +34,8 @@ They don't conflict — run all three against the same backend.
 In Claude Code:
 
 ```
-claude plugins install github:SpillwaveSolutions/agent-brain
+claude plugins marketplace add SpillwaveSolutions/agent-brain
+claude plugins install agent-brain@agent-brain-marketplace
 ```
 
 This installs **30 slash commands**, **3 agents**, and the **2 skills**

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -11,7 +11,8 @@ Get up and running with Agent Brain in minutes. The Claude Code plugin is the pr
 Install the Agent Brain plugin in Claude Code:
 
 ```bash
-claude plugins install github:SpillwaveSolutions/agent-brain
+claude plugins marketplace add SpillwaveSolutions/agent-brain
+claude plugins install agent-brain@agent-brain-marketplace
 ```
 
 This gives you access to 30 commands, 3 intelligent agents, and 2 skills for working with Agent Brain.


### PR DESCRIPTION
## Problem

The documented install command is invalid:

```bash
claude plugins install github:SpillwaveSolutions/agent-brain
```

`claude plugins install` takes a `plugin@marketplace` reference, not a GitHub repo. Running it fails with:

> Plugin "github:SpillwaveSolutions/agent-brain" not found in any configured marketplace

The `github:owner/repo` form belongs to `marketplace add`, not `install`.

## Fix

This repo *is* a plugin marketplace (`.claude-plugin/marketplace.json` → `agent-brain-marketplace`, exposing plugin `agent-brain`), so install is two steps:

```bash
claude plugins marketplace add SpillwaveSolutions/agent-brain
claude plugins install agent-brain@agent-brain-marketplace
```

Updated in all five user-facing docs: `README.md`, `agent-brain-plugin/README.md`, `docs/QUICK_START.md`, `docs/PLUGIN_GUIDE.md`, `docs/PROJECT_SETUP_PLUGIN_SKILLS_MCP.md`.

Also:
- Added a note clarifying the plugin is **not** installed via `pip` (pip only installs the underlying `agent-brain-rag` / `agent-brain-cli` packages, which `/agent-brain-setup` handles).
- Corrected the stale "24 slash commands" count in `README.md` to 30 (matches the 30 files in `agent-brain-plugin/commands/` and the other docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)