### PR TITLE
chore(release): bump version to 10.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "agent-brain",
       "description": "Document search with hybrid BM25/semantic retrieval, GraphRAG knowledge graphs, and pluggable providers",
-      "version": "10.5.1",
+      "version": "10.6.0",
       "author": {
         "name": "Spillwave Solutions",
         "email": "support@spillwave.com"

--- a/agent-brain-cli/agent_brain_cli/__init__.py
+++ b/agent-brain-cli/agent_brain_cli/__init__.py
@@ -1,3 +1,3 @@
 """Doc-Serve CLI - Command-line interface for managing Doc-Serve server."""
 
-__version__ = "10.5.1"
+__version__ = "10.6.0"

--- a/agent-brain-cli/pyproject.toml
+++ b/agent-brain-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agent-brain-cli"
-version = "10.5.1"
+version = "10.6.0"
 description = "Agent Brain CLI - Command-line interface for managing AI agent memory and knowledge retrieval"
 authors = ["Spillwave Solutions"]
 readme = "README.md"

--- a/agent-brain-mcp/agent_brain_mcp/__init__.py
+++ b/agent-brain-mcp/agent_brain_mcp/__init__.py
@@ -4,4 +4,4 @@ See docs/plans/2026-05-28-mcp-uds-transport-design.md §4.2.
 v1 surface lands in Phase 4: 7 tools, 5 read-only resources, 6 prompts, stdio.
 """
 
-__version__ = "10.5.1"
+__version__ = "10.6.0"

--- a/agent-brain-mcp/pyproject.toml
+++ b/agent-brain-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agent-brain-ag-mcp"
-version = "10.5.1"
+version = "10.6.0"
 description = "Agent Brain MCP - Model Context Protocol server exposing Agent Brain as MCP tools, resources, and prompts"
 authors = ["Spillwave Solutions"]
 readme = "README.md"

--- a/agent-brain-plugin/.claude-plugin/plugin.json
+++ b/agent-brain-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-brain",
   "description": "Document search with hybrid BM25/semantic retrieval, GraphRAG knowledge graphs, and pluggable providers for Claude Code. Index documentation and code, then search using keyword matching, semantic similarity, graph relationships, or comprehensive multi-mode fusion.",
-  "version": "10.5.1",
+  "version": "10.6.0",
   "author": {
     "name": "Spillwave Solutions",
     "email": "rick@spillwave.com"

--- a/agent-brain-plugin/.codex-plugin/plugin.json
+++ b/agent-brain-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-brain",
-  "version": "10.5.1",
+  "version": "10.6.0",
   "description": "Local-first RAG memory for AI agents: hybrid BM25/semantic search, GraphRAG, and an MCP server with OAuth 2.1.",
   "author": {
     "name": "Spillwave Solutions",

--- a/agent-brain-plugin/.cursor-plugin/plugin.json
+++ b/agent-brain-plugin/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-brain",
-  "version": "10.5.1",
+  "version": "10.6.0",
   "description": "Local-first RAG memory for AI agents: hybrid BM25/semantic search, GraphRAG, and an MCP server with OAuth 2.1.",
   "author": {
     "name": "Spillwave Solutions"

--- a/agent-brain-plugin/.grok-plugin/marketplace.json
+++ b/agent-brain-plugin/.grok-plugin/marketplace.json
@@ -1,13 +1,13 @@
 {
   "name": "agent-brain-marketplace",
   "description": "Optional native Grok marketplace metadata. Grok Build already loads Claude plugins with zero config. This file pins identity for Grok marketplace listings.",
-  "version": "10.5.1",
+  "version": "10.6.0",
   "plugins": [
     {
       "name": "agent-brain",
       "source": ".",
       "description": "Local-first RAG memory for AI agents: hybrid BM25/semantic search, GraphRAG, MCP with OAuth 2.1. Claude-compatible.",
-      "version": "10.5.1",
+      "version": "10.6.0",
       "compatibility": {
         "claude_plugin": true,
         "zero_config": true

--- a/agent-brain-plugin/plugin.json
+++ b/agent-brain-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "agent-brain",
-  "version": "10.5.1",
+  "version": "10.6.0",
   "description": "Local-first RAG memory for AI agents: hybrid BM25/semantic search, GraphRAG, and an MCP server with OAuth 2.1. Index docs and code, then search from Claude Code, Cursor, Codex, OpenCode, or Grok Build.",
   "author": {
     "name": "Spillwave Solutions",

--- a/agent-brain-server/agent_brain_server/__init__.py
+++ b/agent-brain-server/agent_brain_server/__init__.py
@@ -1,3 +1,3 @@
 """Doc-Serve Server - RAG-based document indexing and query service."""
 
-__version__ = "10.5.1"
+__version__ = "10.6.0"

--- a/agent-brain-server/pyproject.toml
+++ b/agent-brain-server/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agent-brain-rag"
-version = "10.5.1"
+version = "10.6.0"
 description = "Agent Brain RAG - Intelligent document indexing and semantic search server that gives AI agents long-term memory"
 authors = ["Spillwave Solutions"]
 readme = "README.md"

--- a/agent-brain-uds/agent_brain_uds/__init__.py
+++ b/agent-brain-uds/agent_brain_uds/__init__.py
@@ -38,7 +38,7 @@ from .paths import (
 )
 from .permissions import validate_socket
 
-__version__ = "10.5.1"
+__version__ = "10.6.0"
 
 __all__ = [
     "BASE_URL",

--- a/agent-brain-uds/pyproject.toml
+++ b/agent-brain-uds/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agent-brain-uds"
-version = "10.5.1"
+version = "10.6.0"
 description = "Agent Brain UDS - Unix-domain-socket transport for Agent Brain (socket path resolution, permission validation, httpx UDS client factory)"
 authors = ["Spillwave Solutions"]
 readme = "README.md"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [10.6.0] - 2026-09-03
+
 ### Added
 
 - **Multi-host plugin packaging** (`agent-brain-plugin/`; `agent-brain-cli` converters; closes [#239](https://github.com/SpillwaveSolutions/agent-brain/issues/239)). One shared payload (`commands/`, `skills/`) now ships with thin per-host manifests so the plugin installs natively in Claude Code, OpenCode, Codex, Cursor, and Grok Build, and as an [Agent Plugins 1.0](https://agent-plugins.org/specification) payload:


### PR DESCRIPTION
## Summary

Minor release for multi-host plugin packaging (#239, merged in #243).

Versions: all four packages + Claude/Cursor/Codex/Grok/universal plugin manifests → 10.6.0. Cross-package pins stay \`^10.4.0\`.

## Test plan

- [ ] PR QA Gate green; \`scripts/check_plugin_manifest_versions.sh\` exits 0
- [ ] After merge: tag \`v10.6.0\`, GitHub release (triggers PyPI)
- [ ] Confirm all four packages at 10.6.0 on PyPI JSON API