### PR TITLE
feat(graph): POST /graph/project for pre-typed entity/relation projection

### DIFF
--- a/agent-brain-server/agent_brain_server/api/routers/graph.py
+++ b/agent-brain-server/agent_brain_server/api/routers/graph.py
@@ -23,28 +23,36 @@ Status codes (decision B in 50-CONTEXT.md):
   (issue #178); the server keeps running but graph lookup is offline
   until the operator switches to ``graphrag.store_type: simple`` or the
   Kuzu issue is fixed.
-- ``400 invalid_entity_type`` — ``entity_type`` is not one of the 17
-  SCHEMA-01 types. Response body includes the canonical ``valid_types``
-  list so callers can discover the vocabulary at runtime.
+- ``400 invalid_entity_type`` — ``entity_type`` is not a SCHEMA-01 type
+  and is not a namespaced ``prefix:Name`` (e.g. ``okf:Claim``). Response
+  body includes the canonical ``valid_types`` list (SCHEMA-01) so callers
+  can discover the built-in vocabulary; namespaced types are accepted in
+  addition to that list (#235).
 - ``404 entity_not_found`` — type is valid but no entity with that
   ``(type, id)`` exists in the graph.
 
-The valid type vocabulary is sourced from ``ENTITY_TYPES`` in
-``agent_brain_server.models.graph`` — the same Literal that the
-extraction pipeline validates against. Plan 03 deliberately does NOT
-keep a parallel list (SCHEMA-01 vocabulary drift risk noted in the plan).
+``POST /graph/project`` and ``DELETE /graph/project`` (#235) accept
+pre-typed entities/relations from an external projector. Writes run in
+the same out-of-process kuzu isolation as document indexing (#178).
 """
 
 from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 
 from agent_brain_server.api.security import verify_bearer_token
 from agent_brain_server.config.provider_config import load_provider_settings
 from agent_brain_server.config.settings import settings
-from agent_brain_server.models import ENTITY_TYPES, GraphEntityRecord
+from agent_brain_server.models import (
+    ENTITY_TYPES,
+    GraphEntityRecord,
+    GraphProjectRequest,
+    GraphProjectResponse,
+    is_valid_entity_type,
+)
+from agent_brain_server.models.graph import SOURCE_TAG_RE
 from agent_brain_server.storage.graph_store import (
     KuzuUnavailableError,
     get_graph_store_manager,
@@ -56,9 +64,10 @@ router = APIRouter(dependencies=[Depends(verify_bearer_token)])
 
 
 # Frozen at module import for predictable 400-body content. The 17 SCHEMA-01
-# entity types are stable for the v2 milestone; new types added in future
-# milestones will flip ``ENTITY_TYPES`` and this set together.
+# entity types are the built-in vocabulary; namespaced types (``okf:Claim``)
+# are accepted in addition via ``is_valid_entity_type``.
 _VALID_ENTITY_TYPES: frozenset[str] = frozenset(ENTITY_TYPES)
+
 
 
 def _graphrag_enabled() -> bool:
@@ -129,16 +138,23 @@ async def get_graph_entity(
         )
 
     # 400: unknown entity type. We do this BEFORE touching the graph store
-    # so a bogus type doesn't load the graph manager.
-    if entity_type not in _VALID_ENTITY_TYPES:
+    # so a bogus type doesn't load the graph manager. SCHEMA-01 plus
+    # namespaced ``prefix:Name`` (#235) are accepted; invented
+    # un-namespaced types still 400.
+    if not is_valid_entity_type(entity_type):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={
                 "error": "invalid_entity_type",
                 "type": entity_type,
                 "valid_types": sorted(_VALID_ENTITY_TYPES),
+                "hint": (
+                    "Namespaced types (prefix:Name, e.g. okf:Claim) are "
+                    "also accepted."
+                ),
             },
         )
+
 
     graph_mgr = get_graph_store_manager()
     # Lazy-initialize: in production the lifespan preflight runs for Kuzu,
@@ -202,3 +218,168 @@ async def get_graph_entity(
             },
         )
     return record
+
+
+def _graph_disabled_exc() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail={
+            "error": "graphrag_disabled",
+            "hint": (
+                "set graphrag.enabled = true in config to enable "
+                "graph-entity addressing"
+            ),
+        },
+    )
+
+
+def _kuzu_unavailable_exc() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail={
+            "error": "kuzu_unavailable",
+            "hint": (
+                "Kuzu graph store raised during projection (issue #178). "
+                "Set graphrag.store_type=simple in config until the "
+                "Kuzu fix lands."
+            ),
+        },
+    )
+
+
+
+@router.post(
+    "/project",
+    response_model=GraphProjectResponse,
+    summary="Project pre-typed entities and relations",
+    description=(
+        "Upsert explicit typed entities and relations into the property "
+        "graph with no LLM/AST extraction. Writes run in an out-of-process "
+        "spawn worker so a kuzu-native crash cannot take down the server "
+        "(#178). Pass ``replace=true`` to delete prior facts with the same "
+        "``source_tag`` first (deterministic rebuild)."
+    ),
+    responses={
+        200: {"description": "Projection applied; counts returned."},
+        400: {"description": "Invalid type, predicate, or relation endpoint."},
+        503: {
+            "description": (
+                "GraphRAG disabled, or isolated kuzu worker crashed (#178)."
+            )
+        },
+    },
+)
+async def project_graph(body: GraphProjectRequest) -> GraphProjectResponse:
+    """Accept pre-typed facts from an external projector (#235)."""
+    if not _graphrag_enabled():
+        raise _graph_disabled_exc()
+
+    payload_ids = {entity.id for entity in body.entities}
+    missing: list[str] = []
+    for rel in body.relations:
+        if rel.src not in payload_ids:
+            missing.append(rel.src)
+        if rel.dst not in payload_ids:
+            missing.append(rel.dst)
+    if missing:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": "unknown_relation_endpoint",
+                "missing_ids": sorted(set(missing)),
+                "hint": (
+                    "Every relation src/dst must match an entity id in "
+                    "the same request."
+                ),
+            },
+        )
+
+    entities = [
+        {
+            "type": entity.type,
+            "id": entity.id,
+            "properties": dict(entity.properties),
+        }
+        for entity in body.entities
+    ]
+    relations = [
+        {"src": rel.src, "predicate": rel.predicate, "dst": rel.dst}
+        for rel in body.relations
+    ]
+
+    try:
+        from agent_brain_server.indexing.graph_index import project_isolated
+        from agent_brain_server.storage.graph_errors import GraphBuildFailedError
+
+        counts = project_isolated(
+            entities,
+            relations,
+            body.source_tag,
+            replace=body.replace,
+        )
+    except (GraphBuildFailedError, KuzuUnavailableError) as exc:
+        raise _kuzu_unavailable_exc() from exc
+
+
+    return GraphProjectResponse(
+        entities_upserted=int(counts.get("entities_upserted", 0)),
+        relations_upserted=int(counts.get("relations_upserted", 0)),
+        entities_deleted=int(counts.get("entities_deleted", 0)),
+        relations_deleted=int(counts.get("relations_deleted", 0)),
+        source_tag=body.source_tag,
+    )
+
+
+@router.delete(
+    "/project",
+    response_model=GraphProjectResponse,
+    summary="Delete projected facts by source_tag",
+    description=(
+        "Remove every node (and incident edge) stamped with ``source_tag``. "
+        "Runs in the same isolated worker as ``POST /graph/project``."
+    ),
+    responses={
+        200: {"description": "Tagged facts removed; counts returned."},
+        400: {"description": "Missing or invalid source_tag."},
+        503: {"description": "GraphRAG disabled, or isolated worker crashed."},
+    },
+)
+async def delete_projected_graph(
+    source_tag: str = Query(..., min_length=1, max_length=64),
+) -> GraphProjectResponse:
+    """Delete-by-source_tag for a deterministic projector rebuild (#235)."""
+    if not _graphrag_enabled():
+        raise _graph_disabled_exc()
+
+    if SOURCE_TAG_RE.fullmatch(source_tag) is None:
+
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": "invalid_source_tag",
+                "source_tag": source_tag,
+            },
+        )
+
+    try:
+        from agent_brain_server.indexing.graph_index import project_isolated
+        from agent_brain_server.storage.graph_errors import GraphBuildFailedError
+
+        counts = project_isolated(
+            [],
+            [],
+            source_tag,
+            replace=True,
+        )
+    except (GraphBuildFailedError, KuzuUnavailableError) as exc:
+        raise _kuzu_unavailable_exc() from exc
+
+
+    return GraphProjectResponse(
+        entities_upserted=0,
+        relations_upserted=0,
+        entities_deleted=int(counts.get("entities_deleted", 0)),
+        relations_deleted=int(counts.get("relations_deleted", 0)),
+        source_tag=source_tag,
+    )
+

--- a/agent-brain-server/agent_brain_server/indexing/graph_index.py
+++ b/agent-brain-server/agent_brain_server/indexing/graph_index.py
@@ -262,6 +262,159 @@ def build_from_documents_isolated(
     )
 
 
+_PROJECT_FAILED_MESSAGE_TEMPLATE = (
+    "Graph projection failed in isolated worker (exit_code={code}); "
+    "the server process is unaffected. The graph was NOT updated for this "
+    "run. To switch backends permanently, set graphrag.store_type=simple "
+    "in your config (the server does not change it automatically)."
+)
+
+_PROJECT_TIMEOUT_MESSAGE_TEMPLATE = (
+    "Graph projection timed out in isolated worker (timeout={timeout_s}s); "
+    "the server process is unaffected. The graph was NOT updated for this "
+    "run. To switch backends permanently, set graphrag.store_type=simple "
+    "in your config (the server does not change it automatically)."
+)
+
+
+def _child_project_worker(
+    payload: dict[str, Any],
+    result_queue: "multiprocessing.Queue[dict[str, int] | BaseException]",
+) -> None:
+    """Spawn-child entry for ``project_isolated``.
+
+    Re-resolves the graph-store singleton inside the child so the kuzu
+    handle is never inherited from the parent (#178).
+    """
+    try:
+        store = get_graph_store_manager()
+        if not store.is_initialized:
+            store.initialize()
+        result = store.project(
+            entities=payload["entities"],
+            relations=payload["relations"],
+            source_tag=payload["source_tag"],
+            replace=bool(payload.get("replace", False)),
+        )
+        result_queue.put(result)
+    except BaseException as exc:  # noqa: BLE001
+        result_queue.put(exc)
+
+
+def _run_project_in_child(
+    payload: dict[str, Any],
+    result_queue: "multiprocessing.Queue[dict[str, int] | BaseException]",
+    timeout_s: float | None,
+    child_target: Any,
+) -> dict[str, int]:
+    """Spawn the projection child and wait for a counts dict."""
+    ctx = multiprocessing.get_context("spawn")
+    proc = ctx.Process(
+        target=child_target,
+        args=(payload, result_queue),
+        daemon=True,
+    )
+    proc.start()
+
+    timed_out = False
+    try:
+        proc.join(timeout=timeout_s)
+    except Exception:
+        pass
+
+    if proc.is_alive():
+        timed_out = True
+        proc.terminate()
+        proc.join(timeout=5.0)
+        if proc.is_alive():
+            proc.kill()
+            proc.join(timeout=2.0)
+
+    exit_code = proc.exitcode
+
+    if timed_out:
+        raise GraphBuildFailedError(
+            _PROJECT_TIMEOUT_MESSAGE_TEMPLATE.format(timeout_s=timeout_s),
+            exit_code=exit_code,
+        )
+
+    if exit_code != 0:
+        raise GraphBuildFailedError(
+            _PROJECT_FAILED_MESSAGE_TEMPLATE.format(code=exit_code),
+            exit_code=exit_code,
+        )
+
+    try:
+        result = result_queue.get_nowait()
+    except Exception as exc:
+        raise GraphBuildFailedError(
+            _PROJECT_FAILED_MESSAGE_TEMPLATE.format(code=0),
+            exit_code=0,
+        ) from exc
+
+    if isinstance(result, BaseException):
+        raise GraphBuildFailedError(
+            f"Graph projection raised exception in isolated worker: {result}; "
+            "the server process is unaffected. The graph was NOT updated for "
+            "this run. To switch backends permanently, set "
+            "graphrag.store_type=simple in your config (the server does not "
+            "change it automatically).",
+            exit_code=0,
+        ) from result
+
+    if not isinstance(result, dict):
+        raise GraphBuildFailedError(
+            _PROJECT_FAILED_MESSAGE_TEMPLATE.format(code=0),
+            exit_code=0,
+        )
+    return result
+
+
+def project_isolated(
+    entities: list[dict[str, Any]],
+    relations: list[dict[str, Any]],
+    source_tag: str,
+    *,
+    replace: bool = False,
+    timeout_s: float | None = None,
+    _child_target_override: Any = None,
+) -> dict[str, int]:
+    """Project pre-typed entities/relations in an isolated subprocess.
+
+    Same spawn isolation as ``build_from_documents_isolated`` (Phase 64 /
+    GSTAB-01 / #178): a kuzu-native crash becomes a catchable
+    ``GraphBuildFailedError`` instead of taking down the server. The
+    projector never calls LLM/AST extractors.
+
+    Args:
+        entities: ``[{type, id, properties?}, ...]``.
+        relations: ``[{src, predicate, dst}, ...]``.
+        source_tag: Attribution tag stamped on every written node/edge.
+        replace: When True, delete-by-source_tag runs before the upsert.
+        timeout_s: Seconds before the child is killed. None = no limit.
+        _child_target_override: Test-only replacement for the child worker.
+
+    Returns:
+        Counts dict from the child (entities_upserted, relations_upserted,
+        entities_deleted, relations_deleted).
+
+    Raises:
+        GraphBuildFailedError: Child non-zero exit (including SIGSEGV) or
+            timeout. Parent process is unaffected.
+    """
+    child_target = _child_target_override or _child_project_worker
+    ctx = multiprocessing.get_context("spawn")
+    result_queue: multiprocessing.Queue[dict[str, int] | BaseException] = ctx.Queue()
+    payload = {
+        "entities": entities,
+        "relations": relations,
+        "source_tag": source_tag,
+        "replace": replace,
+    }
+    return _run_project_in_child(payload, result_queue, timeout_s, child_target)
+
+
+
 class GraphIndexManager:
     """Manages graph index building and querying.
 

--- a/agent-brain-server/agent_brain_server/models/__init__.py
+++ b/agent-brain-server/agent_brain_server/models/__init__.py
@@ -23,10 +23,16 @@ from .graph import (
     GraphEntityRecordNeighbors,
     GraphEntityRecordNode,
     GraphIndexStatus,
+    GraphProjectRequest,
+    GraphProjectResponse,
     GraphQueryContext,
     GraphTriple,
     InfraEntityType,
+    ProjectedEntity,
+    ProjectedRelation,
     RelationshipType,
+    is_valid_entity_type,
+    is_valid_predicate,
     normalize_entity_type,
 )
 from .health import HealthStatus, IndexingStatus
@@ -81,7 +87,14 @@ __all__ = [
     "GraphEntityRecordNeighbor",
     "GraphEntityRecordNeighbors",
     "GraphEntityRecordNode",
+    "GraphProjectRequest",
+    "GraphProjectResponse",
+    "ProjectedEntity",
+    "ProjectedRelation",
+    "is_valid_entity_type",
+    "is_valid_predicate",
     # Graph schema types (Feature 122 - Phase 3)
+
     "EntityType",
     "CodeEntityType",
     "DocEntityType",

--- a/agent-brain-server/agent_brain_server/models/graph.py
+++ b/agent-brain-server/agent_brain_server/models/graph.py
@@ -4,10 +4,11 @@ Defines Pydantic models for graph entities, relationships, and status.
 All models are configured with frozen=True for immutability.
 """
 
+import re
 from datetime import datetime
 from typing import Any, Literal, get_args
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 # Entity Type Schema (SCHEMA-01, SCHEMA-02, SCHEMA-03)
 
@@ -138,6 +139,47 @@ def normalize_entity_type(raw_type: str | None) -> str | None:
     if mapped:
         return mapped
     return raw_type  # Fallback: keep original for flexibility
+
+
+# Namespaced types (e.g. ``okf:Claim``) let a projector supply domain nouns
+# without forking SCHEMA-01. Prefix is a lowercase vendor/ontology id;
+# the local name is an identifier. See #235 / POST /graph/project.
+NAMESPACED_ENTITY_TYPE_RE = re.compile(
+    r"^[a-z][a-z0-9_-]{0,31}:[A-Za-z][A-Za-z0-9_]{0,63}$"
+)
+PREDICATE_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+NAMESPACED_PREDICATE_RE = re.compile(
+    r"^[a-z][a-z0-9_-]{0,31}:[a-z][a-z0-9_]*$"
+)
+SOURCE_TAG_RE = re.compile(r"^[A-Za-z][A-Za-z0-9._:-]{0,63}$")
+
+
+def is_valid_entity_type(entity_type: str) -> bool:
+    """Return True for a SCHEMA-01 type or a namespaced ``prefix:Name``.
+
+    SCHEMA-01 stays the built-in 17-type vocabulary. Namespaced types
+    (``okf:Claim``, ``okf:Finding``) are accepted so an external projector
+    can write domain nouns without a core schema fork. Un-namespaced
+    invented types (``NotARealType``) are rejected.
+    """
+    if entity_type in ENTITY_TYPES:
+        return True
+    return NAMESPACED_ENTITY_TYPE_RE.fullmatch(entity_type) is not None
+
+
+def is_valid_predicate(predicate: str) -> bool:
+    """Return True for a SCHEMA-03 predicate or an extensible extra.
+
+    Extensible extras are snake_case (``asserts``, ``evidenced_by``) or
+    namespaced (``okf:asserts``). This is a validation concern, not a
+    physical Kuzu table constraint.
+    """
+    if predicate in RELATIONSHIP_TYPES:
+        return True
+    if PREDICATE_RE.fullmatch(predicate) is not None:
+        return True
+    return NAMESPACED_PREDICATE_RE.fullmatch(predicate) is not None
+
 
 
 class GraphTriple(BaseModel):
@@ -566,3 +608,117 @@ class GraphEntityRecord(BaseModel):
         default_factory=GraphEntityRecordNeighbors,
         description="1-hop neighbors split by direction. Empty lists, never None.",
     )
