### PR TITLE
feat(plugin): multi-host packaging — Cursor, Grok Build, Agent Plugins 1.0

### DIFF
--- a/.claude/commands/ag-brain-release.md
+++ b/.claude/commands/ag-brain-release.md
@@ -43,7 +43,7 @@ Execute a versioned release with these steps:
 
 1. Calculate new version from current + bump type (also used by pre-release check #5)
 2. Flip CLI dependency to PyPI if path-based
-3. Update version in 9 files:
+3. Update version in these files (the CI script `scripts/check_plugin_manifest_versions.sh` is the checklist):
    - `agent-brain-server/pyproject.toml`
    - `agent-brain-server/agent_brain_server/__init__.py`
    - `agent-brain-cli/pyproject.toml`
@@ -52,7 +52,12 @@ Execute a versioned release with these steps:
    - `agent-brain-uds/agent_brain_uds/__init__.py`
    - `agent-brain-mcp/pyproject.toml`
    - `agent-brain-mcp/agent_brain_mcp/__init__.py`
-   - `agent-brain-plugin/.claude-plugin/plugin.json` (top-level `"version"` field — must match CLI/server)
+   - `agent-brain-plugin/.claude-plugin/plugin.json`
+   - `.claude-plugin/marketplace.json` (`plugins[0].version`)
+   - `agent-brain-plugin/plugin.json` (Agent Plugins 1.0)
+   - `agent-brain-plugin/.codex-plugin/plugin.json`
+   - `agent-brain-plugin/.cursor-plugin/plugin.json`
+   - `agent-brain-plugin/.grok-plugin/marketplace.json` (top-level + `plugins[0].version`)
 4. Commit: `chore(release): bump version to X.Y.Z`
 5. Tag: `vX.Y.Z`
 6. Push branch and tag

--- a/.github/workflows/pr-qa-gate.yml
+++ b/.github/workflows/pr-qa-gate.yml
@@ -138,19 +138,7 @@ jobs:
         run: task typecheck
 
       - name: Check server/CLI version alignment
-        run: |
-          SERVER_VERSION=$(grep '^version = ' agent-brain-server/pyproject.toml | cut -d'"' -f2)
-          CLI_VERSION=$(grep '^version = ' agent-brain-cli/pyproject.toml | cut -d'"' -f2)
-
-          echo "Server version: $SERVER_VERSION"
-          echo "CLI version: $CLI_VERSION"
-
-          if [ "$SERVER_VERSION" != "$CLI_VERSION" ]; then
-            echo "ERROR: Server and CLI versions must match"
-            echo "Server: $SERVER_VERSION, CLI: $CLI_VERSION"
-            exit 1
-          fi
-          echo "✓ Versions aligned: $SERVER_VERSION"
+        run: ./scripts/check_plugin_manifest_versions.sh
 
       - name: Run tests with coverage (Server)
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,6 +250,8 @@ Transport is selectable via the global `--transport {auto,http,uds,mcp}` flag (o
 | `agent-brain install-agent --agent claude` | Install for Claude Code |
 | `agent-brain install-agent --agent opencode` | Install for OpenCode |
 | `agent-brain install-agent --agent codex` | Install for Codex (+ AGENTS.md) |
+| `agent-brain install-agent --agent cursor` | Install for Cursor |
+| `agent-brain install-agent --agent grok` | Install for Grok Build |
 | `agent-brain install-agent --agent skill-runtime --dir <path>` | Install for any skill-based runtime |
 | `agent-brain install-agent --agent <runtime> --dry-run` | Preview installation |
 | `agent-brain install-agent --agent <runtime> --global` | Install globally |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -206,6 +206,7 @@ tasks:
       - defer: ./scripts/before_push_lock_guard.sh check
       - ./scripts/before_push_lock_guard.sh start
       - ./scripts/check_no_runtime_path_deps.sh
+      - ./scripts/check_plugin_manifest_versions.sh
       - echo "--- Formatting code ---"
       - task: format
       - echo "--- Linting code ---"

--- a/agent-brain-cli/agent_brain_cli/commands/install_agent.py
+++ b/agent-brain-cli/agent_brain_cli/commands/install_agent.py
@@ -12,10 +12,14 @@ from rich.panel import Panel
 
 from agent_brain_cli.runtime.claude_converter import ClaudeConverter
 from agent_brain_cli.runtime.codex_converter import CodexConverter
+from agent_brain_cli.runtime.cursor_converter import CursorConverter
+from agent_brain_cli.runtime.grok_converter import GrokConverter
 from agent_brain_cli.runtime.mcp_registration import (
     McpRegistrationResult,
     register_claude_mcp,
     register_codex_mcp,
+    register_cursor_mcp,
+    register_grok_mcp,
     register_opencode_mcp,
 )
 from agent_brain_cli.runtime.opencode_converter import OpenCodeConverter
@@ -39,13 +43,26 @@ INSTALL_DIRS: dict[str, dict[str, str]] = {
         "project": ".codex/skills/agent-brain",
         "global": "~/.codex/skills/agent-brain",
     },
+    "cursor": {
+        "project": ".cursor/plugins/agent-brain",
+        "global": "~/.cursor/plugins/agent-brain",
+    },
+    "grok": {
+        "project": ".grok/plugins/agent-brain",
+        "global": "~/.grok/plugins/agent-brain",
+    },
 }
 
 # Runtimes that require --dir (no default directory)
 DIR_REQUIRED_RUNTIMES = {"skill-runtime"}
 
 ConverterType = type[
-    ClaudeConverter | OpenCodeConverter | SkillRuntimeConverter | CodexConverter
+    ClaudeConverter
+    | OpenCodeConverter
+    | SkillRuntimeConverter
+    | CodexConverter
+    | CursorConverter
+    | GrokConverter
 ]
 
 CONVERTERS: dict[str, ConverterType] = {
@@ -53,6 +70,8 @@ CONVERTERS: dict[str, ConverterType] = {
     "opencode": OpenCodeConverter,
     "skill-runtime": SkillRuntimeConverter,
     "codex": CodexConverter,
+    "cursor": CursorConverter,
+    "grok": GrokConverter,
 }
 
 
@@ -92,7 +111,14 @@ def _resolve_target_dir(
     return project_root / dir_template
 
 
-RUNTIME_CHOICES = ["claude", "opencode", "skill-runtime", "codex"]
+RUNTIME_CHOICES = [
+    "claude",
+    "opencode",
+    "skill-runtime",
+    "codex",
+    "cursor",
+    "grok",
+]
 
 # Runtimes for which we can auto-register the MCP server today, mapped to the
 # writer that knows that runtime's config schema. All writers share the
@@ -101,6 +127,8 @@ MCP_REGISTRARS: dict[str, Callable[..., McpRegistrationResult]] = {
     "claude": register_claude_mcp,
     "opencode": register_opencode_mcp,
     "codex": register_codex_mcp,
+    "cursor": register_cursor_mcp,
+    "grok": register_grok_mcp,
 }
 
 
@@ -124,6 +152,8 @@ def _resolve_mcp_paths(
     * **codex** — always ``$CODEX_HOME/config.toml`` (default
       ``~/.codex/config.toml``); Codex has no project-level MCP config, so the
       file is shared and the project's ``.agent-brain`` is pinned via the entry.
+    * **cursor** — project ``.cursor/mcp.json``, global ``~/.cursor/mcp.json``.
+    * **grok** — same files as Claude (Grok Build loads Claude plugins).
     """
     root = project_root if project_root is not None else Path.cwd()
     if agent == "opencode":
@@ -136,7 +166,11 @@ def _resolve_mcp_paths(
             Path.home() / ".agent-brain" if scope == "global" else root / ".agent-brain"
         )
         return _codex_config_path(), state_dir
-    # claude (and any future mcpServers-style runtime)
+    if agent == "cursor":
+        if scope == "global":
+            return Path.home() / ".cursor" / "mcp.json", Path.home() / ".agent-brain"
+        return root / ".cursor" / "mcp.json", root / ".agent-brain"
+    # claude, grok, and any future mcpServers-style runtime
     if scope == "global":
         return Path.home() / ".claude.json", Path.home() / ".agent-brain"
     return root / ".mcp.json", root / ".agent-brain"
@@ -229,7 +263,8 @@ def _register_mcp(
 @click.option(
     "--with-mcp",
     is_flag=True,
-    help="Also register the agent-brain MCP server (Claude Code, OpenCode, Codex)",
+    help="Also register the agent-brain MCP server "
+    "(Claude Code, OpenCode, Codex, Cursor, Grok)",
 )
 @click.option(
     "--mcp-auth",
@@ -386,7 +421,12 @@ def install_agent_command(
 
 def _handle_dry_run(
     converter: (
-        ClaudeConverter | OpenCodeConverter | SkillRuntimeConverter | CodexConverter
+        ClaudeConverter
+        | OpenCodeConverter
+        | SkillRuntimeConverter
+        | CodexConverter
+        | CursorConverter
+        | GrokConverter
     ),
     bundle: Any,
     target: Path,

--- a/agent-brain-cli/agent_brain_cli/runtime/cursor_converter.py
+++ b/agent-brain-cli/agent_brain_cli/runtime/cursor_converter.py
@@ -1,0 +1,49 @@
+"""Cursor runtime converter.
+
+Cursor consumes the same commands/skills layout as Claude Code, plus a
+``.cursor-plugin/plugin.json`` that points at those directories. Grok-style
+Agent Plugins 1.0 files (``plugin.json``, ``mcp.json``) are copied through
+when present so a Cursor install is also a valid universal plugin.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from agent_brain_cli.runtime.claude_converter import ClaudeConverter
+from agent_brain_cli.runtime.types import PluginBundle, RuntimeType, Scope
+
+
+def _copy_rel(source: Path, target: Path, rel: str, created: list[Path]) -> None:
+    src = source / rel
+    if not src.is_file():
+        return
+    dest = target / rel
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dest)
+    created.append(dest)
+
+
+class CursorConverter(ClaudeConverter):
+    """Converter for Cursor (Claude layout + Cursor/universal manifests)."""
+
+    @property
+    def runtime_type(self) -> RuntimeType:
+        return RuntimeType.CURSOR
+
+    def install(
+        self,
+        bundle: PluginBundle,
+        target_dir: Path,
+        scope: Scope,
+    ) -> list[Path]:
+        created = super().install(bundle, target_dir, scope)
+        source = Path(bundle.source_dir)
+        for rel in (
+            ".cursor-plugin/plugin.json",
+            "plugin.json",
+            "mcp.json",
+        ):
+            _copy_rel(source, target_dir, rel, created)
+        return created

--- a/agent-brain-cli/agent_brain_cli/runtime/grok_converter.py
+++ b/agent-brain-cli/agent_brain_cli/runtime/grok_converter.py
@@ -1,0 +1,38 @@
+"""Grok Build runtime converter.
+
+Grok Build loads Claude Code plugins with zero config, so the payload is the
+Claude layout plus ``.grok-plugin/marketplace.json`` for native marketplace
+identity. Universal Agent Plugins 1.0 files are copied through when present.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_brain_cli.runtime.claude_converter import ClaudeConverter
+from agent_brain_cli.runtime.cursor_converter import _copy_rel
+from agent_brain_cli.runtime.types import PluginBundle, RuntimeType, Scope
+
+
+class GrokConverter(ClaudeConverter):
+    """Converter for Grok Build (Claude-compatible + Grok marketplace)."""
+
+    @property
+    def runtime_type(self) -> RuntimeType:
+        return RuntimeType.GROK
+
+    def install(
+        self,
+        bundle: PluginBundle,
+        target_dir: Path,
+        scope: Scope,
+    ) -> list[Path]:
+        created = super().install(bundle, target_dir, scope)
+        source = Path(bundle.source_dir)
+        for rel in (
+            ".grok-plugin/marketplace.json",
+            "plugin.json",
+            "mcp.json",
+        ):
+            _copy_rel(source, target_dir, rel, created)
+        return created

--- a/agent-brain-cli/agent_brain_cli/runtime/mcp_registration.py
+++ b/agent-brain-cli/agent_brain_cli/runtime/mcp_registration.py
@@ -314,3 +314,47 @@ def register_codex_mcp(
         server_name=MCP_SERVER_NAME,
         entry=entry,
     )
+
+
+def register_cursor_mcp(
+    config_path: Path,
+    state_dir: Path,
+    *,
+    backend: str = "auto",
+    auth: str = "none",
+    dry_run: bool = False,
+) -> McpRegistrationResult:
+    """Merge the Agent Brain MCP entry into a Cursor ``mcp.json`` file.
+
+    Cursor uses the same ``mcpServers`` JSON shape as Claude Code; only the
+    on-disk path differs (``.cursor/mcp.json`` / ``~/.cursor/mcp.json``).
+    """
+    return register_claude_mcp(
+        config_path,
+        state_dir,
+        backend=backend,
+        auth=auth,
+        dry_run=dry_run,
+    )
+
+
+def register_grok_mcp(
+    config_path: Path,
+    state_dir: Path,
+    *,
+    backend: str = "auto",
+    auth: str = "none",
+    dry_run: bool = False,
+) -> McpRegistrationResult:
+    """Merge the Agent Brain MCP entry for Grok Build.
+
+    Grok Build loads Claude plugins with zero config, so registration uses
+    the Claude Code ``mcpServers`` file (``.mcp.json`` / ``~/.claude.json``).
+    """
+    return register_claude_mcp(
+        config_path,
+        state_dir,
+        backend=backend,
+        auth=auth,
+        dry_run=dry_run,
+    )

--- a/agent-brain-cli/agent_brain_cli/runtime/tool_maps.py
+++ b/agent-brain-cli/agent_brain_cli/runtime/tool_maps.py
@@ -40,6 +40,8 @@ OPENCODE_TOOLS: dict[str, str] = {
 TOOL_MAPS: dict[str, dict[str, str]] = {
     "claude": CLAUDE_TOOLS,
     "opencode": OPENCODE_TOOLS,
+    "cursor": CLAUDE_TOOLS,
+    "grok": CLAUDE_TOOLS,
 }
 
 

--- a/agent-brain-cli/agent_brain_cli/runtime/types.py
+++ b/agent-brain-cli/agent_brain_cli/runtime/types.py
@@ -11,6 +11,8 @@ class RuntimeType(str, Enum):
     OPENCODE = "opencode"
     SKILL_RUNTIME = "skill-runtime"
     CODEX = "codex"
+    CURSOR = "cursor"
+    GROK = "grok"
 
 
 class Scope(str, Enum):

--- a/agent-brain-cli/tests/test_cursor_converter.py
+++ b/agent-brain-cli/tests/test_cursor_converter.py
@@ -1,0 +1,69 @@
+"""Tests for the Cursor runtime converter."""
+
+from pathlib import Path
+
+from agent_brain_cli.runtime.cursor_converter import CursorConverter
+from agent_brain_cli.runtime.parser import parse_plugin_dir
+from agent_brain_cli.runtime.types import RuntimeType, Scope
+
+_CURSOR_PLUGIN = (
+    '{"name": "agent-brain", "version": "1.0.0",'
+    ' "skills": "skills/", "commands": "commands/"}'
+)
+_UNIVERSAL_PLUGIN = (
+    '{"$schema": "https://agent-plugins.org/schemas/1.0.0/'
+    'plugin.schema.json", "name": "agent-brain"}'
+)
+_MCP = (
+    '{"$schema": "https://agent-plugins.org/schemas/1.0.0/'
+    'mcp.schema.json", "mcpServers": {}}'
+)
+
+
+def _plugin_dir(tmp_path: Path) -> Path:
+    root = tmp_path / "plugin"
+    (root / ".claude-plugin").mkdir(parents=True)
+    (root / ".claude-plugin" / "plugin.json").write_text(
+        '{"name": "agent-brain", "version": "1.0.0"}'
+    )
+    (root / ".cursor-plugin").mkdir()
+    (root / ".cursor-plugin" / "plugin.json").write_text(_CURSOR_PLUGIN)
+    (root / "plugin.json").write_text(_UNIVERSAL_PLUGIN)
+    (root / "mcp.json").write_text(_MCP)
+    cmds = root / "commands"
+    cmds.mkdir()
+    (cmds / "agent-brain-search.md").write_text(
+        "---\nname: agent-brain-search\n"
+        "description: Search docs\nparameters: []\nskills: []\n"
+        "---\nSearch in .claude/agent-brain/data."
+    )
+    skills = root / "skills" / "using-agent-brain"
+    skills.mkdir(parents=True)
+    (skills / "SKILL.md").write_text(
+        "---\nname: using-agent-brain\n"
+        "description: Search skill\n"
+        "allowed-tools:\n  - Bash\n"
+        "---\nSkill body."
+    )
+    return root
+
+
+class TestCursorConverter:
+    def test_runtime_type(self) -> None:
+        assert CursorConverter().runtime_type is RuntimeType.CURSOR
+
+    def test_install_creates_cursor_layout(self, tmp_path: Path) -> None:
+        source = _plugin_dir(tmp_path)
+        bundle = parse_plugin_dir(source)
+        target = tmp_path / ".cursor" / "plugins" / "agent-brain"
+        created = CursorConverter().install(bundle, target, Scope.PROJECT)
+
+        assert (target / "commands" / "agent-brain-search.md").exists()
+        assert (target / "skills" / "using-agent-brain" / "SKILL.md").exists()
+        assert (target / ".cursor-plugin" / "plugin.json").exists()
+        assert (target / "plugin.json").exists()
+        assert (target / "mcp.json").exists()
+        content = (target / "commands" / "agent-brain-search.md").read_text()
+        assert ".agent-brain" in content
+        assert ".claude/agent-brain" not in content
+        assert any(p.name == "plugin.json" for p in created)

--- a/agent-brain-cli/tests/test_grok_converter.py
+++ b/agent-brain-cli/tests/test_grok_converter.py
@@ -1,0 +1,52 @@
+"""Tests for the Grok Build runtime converter."""
+
+from pathlib import Path
+
+from agent_brain_cli.runtime.grok_converter import GrokConverter
+from agent_brain_cli.runtime.parser import parse_plugin_dir
+from agent_brain_cli.runtime.types import RuntimeType, Scope
+
+_UNIVERSAL_PLUGIN = (
+    '{"$schema": "https://agent-plugins.org/schemas/1.0.0/'
+    'plugin.schema.json", "name": "agent-brain"}'
+)
+
+
+def _plugin_dir(tmp_path: Path) -> Path:
+    root = tmp_path / "plugin"
+    (root / ".claude-plugin").mkdir(parents=True)
+    (root / ".claude-plugin" / "plugin.json").write_text(
+        '{"name": "agent-brain", "version": "1.0.0"}'
+    )
+    (root / ".grok-plugin").mkdir()
+    (root / ".grok-plugin" / "marketplace.json").write_text(
+        '{"name": "agent-brain-marketplace",'
+        ' "version": "1.0.0", "plugins": []}'
+    )
+    (root / "plugin.json").write_text(_UNIVERSAL_PLUGIN)
+    cmds = root / "commands"
+    cmds.mkdir()
+    (cmds / "agent-brain-search.md").write_text(
+        "---\nname: agent-brain-search\n"
+        "description: Search docs\nparameters: []\nskills: []\n"
+        "---\nSearch in .claude/agent-brain/data."
+    )
+    return root
+
+
+class TestGrokConverter:
+    def test_runtime_type(self) -> None:
+        assert GrokConverter().runtime_type is RuntimeType.GROK
+
+    def test_install_creates_grok_layout(self, tmp_path: Path) -> None:
+        source = _plugin_dir(tmp_path)
+        bundle = parse_plugin_dir(source)
+        target = tmp_path / ".grok" / "plugins" / "agent-brain"
+        GrokConverter().install(bundle, target, Scope.PROJECT)
+
+        assert (target / "commands" / "agent-brain-search.md").exists()
+        assert (target / ".claude-plugin" / "plugin.json").exists()
+        assert (target / ".grok-plugin" / "marketplace.json").exists()
+        assert (target / "plugin.json").exists()
+        content = (target / "commands" / "agent-brain-search.md").read_text()
+        assert ".claude/agent-brain" not in content

--- a/agent-brain-cli/tests/test_install_agent.py
+++ b/agent-brain-cli/tests/test_install_agent.py
@@ -192,6 +192,42 @@ class TestInstallAgentCommand:
         assert ".agent-brain" in content
         assert ".claude/agent-brain" not in content
 
+    def test_cursor_project_install(
+        self, runner: CliRunner, plugin_dir: Path, tmp_path: Path
+    ) -> None:
+        result = runner.invoke(
+            install_agent_command,
+            [
+                "--agent",
+                "cursor",
+                "--plugin-dir",
+                str(plugin_dir),
+                "--path",
+                str(tmp_path),
+            ],
+        )
+        assert result.exit_code == 0
+        target = tmp_path / ".cursor" / "plugins" / "agent-brain"
+        assert (target / "commands" / "agent-brain-search.md").exists()
+
+    def test_grok_project_install(
+        self, runner: CliRunner, plugin_dir: Path, tmp_path: Path
+    ) -> None:
+        result = runner.invoke(
+            install_agent_command,
+            [
+                "--agent",
+                "grok",
+                "--plugin-dir",
+                str(plugin_dir),
+                "--path",
+                str(tmp_path),
+            ],
+        )
+        assert result.exit_code == 0
+        target = tmp_path / ".grok" / "plugins" / "agent-brain"
+        assert (target / "commands" / "agent-brain-search.md").exists()
+
 
 class TestInstallAgentCLIIntegration:
     """Integration tests via the main CLI entry point."""

--- a/agent-brain-cli/tests/test_install_agent_mcp.py
+++ b/agent-brain-cli/tests/test_install_agent_mcp.py
@@ -121,6 +121,49 @@ class TestInstallAgentWithMcp:
         assert not (tmp_path / "opencode.json").exists()
         assert "mcp" in result.output.lower()
 
+    def test_with_mcp_writes_cursor_mcp_json(
+        self, runner: CliRunner, plugin_dir: Path, tmp_path: Path
+    ) -> None:
+        result = runner.invoke(
+            install_agent_command,
+            [
+                "--agent",
+                "cursor",
+                "--plugin-dir",
+                str(plugin_dir),
+                "--path",
+                str(tmp_path),
+                "--with-mcp",
+            ],
+        )
+        assert result.exit_code == 0
+        config = tmp_path / ".cursor" / "mcp.json"
+        assert config.exists()
+        data = json.loads(config.read_text())
+        assert data["mcpServers"]["agent-brain"]["command"] == "agent-brain-mcp"
+        assert not (tmp_path / ".mcp.json").exists()
+
+    def test_with_mcp_grok_uses_claude_mcp_json(
+        self, runner: CliRunner, plugin_dir: Path, tmp_path: Path
+    ) -> None:
+        result = runner.invoke(
+            install_agent_command,
+            [
+                "--agent",
+                "grok",
+                "--plugin-dir",
+                str(plugin_dir),
+                "--path",
+                str(tmp_path),
+                "--with-mcp",
+            ],
+        )
+        assert result.exit_code == 0
+        config = tmp_path / ".mcp.json"
+        assert config.exists()
+        data = json.loads(config.read_text())
+        assert data["mcpServers"]["agent-brain"]["command"] == "agent-brain-mcp"
+
 
 class TestInstallAgentOpenCodeWithMcp:
     """OpenCode auto-registration writes the project-root `opencode.json`."""

--- a/agent-brain-cli/tests/test_plugin_manifest_versions.py
+++ b/agent-brain-cli/tests/test_plugin_manifest_versions.py
@@ -1,0 +1,50 @@
+"""Guard: every plugin/marketplace manifest reports the server version."""
+
+import json
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _server_version() -> str:
+    pyproject = REPO_ROOT / "agent-brain-server" / "pyproject.toml"
+    for line in pyproject.read_text().splitlines():
+        if line.startswith("version = "):
+            return line.split('"')[1]
+    raise AssertionError("server version not found")
+
+
+class TestPluginManifestVersions:
+    def test_all_manifests_match_server(self) -> None:
+        expected = _server_version()
+        plugin = REPO_ROOT / "agent-brain-plugin"
+        paths = [
+            plugin / ".claude-plugin" / "plugin.json",
+            plugin / "plugin.json",
+            plugin / ".codex-plugin" / "plugin.json",
+            plugin / ".cursor-plugin" / "plugin.json",
+        ]
+        for path in paths:
+            data = json.loads(path.read_text())
+            assert data["version"] == expected, path
+
+        market_path = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+        market = json.loads(market_path.read_text())
+        assert market["plugins"][0]["version"] == expected
+
+        grok_path = plugin / ".grok-plugin" / "marketplace.json"
+        grok = json.loads(grok_path.read_text())
+        assert grok["version"] == expected
+        assert grok["plugins"][0]["version"] == expected
+
+    def test_check_script_exits_zero(self) -> None:
+        script = REPO_ROOT / "scripts" / "check_plugin_manifest_versions.sh"
+        result = subprocess.run(
+            [str(script)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr

--- a/agent-brain-plugin/.codex-plugin/plugin.json
+++ b/agent-brain-plugin/.codex-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "agent-brain",
+  "version": "10.5.1",
+  "description": "Local-first RAG memory for AI agents: hybrid BM25/semantic search, GraphRAG, and an MCP server with OAuth 2.1.",
+  "author": {
+    "name": "Spillwave Solutions",
+    "url": "https://github.com/SpillwaveSolutions"
+  },
+  "homepage": "https://github.com/SpillwaveSolutions/agent-brain",
+  "repository": "https://github.com/SpillwaveSolutions/agent-brain",
+  "license": "MIT",
+  "keywords": [
+    "rag",
+    "mcp",
+    "graphrag",
+    "codex",
+    "agent-skills"
+  ]
+}

--- a/agent-brain-plugin/.cursor-plugin/plugin.json
+++ b/agent-brain-plugin/.cursor-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "agent-brain",
+  "version": "10.5.1",
+  "description": "Local-first RAG memory for AI agents: hybrid BM25/semantic search, GraphRAG, and an MCP server with OAuth 2.1.",
+  "author": {
+    "name": "Spillwave Solutions"
+  },
+  "homepage": "https://github.com/SpillwaveSolutions/agent-brain",
+  "repository": "https://github.com/SpillwaveSolutions/agent-brain",
+  "license": "MIT",
+  "keywords": [
+    "rag",
+    "mcp",
+    "graphrag",
+    "cursor"
+  ],
+  "skills": "skills/",
+  "commands": "commands/"
+}

--- a/agent-brain-plugin/.grok-plugin/marketplace.json
+++ b/agent-brain-plugin/.grok-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "agent-brain-marketplace",
+  "description": "Optional native Grok marketplace metadata. Grok Build already loads Claude plugins with zero config. This file pins identity for Grok marketplace listings.",
+  "version": "10.5.1",
+  "plugins": [
+    {
+      "name": "agent-brain",
+      "source": ".",
+      "description": "Local-first RAG memory for AI agents: hybrid BM25/semantic search, GraphRAG, MCP with OAuth 2.1. Claude-compatible.",
+      "version": "10.5.1",
+      "compatibility": {
+        "claude_plugin": true,
+        "zero_config": true
+      },
+      "repository": "https://github.com/SpillwaveSolutions/agent-brain"
+    }
+  ]
+}

--- a/agent-brain-plugin/README.md
+++ b/agent-brain-plugin/README.md
@@ -1,6 +1,6 @@
 # Agent Brain Plugin
 
-A Claude Code plugin for document search with hybrid BM25/semantic retrieval. Index your documentation and source code, then search using keyword matching, semantic similarity, or combined hybrid mode.
+A multi-host plugin for document search with hybrid BM25/semantic retrieval. Index your documentation and source code, then search using keyword matching, semantic similarity, or combined hybrid mode. Installs natively in Claude Code, OpenCode, Codex, Cursor, and Grok Build; a conforming Agent Plugins 1.0 client can consume `plugin.json` + `skills/` + `mcp.json`.
 
 ## Features
 

--- a/agent-brain-plugin/mcp.json
+++ b/agent-brain-plugin/mcp.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "agent-brain": {
+      "type": "stdio",
+      "command": "agent-brain-mcp",
+      "args": ["--backend", "auto"],
+      "env": {
+        "AGENT_BRAIN_STATE_DIR": "${PLUGIN_DATA}"
+      }
+    }
+  }
+}

--- a/agent-brain-plugin/plugin.json
+++ b/agent-brain-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "agent-brain",
+  "version": "10.5.1",
+  "description": "Local-first RAG memory for AI agents: hybrid BM25/semantic search, GraphRAG, and an MCP server with OAuth 2.1. Index docs and code, then search from Claude Code, Cursor, Codex, OpenCode, or Grok Build.",
+  "author": {
+    "name": "Spillwave Solutions",
+    "email": "rick@spillwave.com",
+    "url": "https://github.com/SpillwaveSolutions"
+  },
+  "homepage": "https://github.com/SpillwaveSolutions/agent-brain",
+  "repository": "https://github.com/SpillwaveSolutions/agent-brain",
+  "license": "MIT",
+  "keywords": [
+    "rag",
+    "mcp",
+    "graphrag",
+    "hybrid-search",
+    "agent-memory",
+    "claude-code",
+    "grok-build",
+    "codex",
+    "cursor",
+    "opencode",
+    "agent-plugins"
+  ]
+}

--- a/agent-brain-plugin/skills/configuring-agent-brain/SKILL.md
+++ b/agent-brain-plugin/skills/configuring-agent-brain/SKILL.md
@@ -48,6 +48,8 @@ Agent Brain supports multiple AI coding runtimes from a single canonical plugin 
 | Claude Code | `agent-brain install-agent --agent claude` |
 | OpenCode | `agent-brain install-agent --agent opencode` |
 | Codex (+ AGENTS.md) | `agent-brain install-agent --agent codex` |
+| Cursor | `agent-brain install-agent --agent cursor` |
+| Grok Build | `agent-brain install-agent --agent grok` |
 | Any skill runtime | `agent-brain install-agent --agent skill-runtime --dir <path>` |
 
 All runtimes share the same `.agent-brain/` data directory for indexes, configuration, and server state. The `install-agent` command converts the canonical plugin format into each runtime's native format automatically.
@@ -285,6 +287,12 @@ agent-brain install-agent --agent opencode --with-mcp
 # ...or for Codex (writes ~/.codex/config.toml, TOML [mcp_servers.agent-brain])
 agent-brain install-agent --agent codex --with-mcp
 
+# ...or for Cursor (writes .cursor/mcp.json)
+agent-brain install-agent --agent cursor --with-mcp
+
+# ...or for Grok Build (writes .mcp.json — Grok loads Claude plugins)
+agent-brain install-agent --agent grok --with-mcp
+
 # Preview without writing anything
 agent-brain install-agent --agent claude --with-mcp --dry-run
 
@@ -295,8 +303,9 @@ agent-brain install-agent --agent claude --with-mcp --mcp-auth oauth
 What `--with-mcp` does:
 - Writes/merges an `agent-brain` entry into the runtime's MCP config, **preserving any other
   MCP servers and keys** — Claude Code's `.mcp.json` / `~/.claude.json` (`mcpServers`), OpenCode's
-  project-root `opencode.json` / `~/.config/opencode/opencode.json` (`mcp`), or Codex's
-  `$CODEX_HOME/config.toml` (default `~/.codex/config.toml`, `[mcp_servers.agent-brain]` TOML).
+  project-root `opencode.json` / `~/.config/opencode/opencode.json` (`mcp`), Codex's
+  `$CODEX_HOME/config.toml` (default `~/.codex/config.toml`, `[mcp_servers.agent-brain]` TOML),
+  Cursor's `.cursor/mcp.json` / `~/.cursor/mcp.json`, or Grok Build's Claude path.
 - Pins `AGENT_BRAIN_STATE_DIR` to the project's absolute `.agent-brain` path so the
   server is discoverable regardless of the client's working directory.
 - Is **idempotent** — re-running reports `unchanged` when the entry already matches.
@@ -307,9 +316,10 @@ What `--with-mcp` does:
 | `--mcp-backend` | `auto`/`uds`/`http` | `auto` | How the MCP server reaches `agent-brain-serve` |
 | `--mcp-auth` | `none`/`oauth` | `none` | Write `AGENT_BRAIN_MCP_AUTH=oauth` for remote OAuth servers |
 
-> Auto-registration targets **Claude Code**, **OpenCode**, and **Codex**. For other MCP hosts,
+> Auto-registration targets **Claude Code**, **OpenCode**, **Codex**, **Cursor**, and **Grok Build**. For other MCP hosts,
 > register manually with the JSON block below (the flag will print a note and skip). Codex has no
-> project-level MCP config, so both scopes write the single user-level `config.toml`.
+> project-level MCP config, so both scopes write the single user-level `config.toml`. Conforming
+> Agent Plugins 1.0 clients also pick up `agent-brain-plugin/mcp.json` automatically.
 
 ### Configure an MCP client (manual)
 

--- a/agent-brain-plugin/skills/configuring-agent-brain/references/configuration-guide.md
+++ b/agent-brain-plugin/skills/configuring-agent-brain/references/configuration-guide.md
@@ -684,6 +684,8 @@ Install the Agent Brain plugin into different AI coding assistant runtimes:
 agent-brain install-agent --agent claude     # Claude Code
 agent-brain install-agent --agent opencode   # OpenCode
 agent-brain install-agent --agent codex      # Codex
+agent-brain install-agent --agent cursor     # Cursor
+agent-brain install-agent --agent grok       # Grok Build
 agent-brain install-agent --agent skill-runtime --dir /path  # Generic
 ```
 

--- a/agent-brain-plugin/skills/configuring-agent-brain/references/installation-guide.md
+++ b/agent-brain-plugin/skills/configuring-agent-brain/references/installation-guide.md
@@ -402,10 +402,14 @@ agent-brain install-agent --agent claude
 # Install for OpenCode
 agent-brain install-agent --agent opencode
 
-# Install for Gemini
-
 # Install for Codex (generates skill directories + AGENTS.md)
 agent-brain install-agent --agent codex
+
+# Install for Cursor
+agent-brain install-agent --agent cursor --with-mcp
+
+# Install for Grok Build
+agent-brain install-agent --agent grok --with-mcp
 
 # Install for any skill-based runtime (requires --dir)
 agent-brain install-agent --agent skill-runtime --dir /path/to/skills
@@ -414,7 +418,7 @@ agent-brain install-agent --agent skill-runtime --dir /path/to/skills
 agent-brain install-agent --agent claude --dry-run
 
 # Global (user-level) installation
-agent-brain install-agent --agent claude --scope global
+agent-brain install-agent --agent claude --global
 ```
 
 ### Supported Runtimes
@@ -423,8 +427,9 @@ agent-brain install-agent --agent claude --scope global
 |---------|-------------------|--------|
 | `claude` | `.claude/plugins/agent-brain` | Claude plugin |
 | `opencode` | `.opencode/plugins/agent-brain` | OpenCode plugin |
-| `gemini` | `.gemini/plugins/agent-brain` | Gemini plugin |
 | `codex` | `.codex/skills/agent-brain` | Skill dirs + AGENTS.md |
+| `cursor` | `.cursor/plugins/agent-brain` | Cursor plugin + Agent Plugins 1.0 |
+| `grok` | `.grok/plugins/agent-brain` | Claude-compatible + Grok marketplace |
 | `skill-runtime` | (requires `--dir`) | Generic skill dirs |
 
 ### Uninstalling

--- a/agent-brain-plugin/skills/configuring-agent-brain/references/mcp-setup-guide.md
+++ b/agent-brain-plugin/skills/configuring-agent-brain/references/mcp-setup-guide.md
@@ -15,12 +15,14 @@ path is `agent_brain_mcp`.
 
 ## 2. Register the server
 
-### Option A — through the plugin (Claude Code, OpenCode & Codex, recommended)
+### Option A — through the plugin (recommended)
 
 ```bash
 agent-brain install-agent --agent claude   --with-mcp     # → .mcp.json / ~/.claude.json
 agent-brain install-agent --agent opencode --with-mcp     # → opencode.json (project root)
 agent-brain install-agent --agent codex    --with-mcp     # → ~/.codex/config.toml (TOML)
+agent-brain install-agent --agent cursor   --with-mcp     # → .cursor/mcp.json
+agent-brain install-agent --agent grok     --with-mcp     # → .mcp.json (Grok loads Claude plugins)
 ```
 
 This writes/merges an `agent-brain` entry into the runtime's MCP config, preserving any other
@@ -32,6 +34,8 @@ pins `AGENT_BRAIN_STATE_DIR` to the project's absolute `.agent-brain` path.
 | `claude` | `.mcp.json` | `~/.claude.json` | `mcpServers` (`command` + `args` + `env`) |
 | `opencode` | `opencode.json` (project root) | `~/.config/opencode/opencode.json` | `mcp` (`type: local`, `command: [...]`, `environment`) |
 | `codex` | `$CODEX_HOME/config.toml` (default `~/.codex/config.toml`) | same file | `[mcp_servers.agent-brain]` TOML (`command` + `args` + `env`) |
+| `cursor` | `.cursor/mcp.json` | `~/.cursor/mcp.json` | `mcpServers` (same shape as Claude) |
+| `grok` | `.mcp.json` | `~/.claude.json` | `mcpServers` (Grok Build loads Claude plugins) |
 
 > **Codex note:** Codex has no project-level MCP config — servers live in the single user-level
 > `config.toml`, so both scopes write the same file. The project's `.agent-brain` is pinned in the
@@ -105,10 +109,11 @@ Current surface: **16 tools**, 5 `corpus://` resources, 6 prompts.
 
 ## 5. Other runtimes
 
-`install-agent --with-mcp` auto-registers for **Claude Code**, **OpenCode**, and **Codex** (see
+`install-agent --with-mcp` auto-registers for **Claude Code**, **OpenCode**, **Codex**, **Cursor**, and **Grok Build** (see
 the table in Option A for each runtime's config location and schema). For other MCP hosts (Claude
-Desktop, Cursor, Windsurf), register manually using the Option B JSON. The flag prints a note and
-skips for runtimes it can't register rather than failing.
+Desktop, Windsurf), register manually using the Option B JSON. The flag prints a note and
+skips for runtimes it can't register rather than failing. Conforming Agent Plugins 1.0 clients
+also pick up `agent-brain-plugin/mcp.json` automatically.
 
 > The `gemini` runtime has been removed (Google deprecated the Gemini CLI — see
 > [#231](https://github.com/SpillwaveSolutions/agent-brain/issues/231)).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Multi-host plugin packaging** (`agent-brain-plugin/`; `agent-brain-cli` converters; closes [#239](https://github.com/SpillwaveSolutions/agent-brain/issues/239)). One shared payload (`commands/`, `skills/`) now ships with thin per-host manifests so the plugin installs natively in Claude Code, OpenCode, Codex, Cursor, and Grok Build, and as an [Agent Plugins 1.0](https://agent-plugins.org/specification) payload:
+  - Universal `plugin.json` + `mcp.json` (stdio `agent-brain-mcp`, `AGENT_BRAIN_STATE_DIR=${PLUGIN_DATA}`) so a conforming host wires the MCP server on plugin install.
+  - `.cursor-plugin/plugin.json` (explicit `skills` / `commands` pointers), `.codex-plugin/plugin.json`, `.grok-plugin/marketplace.json`.
+  - `agent-brain install-agent --agent {cursor,grok}` installs the payload; `--with-mcp` writes `.cursor/mcp.json` (Cursor) or the Claude `.mcp.json` path (Grok).
+  - `scripts/check_plugin_manifest_versions.sh` is the CI/before-push guard that every package and plugin manifest reports the same version — the drift that left marketplace users on `2.0.0` cannot recur silently.
+
 ---
 
 ## [10.5.1] - 2026-09-03

--- a/docs/PLUGIN_GUIDE.md
+++ b/docs/PLUGIN_GUIDE.md
@@ -33,6 +33,17 @@ claude plugins marketplace add SpillwaveSolutions/agent-brain
 claude plugins install agent-brain@agent-brain-marketplace
 ```
 
+Other hosts, from a checkout or via the CLI:
+
+```bash
+agent-brain install-agent --agent cursor --with-mcp   # .cursor/plugins/agent-brain + .cursor/mcp.json
+agent-brain install-agent --agent grok --with-mcp     # .grok/plugins/agent-brain; MCP via .mcp.json
+agent-brain install-agent --agent opencode --with-mcp
+agent-brain install-agent --agent codex --with-mcp
+```
+
+A conforming [Agent Plugins 1.0](https://agent-plugins.org/specification) client can consume `agent-brain-plugin/plugin.json` + `skills/` + `mcp.json` directly.
+
 This provides:
 - **30 slash commands** for all operations
 - **3 intelligent agents** for complex tasks

--- a/scripts/check_plugin_manifest_versions.sh
+++ b/scripts/check_plugin_manifest_versions.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Fail if any plugin/marketplace manifest version drifts from the server
+# package version. Going from 1 manifest to 5+ (issue #239) multiplies the
+# failure mode that left marketplace users on 2.0.0 for years.
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT"
+
+EXPECTED="$(grep '^version = ' agent-brain-server/pyproject.toml | cut -d'"' -f2)"
+if [[ -z "$EXPECTED" ]]; then
+  echo "ERROR: could not read version from agent-brain-server/pyproject.toml" >&2
+  exit 1
+fi
+
+fail=0
+check_json() {
+  local path="$1"
+  local jq_expr="$2"
+  local label="${3:-$path}"
+  if [[ ! -f "$path" ]]; then
+    echo "ERROR: missing $label" >&2
+    fail=1
+    return
+  fi
+  local got
+  got="$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); v=$jq_expr; print(v)" "$path")"
+  if [[ "$got" != "$EXPECTED" ]]; then
+    echo "ERROR: $label is '$got'; expected '$EXPECTED'" >&2
+    fail=1
+  else
+    echo "ok $label = $got"
+  fi
+}
+
+check_toml_version() {
+  local path="$1"
+  local got
+  got="$(grep '^version = ' "$path" | cut -d'"' -f2)"
+  if [[ "$got" != "$EXPECTED" ]]; then
+    echo "ERROR: $path is '$got'; expected '$EXPECTED'" >&2
+    fail=1
+  else
+    echo "ok $path = $got"
+  fi
+}
+
+check_py_version() {
+  local path="$1"
+  local got
+  got="$(grep -E '^__version__ = ' "$path" | cut -d'"' -f2)"
+  if [[ "$got" != "$EXPECTED" ]]; then
+    echo "ERROR: $path is '$got'; expected '$EXPECTED'" >&2
+    fail=1
+  else
+    echo "ok $path = $got"
+  fi
+}
+
+check_toml_version agent-brain-cli/pyproject.toml
+check_toml_version agent-brain-uds/pyproject.toml
+check_toml_version agent-brain-mcp/pyproject.toml
+check_py_version agent-brain-server/agent_brain_server/__init__.py
+check_py_version agent-brain-cli/agent_brain_cli/__init__.py
+check_py_version agent-brain-uds/agent_brain_uds/__init__.py
+check_py_version agent-brain-mcp/agent_brain_mcp/__init__.py
+
+check_json agent-brain-plugin/.claude-plugin/plugin.json 'd["version"]'
+check_json .claude-plugin/marketplace.json 'd["plugins"][0]["version"]' ".claude-plugin/marketplace.json plugins[0].version"
+check_json agent-brain-plugin/plugin.json 'd["version"]'
+check_json agent-brain-plugin/.codex-plugin/plugin.json 'd["version"]'
+check_json agent-brain-plugin/.cursor-plugin/plugin.json 'd["version"]'
+check_json agent-brain-plugin/.grok-plugin/marketplace.json 'd["version"]' "agent-brain-plugin/.grok-plugin/marketplace.json version"
+check_json agent-brain-plugin/.grok-plugin/marketplace.json 'd["plugins"][0]["version"]' "agent-brain-plugin/.grok-plugin/marketplace.json plugins[0].version"
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "Plugin/package versions drifted from $EXPECTED" >&2
+  exit 1
+fi
+echo "✓ All package and plugin manifests are $EXPECTED"


### PR DESCRIPTION
## Summary

Closes #239. One shared payload (`commands/`, `skills/`) plus thin per-host manifests, matching the [imagen-diagrams](https://github.com/SpillwaveSolutions/imagen-diagrams) pattern.

**Manifests** in `agent-brain-plugin/`:
- `plugin.json` — Agent Plugins 1.0 universal
- `mcp.json` — stdio `agent-brain-mcp` with `AGENT_BRAIN_STATE_DIR=${PLUGIN_DATA}` so a conforming host wires MCP on install
- `.cursor-plugin/plugin.json` (explicit `skills` / `commands` pointers)
- `.codex-plugin/plugin.json`
- `.grok-plugin/marketplace.json`

**CLI**
- `install-agent --agent cursor` → `.cursor/plugins/agent-brain`
- `install-agent --agent grok` → `.grok/plugins/agent-brain` (Claude-compatible payload)
- `--with-mcp` writes `.cursor/mcp.json` (Cursor) or `.mcp.json` (Grok, same as Claude)

**Version-sync guard** (`scripts/check_plugin_manifest_versions.sh`) is the CI/before-push check and the release bump checklist. Marketplace users cannot silently sit on `2.0.0` again.

## Test plan

- [ ] `task before-push` / PR QA Gate green
- [ ] `scripts/check_plugin_manifest_versions.sh` exits 0
- [ ] `agent-brain install-agent --agent cursor --dry-run` and `--agent grok --dry-run`
- [ ] `--with-mcp` creates `.cursor/mcp.json` / `.mcp.json` respectively

Closes #239