### PR TITLE
chore(release): bump version to 10.5.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "agent-brain",
       "description": "Document search with hybrid BM25/semantic retrieval, GraphRAG knowledge graphs, and pluggable providers",
-      "version": "10.5.0",
+      "version": "10.5.1",
       "author": {
         "name": "Spillwave Solutions",
         "email": "support@spillwave.com"

--- a/agent-brain-cli/agent_brain_cli/__init__.py
+++ b/agent-brain-cli/agent_brain_cli/__init__.py
@@ -1,3 +1,3 @@
 """Doc-Serve CLI - Command-line interface for managing Doc-Serve server."""
 
-__version__ = "10.5.0"
+__version__ = "10.5.1"

--- a/agent-brain-cli/pyproject.toml
+++ b/agent-brain-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agent-brain-cli"
-version = "10.5.0"
+version = "10.5.1"
 description = "Agent Brain CLI - Command-line interface for managing AI agent memory and knowledge retrieval"
 authors = ["Spillwave Solutions"]
 readme = "README.md"

--- a/agent-brain-mcp/agent_brain_mcp/__init__.py
+++ b/agent-brain-mcp/agent_brain_mcp/__init__.py
@@ -4,4 +4,4 @@ See docs/plans/2026-05-28-mcp-uds-transport-design.md §4.2.
 v1 surface lands in Phase 4: 7 tools, 5 read-only resources, 6 prompts, stdio.
 """
 
-__version__ = "10.5.0"
+__version__ = "10.5.1"

--- a/agent-brain-mcp/pyproject.toml
+++ b/agent-brain-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agent-brain-ag-mcp"
-version = "10.5.0"
+version = "10.5.1"
 description = "Agent Brain MCP - Model Context Protocol server exposing Agent Brain as MCP tools, resources, and prompts"
 authors = ["Spillwave Solutions"]
 readme = "README.md"

--- a/agent-brain-plugin/.claude-plugin/plugin.json
+++ b/agent-brain-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-brain",
   "description": "Document search with hybrid BM25/semantic retrieval, GraphRAG knowledge graphs, and pluggable providers for Claude Code. Index documentation and code, then search using keyword matching, semantic similarity, graph relationships, or comprehensive multi-mode fusion.",
-  "version": "10.5.0",
+  "version": "10.5.1",
   "author": {
     "name": "Spillwave Solutions",
     "email": "rick@spillwave.com"

--- a/agent-brain-server/agent_brain_server/__init__.py
+++ b/agent-brain-server/agent_brain_server/__init__.py
@@ -1,3 +1,3 @@
 """Doc-Serve Server - RAG-based document indexing and query service."""
 
-__version__ = "10.5.0"
+__version__ = "10.5.1"

--- a/agent-brain-server/pyproject.toml
+++ b/agent-brain-server/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agent-brain-rag"
-version = "10.5.0"
+version = "10.5.1"
 description = "Agent Brain RAG - Intelligent document indexing and semantic search server that gives AI agents long-term memory"
 authors = ["Spillwave Solutions"]
 readme = "README.md"

--- a/agent-brain-uds/agent_brain_uds/__init__.py
+++ b/agent-brain-uds/agent_brain_uds/__init__.py
@@ -38,7 +38,7 @@ from .paths import (
 )
 from .permissions import validate_socket
 
-__version__ = "10.5.0"
+__version__ = "10.5.1"
 
 __all__ = [
     "BASE_URL",

--- a/agent-brain-uds/pyproject.toml
+++ b/agent-brain-uds/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agent-brain-uds"
-version = "10.5.0"
+version = "10.5.1"
 description = "Agent Brain UDS - Unix-domain-socket transport for Agent Brain (socket path resolution, permission validation, httpx UDS client factory)"
 authors = ["Spillwave Solutions"]
 readme = "README.md"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,13 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [10.5.1] - 2026-09-03
+
 ### Fixed
 
-- **CI no longer re-resolves torch/CUDA via `poetry lock` to install CLI/MCP against a local server** (`.github/workflows/pr-qa-gate.yml`, `publish-to-pypi.yml`, `e2e-nightly.yml`; `scripts/ci_install_from_local_wheels.sh`; addresses [#238](https://github.com/SpillwaveSolutions/agent-brain/issues/238), [#240](https://github.com/SpillwaveSolutions/agent-brain/issues/240)). The previous path-dep swap + `poetry lock` discarded the committed lock and re-derived the full tree from scratch — 87 of 95 minutes on the v10.5.0 publish, and the reason the E2E CLI nightly was cancelled at its 30-minute wall before any test ran. Install now uses the committed lock and overlays locally-built server/uds wheels (`pip install --force-reinstall --no-deps`).
+- **Split-AS JWKS verification no longer rejects Keycloak access tokens for a missing `nbf` claim** (`agent_brain_mcp/oauth/verifier.py`; closes [#218](https://github.com/SpillwaveSolutions/agent-brain/issues/218)). RFC 7519 marks `nbf` optional; Keycloak 26 access tokens omit it. `JwksTokenVerifier` (and `LocalRs256Verifier`) required the claim, so every JWT from a split-AS IdP failed signature-path verification regardless of `aud`/`iss`. `nbf` is still verified when present. Confirmed in CI against a live Keycloak 26.1 token: `aud=['http://localhost:8000', 'account']`, `iss` matches, `nbf=None`. All 7 Keycloak E2E tests pass, including `test_keycloak_jwt_accepted`, the tool-call dance, refresh, and the 403 scope boundary.
+- **CI no longer re-resolves torch/CUDA via `poetry lock` to install CLI/MCP against a local server** (`.github/workflows/pr-qa-gate.yml`, `publish-to-pypi.yml`, `e2e-nightly.yml`; `scripts/ci_install_from_local_wheels.sh`; closes [#238](https://github.com/SpillwaveSolutions/agent-brain/issues/238), [#240](https://github.com/SpillwaveSolutions/agent-brain/issues/240)). The previous path-dep swap + `poetry lock` discarded the committed lock and re-derived the full tree from scratch — 87 of 95 minutes on the v10.5.0 publish, and the reason the E2E CLI nightly was cancelled at its 30-minute wall before any test ran. Install now uses the committed lock and overlays locally-built server/uds wheels (`pip install --force-reinstall --no-deps`).
 - **`mcp:install` / `cli:install` restore PyPI pins on any exit**, not just a clean finish (`agent-brain-mcp/Taskfile.yml`, `agent-brain-cli/Taskfile.yml`; [#238](https://github.com/SpillwaveSolutions/agent-brain/issues/238)). An interrupted `poetry install` previously left `path = "../agent-brain-server"` in a tracked `pyproject.toml`.
 - **`before-push` lock guard now covers mcp and uds locks**, and fails if a runtime `path =` pin is present (`scripts/before_push_lock_guard.sh`, `scripts/check_no_runtime_path_deps.sh`; [#238](https://github.com/SpillwaveSolutions/agent-brain/issues/238)).
 - **E2E CLI nightly is `workflow_dispatch` only** (`.github/workflows/e2e-nightly.yml`; [#240](https://github.com/SpillwaveSolutions/agent-brain/issues/240)). The Keycloak nightly stays on the schedule. Supported full-suite path: `./e2e-cli/run.sh`.
-- **Keycloak-in-CI OAuth E2E now passes end-to-end** (`agent_brain_mcp/oauth/verifier.py`; closes [#218](https://github.com/SpillwaveSolutions/agent-brain/issues/218)). Confirmed against a live Keycloak 26.1 token: `aud=['http://localhost:8000', 'account']`, `iss` matches, `nbf=None`. The coverage-gate pytest marker filter now also excludes `e2e_http` (it is not a subset of `e2e`), matching `pyproject.toml` addopts.
+- **OAuth coverage-gate marker filter now excludes `e2e_http`** (`.github/workflows/mcp-keycloak-integration.yml`). `e2e_http` is a separate marker from `e2e`; the previous override of `addopts` leaked a stale v1-surface HTTP smoke into the 90% oauth coverage job.
 
 ---
 


### PR DESCRIPTION
## Summary

Patch release for the work already on main after v10.5.0.

- Split-AS JWKS verification no longer requires optional `nbf` (closes #218). Keycloak 26 omits it; confirmed in CI against a live token.
- CI installs CLI/MCP from the committed lock and overlays local wheels instead of `poetry lock` (closes #238, #240).
- E2E CLI nightly is dispatch-only.

Versions: all four packages + plugin.json + marketplace plugin entry → 10.5.1. Cross-package pins stay `^10.4.0`.

## Test plan

- [ ] PR QA Gate green; server/CLI versions aligned at 10.5.1
- [ ] After merge: tag `v10.5.1`, GitHub release (triggers PyPI)
- [ ] Confirm all four packages at 10.5.1 on PyPI JSON API