+
+
+# -----------------------------------------------------------------------------
+# Graph projection — POST /graph/project (#235)
+#
+# Accepts pre-typed entities and relations from an external projector
+# (research-graph Layer 1). No LLM/AST extraction is involved. Vocabulary
+# is SCHEMA-01 plus namespaced types so OKF research nouns coexist with
+# code/doc/infra types without forking Agent Brain.
+# -----------------------------------------------------------------------------
+
+
+class ProjectedEntity(BaseModel):
+    """A single pre-typed entity supplied by an external projector."""
+
+    model_config = ConfigDict(frozen=True)
+
+    type: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "SCHEMA-01 type or namespaced type (e.g. ``okf:Claim``). "
+            "Un-namespaced invented types are rejected."
+        ),
+    )
+    id: str = Field(
+        ...,
+        min_length=1,
+        max_length=256,
+        description="Stable opaque entity id. Re-projecting the same id upserts.",
+    )
+    properties: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Free-form entity properties. ``source_tag`` is reserved.",
+    )
+
+    @field_validator("type")
+    @classmethod
+    def _type_must_be_schema_or_namespaced(cls, value: str) -> str:
+        if not is_valid_entity_type(value):
+            raise ValueError(
+                "entity type must be a SCHEMA-01 type or namespaced "
+                f"(prefix:Name); got {value!r}"
+            )
+        return value
+
+
+class ProjectedRelation(BaseModel):
+    """A single pre-typed relation. ``src``/``dst`` are entity ids."""
+
+    model_config = ConfigDict(frozen=True)
+
+    src: str = Field(..., min_length=1, max_length=256)
+    predicate: str = Field(..., min_length=1, max_length=64)
+    dst: str = Field(..., min_length=1, max_length=256)
+
+    @field_validator("predicate")
+    @classmethod
+    def _predicate_must_be_extensible(cls, value: str) -> str:
+        if not is_valid_predicate(value):
+            raise ValueError(
+                "predicate must be snake_case or namespaced; "
+                f"got {value!r}"
+
+            )
+        return value
+
+
+class GraphProjectRequest(BaseModel):
+    """Request body for ``POST /graph/project``."""
+
+    model_config = ConfigDict(frozen=True)
+
+    entities: list[ProjectedEntity] = Field(default_factory=list)
+    relations: list[ProjectedRelation] = Field(default_factory=list)
+    source_tag: str = Field(
+        ...,
+        min_length=1,
+        max_length=64,
+        description=(
+            "Attribution tag stamped on every written node/edge. "
+            "``replace=true`` deletes prior facts with this tag first."
+        ),
+    )
+    replace: bool = Field(
+        default=False,
+        description=(
+            "When true, delete-by-source_tag runs before the upsert so a "
+            "rebuild converges deterministically."
+        ),
+    )
+
+    @field_validator("source_tag")
+    @classmethod
+    def _source_tag_shape(cls, value: str) -> str:
+        if SOURCE_TAG_RE.fullmatch(value) is None:
+            raise ValueError(
+                "source_tag must start with a letter and contain only "
+                f"alphanumerics, dot, underscore, colon, or hyphen; got {value!r}"
+            )
+        return value
+
+
+class GraphProjectResponse(BaseModel):
+    """Response body for ``POST /graph/project`` and ``DELETE /graph/project``."""
+
+    model_config = ConfigDict(frozen=True)
+
+    entities_upserted: int = Field(default=0, ge=0)
+    relations_upserted: int = Field(default=0, ge=0)
+    entities_deleted: int = Field(default=0, ge=0)
+    relations_deleted: int = Field(default=0, ge=0)
+    source_tag: str = Field(..., min_length=1)
+

--- a/agent-brain-server/agent_brain_server/storage/graph_store.py
+++ b/agent-brain-server/agent_brain_server/storage/graph_store.py
@@ -1330,7 +1330,7 @@ class GraphStoreManager:
         store = self._graph_store
         try:
             to_delete: list[str] = []
-            nodes = []
+            nodes: list[Any] = []
             if hasattr(store, "get"):
                 try:
                     # Prefer a property filter when the backend supports it.
@@ -1348,7 +1348,6 @@ class GraphStoreManager:
                     node_id = getattr(node, "id", None) or getattr(node, "name", "")
                     if node_id:
                         to_delete.append(str(node_id))
-
 
             if not to_delete and hasattr(store, "_entities"):
                 # _MinimalGraphStore path.

--- a/agent-brain-server/agent_brain_server/storage/graph_store.py
+++ b/agent-brain-server/agent_brain_server/storage/graph_store.py
@@ -1312,6 +1312,244 @@ class GraphStoreManager:
             ),
         )
 
+    def delete_by_source_tag(self, source_tag: str) -> tuple[int, int]:
+        """Remove nodes (and their edges) stamped with ``source_tag``.
+
+        Used by ``POST /graph/project?replace=true`` and
+        ``DELETE /graph/project`` so a projector can destroy-and-rebuild
+        deterministically without wiping SCHEMA-01 extraction output.
+
+        Returns ``(entities_deleted, relations_deleted)``. Relation count
+        is best-effort (triplet delta); 0 when the backend cannot count.
+        """
+        if not _graphrag_enabled():
+            return (0, 0)
+        if not self._initialized or self._graph_store is None:
+            return (0, 0)
+
+        store = self._graph_store
+        try:
+            to_delete: list[str] = []
+            nodes = []
+            if hasattr(store, "get"):
+                try:
+                    # Prefer a property filter when the backend supports it.
+                    try:
+                        nodes = (
+                            store.get(properties={"source_tag": source_tag}) or []
+                        )
+                    except TypeError:
+                        nodes = store.get() or []
+                except TypeError:
+                    nodes = []
+            for node in nodes:
+                props = getattr(node, "properties", None) or {}
+                if isinstance(props, dict) and props.get("source_tag") == source_tag:
+                    node_id = getattr(node, "id", None) or getattr(node, "name", "")
+                    if node_id:
+                        to_delete.append(str(node_id))
+
+
+            if not to_delete and hasattr(store, "_entities"):
+                # _MinimalGraphStore path.
+                entities = getattr(store, "_entities", {})
+                drop_ids = [
+                    eid
+                    for eid, meta in entities.items()
+                    if isinstance(meta, dict) and meta.get("source_tag") == source_tag
+                ]
+                for eid in drop_ids:
+                    entities.pop(eid, None)
+                rels = getattr(store, "_relationships", [])
+                kept = [
+                    r
+                    for r in rels
+                    if not (
+                        isinstance(r, dict)
+                        and (
+                            r.get("source_tag") == source_tag
+                            or r.get("subject") in drop_ids
+                            or r.get("object") in drop_ids
+                        )
+                    )
+                ]
+                rels_dropped = len(rels) - len(kept)
+                store._relationships = kept
+                if hasattr(store, "_data"):
+                    store._data["entities"] = entities
+                    store._data["relationships"] = kept
+                self._update_counts()
+                self.persist()
+                return (len(drop_ids), rels_dropped)
+
+            rels_deleted = 0
+            if to_delete and hasattr(store, "get_triplets"):
+                try:
+                    # SimplePropertyGraphStore.get_triplets() with no args
+                    # returns [] — filter by the ids we are about to drop.
+                    rels_deleted = len(store.get_triplets(ids=to_delete) or [])
+                except Exception:
+                    rels_deleted = 0
+
+            if to_delete and hasattr(store, "delete"):
+                store.delete(ids=to_delete)
+
+            self._update_counts()
+            self.persist()
+            return (len(to_delete), rels_deleted)
+
+        except (IndexError, RuntimeError, OSError) as exc:
+            if self.store_type == "kuzu":
+                raise KuzuUnavailableError(
+                    f"Kuzu graph store raised during delete-by-tag: {exc}. "
+                    "Operator workaround: set graphrag.store_type=simple."
+                ) from exc
+            logger.warning(
+                "graph_store.delete_by_source_tag: %s raised: %s",
+                self.store_type,
+                exc,
+            )
+            return (0, 0)
+
+    def project(
+        self,
+        entities: list[dict[str, Any]],
+        relations: list[dict[str, Any]],
+        source_tag: str,
+        replace: bool = False,
+    ) -> dict[str, int]:
+        """Upsert pre-typed entities and relations. No extraction.
+
+        ``entities`` items: ``{type, id, properties?}``.
+        ``relations`` items: ``{src, predicate, dst}``.
+        ``src``/``dst`` must match entity ids in this payload.
+
+        Stamps ``source_tag`` onto every node (and relation, when the
+        backend preserves relation properties) so a later delete-by-tag
+        can rebuild deterministically.
+
+        Returns counts: entities_upserted, relations_upserted,
+        entities_deleted, relations_deleted.
+        """
+        if not _graphrag_enabled():
+            return {
+                "entities_upserted": 0,
+                "relations_upserted": 0,
+                "entities_deleted": 0,
+                "relations_deleted": 0,
+            }
+
+        if not self._initialized:
+            self.initialize()
+        if self._graph_store is None:
+            return {
+                "entities_upserted": 0,
+                "relations_upserted": 0,
+                "entities_deleted": 0,
+                "relations_deleted": 0,
+            }
+
+        deleted_e, deleted_r = 0, 0
+        if replace:
+            deleted_e, deleted_r = self.delete_by_source_tag(source_tag)
+
+        store = self._graph_store
+        try:
+            upserted_e, upserted_r = self._upsert_projected(
+                store, entities, relations, source_tag
+            )
+        except (IndexError, RuntimeError, OSError) as exc:
+            if self.store_type == "kuzu":
+                raise KuzuUnavailableError(
+                    f"Kuzu graph store raised during projection: {exc}. "
+                    "Operator workaround: set graphrag.store_type=simple."
+                ) from exc
+            logger.error("graph_store.project: %s raised: %s", self.store_type, exc)
+            raise
+
+        self._update_counts()
+        self.persist()
+        self._last_updated = datetime.now(timezone.utc)
+        return {
+            "entities_upserted": upserted_e,
+            "relations_upserted": upserted_r,
+            "entities_deleted": deleted_e,
+            "relations_deleted": deleted_r,
+        }
+
+    def _upsert_projected(
+        self,
+        store: Any,
+        entities: list[dict[str, Any]],
+        relations: list[dict[str, Any]],
+        source_tag: str,
+    ) -> tuple[int, int]:
+        """Write projected facts to ``store``. Returns upsert counts."""
+        if hasattr(store, "upsert_nodes"):
+            from llama_index.core.graph_stores.types import EntityNode, Relation
+
+            nodes: list[Any] = []
+            id_to_node_id: dict[str, str] = {}
+            for item in entities:
+                entity_id = str(item["id"])
+                entity_type = str(item["type"])
+                props = dict(item.get("properties") or {})
+                props["source_tag"] = source_tag
+                # Kuzu's get_triplets historically stashes the schema
+                # label in properties["label"]; keep both.
+                props["label"] = entity_type
+                node = EntityNode(
+                    name=entity_id,
+                    label=entity_type,
+                    properties=props,
+                )
+                nodes.append(node)
+                id_to_node_id[entity_id] = node.id
+            if nodes:
+                store.upsert_nodes(nodes)
+
+            rel_objs: list[Any] = []
+            for item in relations:
+                src = str(item["src"])
+                dst = str(item["dst"])
+                src_id = id_to_node_id.get(src, src)
+                dst_id = id_to_node_id.get(dst, dst)
+                rel_objs.append(
+                    Relation(
+                        label=str(item["predicate"]),
+                        source_id=src_id,
+                        target_id=dst_id,
+                        properties={"source_tag": source_tag},
+                    )
+                )
+            if rel_objs:
+                store.upsert_relations(rel_objs)
+            return (len(entities), len(relations))
+
+        # _MinimalGraphStore fallback.
+        for item in entities:
+            entity_id = str(item["id"])
+            store._entities[entity_id] = {
+                "name": entity_id,
+                "type": str(item["type"]),
+                "source_tag": source_tag,
+                "properties": dict(item.get("properties") or {}),
+            }
+        for item in relations:
+            store._relationships.append(
+                {
+                    "subject": str(item["src"]),
+                    "predicate": str(item["predicate"]),
+                    "object": str(item["dst"]),
+                    "source_tag": source_tag,
+                }
+            )
+        if hasattr(store, "_data"):
+            store._data["entities"] = store._entities
+            store._data["relationships"] = store._relationships
+        return (len(entities), len(relations))
+
+
     def clear(self) -> None:
         """Clear all graph data.
 

--- a/agent-brain-server/tests/indexing/test_graph_project_isolation.py
+++ b/agent-brain-server/tests/indexing/test_graph_project_isolation.py
@@ -1,0 +1,77 @@
+"""Isolation tests for ``project_isolated`` (#235 / #178).
+
+Mirrors ``test_graph_isolation.py``: a SIGSEGV-class child exit must
+raise GraphBuildFailedError without taking down the parent. We use
+``_child_target_override`` so spawn children do not need a real kuzu db.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agent_brain_server.indexing.graph_index import project_isolated
+from agent_brain_server.storage.graph_errors import GraphBuildFailedError
+
+_ENTITIES = [{"type": "okf:Claim", "id": "claim.1", "properties": {}}]
+_RELATIONS: list[dict[str, str]] = []
+
+
+class TestProjectIsolatedParity:
+    def test_returns_counts_from_child(self) -> None:
+        counts = project_isolated(
+            _ENTITIES,
+            _RELATIONS,
+            "research-graph",
+            _child_target_override=_success_child,
+        )
+        assert counts["entities_upserted"] == 1
+        assert counts["relations_upserted"] == 0
+
+
+class TestProjectIsolatedSIGSEGV:
+    def test_sigsegv_raises_graph_build_failed(self) -> None:
+        with pytest.raises(GraphBuildFailedError) as exc_info:
+            project_isolated(
+                _ENTITIES,
+                _RELATIONS,
+                "research-graph",
+                _child_target_override=_sigsegv_child,
+            )
+        err = exc_info.value
+        assert err.exit_code == 139
+        assert "store_type=simple" in str(err)
+        assert "exit_code=139" in str(err)
+
+    def test_parent_settings_unchanged(self) -> None:
+        from agent_brain_server.config import settings
+
+        original = getattr(settings, "GRAPH_STORE_TYPE", "simple")
+        try:
+            project_isolated(
+                _ENTITIES,
+                _RELATIONS,
+                "research-graph",
+                _child_target_override=_sigsegv_child,
+            )
+        except GraphBuildFailedError:
+            pass
+        assert getattr(settings, "GRAPH_STORE_TYPE", "simple") == original
+
+
+def _success_child(payload: dict[str, Any], result_queue: Any) -> None:
+    result_queue.put(
+        {
+            "entities_upserted": 1,
+            "relations_upserted": 0,
+            "entities_deleted": 0,
+            "relations_deleted": 0,
+        }
+    )
+
+
+def _sigsegv_child(payload: dict[str, Any], result_queue: Any) -> None:
+    import os
+
+    os._exit(139)

--- a/agent-brain-server/tests/unit/api/test_graph_entity_endpoint.py
+++ b/agent-brain-server/tests/unit/api/test_graph_entity_endpoint.py
@@ -136,6 +136,67 @@ class TestInvalidEntityType:
         assert r.json()["detail"]["error"] == "invalid_entity_type"
 
 
+class TestNamespacedEntityType:
+    """#235: namespaced types (okf:Claim) are valid; invented types are not."""
+
+    def test_okf_type_is_not_400(self, client: TestClient) -> None:
+        mgr = MagicMock()
+        mgr.is_initialized = True
+        mgr.get_entity_by_id.return_value = None
+        with (
+            patch(
+                "agent_brain_server.api.routers.graph._graphrag_enabled",
+                return_value=True,
+            ),
+            patch(
+                "agent_brain_server.api.routers.graph.get_graph_store_manager",
+                return_value=mgr,
+            ),
+        ):
+            r = client.get("/graph/entity/okf:Finding/finding.1")
+        assert r.status_code == 404
+        assert r.json()["detail"]["error"] == "entity_not_found"
+        mgr.get_entity_by_id.assert_called_once_with("okf:Finding", "finding.1")
+
+    def test_okf_type_200_when_present(self, client: TestClient) -> None:
+        record = GraphEntityRecord(
+            entity=GraphEntityRecordNode(
+                type="okf:Finding",
+                id="finding.1",
+                properties={"source_tag": "research-graph"},
+            ),
+            neighbors=GraphEntityRecordNeighbors(
+                outgoing=[
+                    GraphEntityRecordNeighbor(
+                        type="okf:Claim",
+                        id="claim.1",
+                        predicate="asserts",
+                        properties={},
+                    )
+                ],
+            ),
+        )
+        mgr = MagicMock()
+        mgr.is_initialized = True
+        mgr.get_entity_by_id.return_value = record
+        with (
+            patch(
+                "agent_brain_server.api.routers.graph._graphrag_enabled",
+                return_value=True,
+            ),
+            patch(
+                "agent_brain_server.api.routers.graph.get_graph_store_manager",
+                return_value=mgr,
+            ),
+        ):
+            r = client.get("/graph/entity/okf:Finding/finding.1")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["entity"]["type"] == "okf:Finding"
+        assert body["neighbors"]["outgoing"][0]["predicate"] == "asserts"
+
+
+
 # ---------------------------------------------------------------------------
 # 200 / 404 — the happy paths and entity-not-found.
 # ---------------------------------------------------------------------------

--- a/agent-brain-server/tests/unit/api/test_graph_project_endpoint.py
+++ b/agent-brain-server/tests/unit/api/test_graph_project_endpoint.py
@@ -1,0 +1,256 @@
+"""FastAPI tests for ``POST /graph/project`` and ``DELETE /graph/project``.
+
+Pins the #235 surface: additive endpoint, 503 when GraphRAG is off,
+400 on unknown types / dangling relation endpoints, isolated-worker
+crash maps to 503 ``kuzu_unavailable`` (#178), and namespaced OKF types
+are accepted. The store contract is covered by
+``tests/unit/storage/test_graph_project.py``; isolation by
+``tests/indexing/test_graph_project_isolation.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agent_brain_server.storage.graph_errors import GraphBuildFailedError
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    from agent_brain_server.api.routers.graph import router as graph_router
+
+    app = FastAPI()
+    app.include_router(graph_router, prefix="/graph", tags=["Graph"])
+    return app
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+_OKF_PAYLOAD: dict[str, Any] = {
+    "entities": [
+        {
+            "type": "okf:Finding",
+            "id": "finding.loop-policy.0001",
+            "properties": {"status": "accepted"},
+        },
+        {
+            "type": "okf:Claim",
+            "id": "claim.loop-policy.0003",
+            "properties": {},
+        },
+        {
+            "type": "okf:Evidence",
+            "id": "evidence.loop-policy.0007",
+            "properties": {},
+        },
+    ],
+    "relations": [
+        {
+            "src": "finding.loop-policy.0001",
+            "predicate": "asserts",
+            "dst": "claim.loop-policy.0003",
+        },
+        {
+            "src": "claim.loop-policy.0003",
+            "predicate": "evidenced_by",
+            "dst": "evidence.loop-policy.0007",
+        },
+    ],
+    "source_tag": "research-graph",
+}
+
+
+def _ok_counts(**overrides: int) -> dict[str, int]:
+    counts = {
+        "entities_upserted": 3,
+        "relations_upserted": 2,
+        "entities_deleted": 0,
+        "relations_deleted": 0,
+    }
+    counts.update(overrides)
+    return counts
+
+
+class TestProjectDisabled:
+    def test_returns_503_when_graphrag_off(self, client: TestClient) -> None:
+        with patch(
+            "agent_brain_server.api.routers.graph._graphrag_enabled",
+            return_value=False,
+        ):
+            r = client.post("/graph/project", json=_OKF_PAYLOAD)
+        assert r.status_code == 503
+        assert r.json()["detail"]["error"] == "graphrag_disabled"
+
+
+class TestProjectValidation:
+    def test_unknown_unnamespaced_type_is_422(self, client: TestClient) -> None:
+        """Invented types without a namespace never reach the store."""
+        body = {
+            "entities": [{"type": "NotARealType", "id": "x"}],
+            "relations": [],
+            "source_tag": "research-graph",
+        }
+        with patch(
+            "agent_brain_server.api.routers.graph._graphrag_enabled",
+            return_value=True,
+        ):
+            r = client.post("/graph/project", json=body)
+        assert r.status_code == 422
+
+    def test_dangling_relation_endpoint_is_400(self, client: TestClient) -> None:
+        body = {
+            "entities": [{"type": "okf:Claim", "id": "claim.1"}],
+            "relations": [
+                {"src": "claim.1", "predicate": "asserts", "dst": "missing"}
+            ],
+            "source_tag": "research-graph",
+        }
+        with (
+            patch(
+                "agent_brain_server.api.routers.graph._graphrag_enabled",
+                return_value=True,
+            ),
+            patch(
+                "agent_brain_server.indexing.graph_index.project_isolated",
+            ) as isolated,
+        ):
+            r = client.post("/graph/project", json=body)
+        assert r.status_code == 400
+        detail = r.json()["detail"]
+        assert detail["error"] == "unknown_relation_endpoint"
+        assert "missing" in detail["missing_ids"]
+        isolated.assert_not_called()
+
+    def test_schema_01_type_is_accepted(self, client: TestClient) -> None:
+        body = {
+            "entities": [{"type": "Function", "id": "login"}],
+            "relations": [],
+            "source_tag": "research-graph",
+        }
+        with (
+            patch(
+                "agent_brain_server.api.routers.graph._graphrag_enabled",
+                return_value=True,
+            ),
+            patch(
+                "agent_brain_server.indexing.graph_index.project_isolated",
+                return_value=_ok_counts(entities_upserted=1, relations_upserted=0),
+            ),
+        ):
+            r = client.post("/graph/project", json=body)
+        assert r.status_code == 200
+        assert r.json()["entities_upserted"] == 1
+
+
+class TestProjectHappyPath:
+    def test_okf_payload_calls_isolated_worker(self, client: TestClient) -> None:
+        with (
+            patch(
+                "agent_brain_server.api.routers.graph._graphrag_enabled",
+                return_value=True,
+            ),
+            patch(
+                "agent_brain_server.indexing.graph_index.project_isolated",
+                return_value=_ok_counts(),
+            ) as isolated,
+        ):
+            r = client.post("/graph/project", json=_OKF_PAYLOAD)
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["entities_upserted"] == 3
+        assert body["relations_upserted"] == 2
+        assert body["source_tag"] == "research-graph"
+        isolated.assert_called_once()
+        args, kwargs = isolated.call_args
+        assert args[2] == "research-graph"
+        assert kwargs["replace"] is False
+        assert args[0][0]["type"] == "okf:Finding"
+        assert args[1][0]["predicate"] == "asserts"
+
+    def test_replace_true_forwarded(self, client: TestClient) -> None:
+        payload = {**_OKF_PAYLOAD, "replace": True}
+        with (
+            patch(
+                "agent_brain_server.api.routers.graph._graphrag_enabled",
+                return_value=True,
+            ),
+            patch(
+                "agent_brain_server.indexing.graph_index.project_isolated",
+                return_value=_ok_counts(entities_deleted=3, relations_deleted=2),
+            ) as isolated,
+        ):
+            r = client.post("/graph/project", json=payload)
+        assert r.status_code == 200
+        assert r.json()["entities_deleted"] == 3
+        assert isolated.call_args.kwargs["replace"] is True
+
+
+class TestProjectIsolationFailure:
+    def test_isolated_crash_returns_503(self, client: TestClient) -> None:
+        with (
+            patch(
+                "agent_brain_server.api.routers.graph._graphrag_enabled",
+                return_value=True,
+            ),
+            patch(
+                "agent_brain_server.indexing.graph_index.project_isolated",
+                side_effect=GraphBuildFailedError("boom", exit_code=139),
+            ),
+        ):
+            r = client.post("/graph/project", json=_OKF_PAYLOAD)
+        assert r.status_code == 503
+        assert r.json()["detail"]["error"] == "kuzu_unavailable"
+        assert "graphrag.store_type=simple" in r.json()["detail"]["hint"]
+
+
+class TestDeleteBySourceTag:
+    def test_delete_calls_isolated_replace(self, client: TestClient) -> None:
+        with (
+            patch(
+                "agent_brain_server.api.routers.graph._graphrag_enabled",
+                return_value=True,
+            ),
+            patch(
+                "agent_brain_server.indexing.graph_index.project_isolated",
+                return_value=_ok_counts(
+                    entities_upserted=0,
+                    relations_upserted=0,
+                    entities_deleted=3,
+                    relations_deleted=2,
+                ),
+            ) as isolated,
+        ):
+            r = client.delete("/graph/project", params={"source_tag": "research-graph"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["entities_deleted"] == 3
+        assert body["entities_upserted"] == 0
+        isolated.assert_called_once()
+        assert isolated.call_args.kwargs["replace"] is True
+        assert isolated.call_args.args[2] == "research-graph"
+
+    def test_delete_disabled_is_503(self, client: TestClient) -> None:
+        with patch(
+            "agent_brain_server.api.routers.graph._graphrag_enabled",
+            return_value=False,
+        ):
+            r = client.delete("/graph/project", params={"source_tag": "research-graph"})
+        assert r.status_code == 503
+
+
+class TestOpenAPI:
+    def test_project_route_in_openapi(self, app: FastAPI) -> None:
+        spec: dict[str, Any] = app.openapi()
+        paths = spec.get("paths", {})
+        assert "/graph/project" in paths
+        assert "post" in paths["/graph/project"]
+        assert "delete" in paths["/graph/project"]

--- a/agent-brain-server/tests/unit/storage/test_graph_project.py
+++ b/agent-brain-server/tests/unit/storage/test_graph_project.py
@@ -1,0 +1,126 @@
+"""Store-level tests for graph projection (#235).
+
+Uses the simple backend (always available). Verifies:
+
+- upsert of namespaced entities + extra predicates
+- lookup traverses asserts / evidenced_by
+- re-projecting identical input is idempotent
+- delete-by-source_tag + re-project converges
+- SCHEMA-01 nodes without the tag survive delete-by-tag
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from agent_brain_server.storage.graph_store import (
+    GraphStoreManager,
+    reset_graph_store_manager,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton() -> Any:
+    reset_graph_store_manager()
+    yield
+    reset_graph_store_manager()
+
+
+@pytest.fixture
+def persist_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "graph_index"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def manager(persist_dir: Path) -> Any:
+    patcher = patch("agent_brain_server.storage.graph_store.settings")
+    mock_settings = patcher.start()
+    mock_settings.ENABLE_GRAPH_INDEX = True
+    mock_settings.GRAPH_STORE_TYPE = "simple"
+    try:
+        mgr = GraphStoreManager(persist_dir, store_type="simple")
+        mgr.initialize()
+        if mgr.graph_store is None:
+            pytest.skip("simple backend produced no graph_store")
+        yield mgr
+    finally:
+        patcher.stop()
+
+
+_ENTITIES = [
+    {
+        "type": "okf:Finding",
+        "id": "finding.1",
+        "properties": {"title": "loop policy"},
+    },
+    {"type": "okf:Claim", "id": "claim.1", "properties": {}},
+    {"type": "okf:Evidence", "id": "evidence.1", "properties": {}},
+]
+_RELATIONS = [
+    {"src": "finding.1", "predicate": "asserts", "dst": "claim.1"},
+    {"src": "claim.1", "predicate": "evidenced_by", "dst": "evidence.1"},
+]
+
+
+class TestProjectUpsert:
+    def test_writes_typed_spine(self, manager: GraphStoreManager) -> None:
+        counts = manager.project(_ENTITIES, _RELATIONS, source_tag="research-graph")
+        assert counts["entities_upserted"] == 3
+        assert counts["relations_upserted"] == 2
+
+        finding = manager.get_entity_by_id("okf:Finding", "finding.1")
+        assert finding is not None
+        assert finding.entity.type == "okf:Finding"
+        outgoing = {n.id: n.predicate for n in finding.neighbors.outgoing}
+        assert outgoing.get("claim.1") == "asserts"
+
+        claim = manager.get_entity_by_id("okf:Claim", "claim.1")
+        assert claim is not None
+        outgoing_c = {n.id: n.predicate for n in claim.neighbors.outgoing}
+        incoming_c = {n.id: n.predicate for n in claim.neighbors.incoming}
+        assert outgoing_c.get("evidence.1") == "evidenced_by"
+        assert incoming_c.get("finding.1") == "asserts"
+
+    def test_idempotent_reproject(self, manager: GraphStoreManager) -> None:
+        manager.project(_ENTITIES, _RELATIONS, source_tag="research-graph")
+        manager.project(_ENTITIES, _RELATIONS, source_tag="research-graph")
+        finding = manager.get_entity_by_id("okf:Finding", "finding.1")
+        assert finding is not None
+        assert len(finding.neighbors.outgoing) == 1
+
+    def test_replace_rebuild_converges(self, manager: GraphStoreManager) -> None:
+        manager.project(_ENTITIES, _RELATIONS, source_tag="research-graph")
+        counts = manager.project(
+            _ENTITIES,
+            _RELATIONS,
+            source_tag="research-graph",
+            replace=True,
+        )
+        assert counts["entities_deleted"] >= 1
+        finding = manager.get_entity_by_id("okf:Finding", "finding.1")
+        assert finding is not None
+        assert len(finding.neighbors.outgoing) == 1
+
+    def test_delete_by_tag_spares_other_nodes(
+        self, manager: GraphStoreManager
+    ) -> None:
+        from llama_index.core.graph_stores.types import EntityNode
+
+        store = manager.graph_store
+        assert store is not None
+        store.upsert_nodes(
+            [EntityNode(name="login", label="Function", properties={})]
+        )
+        manager.project(_ENTITIES, _RELATIONS, source_tag="research-graph")
+        deleted_e, _deleted_r = manager.delete_by_source_tag("research-graph")
+        assert deleted_e >= 1
+        assert manager.get_entity_by_id("okf:Finding", "finding.1") is None
+        leftover = manager.get_entity_by_id("Function", "login")
+        assert leftover is not None
+        assert leftover.entity.id == "login"

--- a/agent-brain-server/tests/unit/test_graph_models.py
+++ b/agent-brain-server/tests/unit/test_graph_models.py
@@ -564,3 +564,39 @@ class TestQueryRequestGraphFilters:
 
         assert data["entity_types"] == ["Class", "Function"]
         assert data["relationship_types"] == ["calls"]
+
+
+class TestNamespacedVocabulary:
+    """#235: SCHEMA-01 plus namespaced types; invented types rejected."""
+
+    def test_schema_01_still_valid(self) -> None:
+        from agent_brain_server.models import is_valid_entity_type
+
+        assert is_valid_entity_type("Function")
+        assert is_valid_entity_type("README")
+
+    def test_okf_types_valid(self) -> None:
+        from agent_brain_server.models import is_valid_entity_type
+
+        assert is_valid_entity_type("okf:Claim")
+        assert is_valid_entity_type("okf:Finding")
+        assert is_valid_entity_type("okf:Evidence")
+
+    def test_invented_unnamespaced_rejected(self) -> None:
+        from agent_brain_server.models import is_valid_entity_type
+
+        assert not is_valid_entity_type("NotARealType")
+        assert not is_valid_entity_type("function")
+        assert not is_valid_entity_type("okf:")
+        assert not is_valid_entity_type(":Claim")
+
+    def test_extra_predicates(self) -> None:
+        from agent_brain_server.models import is_valid_predicate
+
+        assert is_valid_predicate("calls")
+        assert is_valid_predicate("asserts")
+        assert is_valid_predicate("evidenced_by")
+        assert is_valid_predicate("okf:asserts")
+        assert not is_valid_predicate("Asserts")
+        assert not is_valid_predicate("has subject")
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`POST /graph/project` and `DELETE /graph/project`** (`agent-brain-server`; [#235](https://github.com/SpillwaveSolutions/agent-brain/issues/235)). Deterministic projection ingestion: an external projector (research-graph Layer 1) supplies pre-typed entities and relations (`{entities, relations, source_tag, replace}`) with **no LLM/AST extraction**. Namespaced types (`okf:Claim`) and extra snake_case predicates (`asserts`, `evidenced_by`) are accepted alongside SCHEMA-01/03 so domain nouns coexist without a core schema fork. `GET /graph/entity/{type}/{id}` accepts the same namespaced vocabulary. Writes run through the existing out-of-process kuzu isolation (#178); `replace=true` / `DELETE /graph/project?source_tag=` delete-by-tag so a rebuild is deterministic and does not wipe SCHEMA-01 extraction output.
+
 ---
 
 ## [10.6.0] - 2026-09-03


### PR DESCRIPTION
## Summary

Implements [#235](https://github.com/SpillwaveSolutions/agent-brain/issues/235): a **projection ingestion path** so research-graph (and any other projector) can write pre-typed entities and relations into the property graph with **no LLM/AST extraction**.

This is Gap A / Phase B from `docs/plans/research-graph-make-it-real.md`. Projector logic stays in the consumer; Agent Brain only accepts explicit facts.

## API

```
POST /graph/project
{
  "entities":  [{"type": "okf:Claim", "id": "claim.1", "properties": {}}],
  "relations": [{"src": "finding.1", "predicate": "asserts", "dst": "claim.1"}],
  "source_tag": "research-graph",
  "replace": false
}
```

- **Upsert** — re-projecting the same id updates in place.
- **`replace=true` / `DELETE /graph/project?source_tag=`** — delete-by-tag so destroy-and-rebuild is deterministic and does not wipe SCHEMA-01 extraction output.
- **Namespaced types** (`okf:Claim`) and extra snake_case predicates (`asserts`, `evidenced_by`) are accepted alongside SCHEMA-01/03. Invented un-namespaced types still 400.
- **`GET /graph/entity/okf:Finding/{id}`** accepts the same vocabulary so the typed spine is traversable.
- **Writes go through spawn isolation** (`project_isolated`), same #178 contract as `build_from_documents_isolated`. A kuzu-native crash is `503 kuzu_unavailable`, not a dead server.
- Additive and gated by `ENABLE_GRAPH_INDEX` / `graphrag.enabled`. No extractor is invoked.

## Tests

- API: `tests/unit/api/test_graph_project_endpoint.py` plus namespaced-type coverage on `GET /graph/entity`
- Store: `tests/unit/storage/test_graph_project.py` (simple backend: spine, idempotent reproject, replace, tag isolation)
- Isolation: `tests/indexing/test_graph_project_isolation.py` (SIGSEGV-class child exit)

Verified locally against `SimplePropertyGraphStore`: Finding→asserts→Claim→evidenced_by→Evidence round-trips, delete-by-tag spares untagged SCHEMA-01 nodes, replace rebuild converges.

Closes #235.